### PR TITLE
chore(api) modify customer group endpoint mapping and tests

### DIFF
--- a/src/ApiPlatform/Resources/CustomerGroup.php
+++ b/src/ApiPlatform/Resources/CustomerGroup.php
@@ -66,6 +66,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
             ],
             // Here, we use command mapping to adapt the normalized command result for the CQRS query
             CQRSCommandMapping: [
+                '[_context][shopIds]' => '[shopIds]',
                 '[groupId]' => '[customerGroupId]',
             ],
         ),

--- a/tests/Integration/ApiPlatform/CustomerGroupApiTest.php
+++ b/tests/Integration/ApiPlatform/CustomerGroupApiTest.php
@@ -105,6 +105,46 @@ class CustomerGroupApiTest extends ApiTestCase
         return $customerGroupId;
     }
 
+    public function testAddCustomerGroupWithoutShopIds(): int
+    {
+        $numberOfGroups = count(\Group::getGroups(\Context::getContext()->language->id));
+
+        $bearerToken = $this->getBearerToken(['customer_group_write']);
+        $response = static::createClient()->request('POST', '/customers/group', [
+            'auth_bearer' => $bearerToken,
+            'json' => [
+                'localizedNames' => [
+                    1 => 'test1',
+                ],
+                'reductionPercent' => 10.3,
+                'displayPriceTaxExcluded' => true,
+                'showPrice' => true,
+            ],
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        self::assertCount($numberOfGroups + 1, \Group::getGroups(\Context::getContext()->language->id));
+
+        $decodedResponse = json_decode($response->getContent(), true);
+        $this->assertNotFalse($decodedResponse);
+        $this->assertArrayHasKey('customerGroupId', $decodedResponse);
+        $customerGroupId = $decodedResponse['customerGroupId'];
+        $this->assertEquals(
+            [
+                'customerGroupId' => $customerGroupId,
+                'localizedNames' => [
+                    1 => 'test1',
+                ],
+                'reductionPercent' => 10.3,
+                'displayPriceTaxExcluded' => true,
+                'showPrice' => true,
+                'shopIds' => [1],
+            ],
+            $decodedResponse
+        );
+
+        return $customerGroupId;
+    }
+
     /**
      * @depends testAddCustomerGroup
      *


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Modify the customer group creation endpoint to add a new mapping that will allow the creation without providing the ShopIds parameter
| Type?             | new feature 
| BC breaks?        | no
| Deprecations?     |  no
| Fixed ticket?     | Fixes #35687
| Sponsor company   | PrestaShop SA
| How to test?      | CI 🟢
