### PR TITLE
Fix swagger doc for CustomerGroup shopIds

### DIFF
--- a/src/ApiPlatform/Resources/CustomerGroup.php
+++ b/src/ApiPlatform/Resources/CustomerGroup.php
@@ -110,5 +110,6 @@ class CustomerGroup
 
     public bool $showPrice;
 
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer']])]
     public array $shopIds;
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix swagger doc for CustomerGroup shopIds.<br>By default, an array is considered as `any[]`.<br>So we need to specify the subtype.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/34506
| Sponsor company   | PrestaShop SA
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/34506


From:
![Capture d’écran 2024-12-11 à 17 28 08](https://github.com/user-attachments/assets/ba16aac1-2bbb-41e4-b539-ab5d19d5efcf)

To:
![Capture d’écran 2024-12-11 à 17 28 33](https://github.com/user-attachments/assets/2a2048b3-cff0-4ef7-8b42-d3d8833d79e1)

