### PR TITLE
Handle localized values based on locale instead of IDs

### DIFF
--- a/src/ApiPlatform/Resources/CartRule.php
+++ b/src/ApiPlatform/Resources/CartRule.php
@@ -25,6 +25,7 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\Command\EditCartRuleCommand;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 
 #[ApiResource(
     operations: [
@@ -52,6 +53,7 @@ class CartRule
 
     public int $customerId;
 
+    #[LocalizedValue]
     public array $localizedNames;
 
     public bool $highlightInCart;

--- a/src/ApiPlatform/Resources/CustomerGroup.php
+++ b/src/ApiPlatform/Resources/CustomerGroup.php
@@ -35,6 +35,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 
 #[ApiResource(
     operations: [
@@ -102,6 +103,7 @@ class CustomerGroup
     #[ApiProperty(identifier: true)]
     public int $customerGroupId;
 
+    #[LocalizedValue]
     public array $localizedNames;
 
     public float $reductionPercent;

--- a/src/ApiPlatform/Resources/Product/NewProductImage.php
+++ b/src/ApiPlatform/Resources/Product/NewProductImage.php
@@ -49,6 +49,8 @@ use Symfony\Component\HttpFoundation\File\File;
 )]
 class NewProductImage
 {
+    public int $productId;
+
     public int $imageId;
 
     public string $imageUrl;

--- a/src/ApiPlatform/Resources/Product/NewProductImage.php
+++ b/src/ApiPlatform/Resources/Product/NewProductImage.php
@@ -26,6 +26,7 @@ use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\AddProductImageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Query\GetProductImage;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use Symfony\Component\HttpFoundation\File\File;
 
 #[ApiResource(
@@ -57,6 +58,7 @@ class NewProductImage
 
     public string $thumbnailUrl;
 
+    #[LocalizedValue]
     public array $legends;
 
     public bool $cover;

--- a/src/ApiPlatform/Resources/Product/Product.php
+++ b/src/ApiPlatform/Resources/Product/Product.php
@@ -34,6 +34,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use Symfony\Component\HttpFoundation\Response;
 
 #[ApiResource(
@@ -95,8 +96,10 @@ class Product
 
     public bool $active;
 
+    #[LocalizedValue]
     public array $names;
 
+    #[LocalizedValue]
     public array $descriptions;
 
     public const QUERY_MAPPING = [

--- a/src/ApiPlatform/Resources/Product/ProductImage.php
+++ b/src/ApiPlatform/Resources/Product/ProductImage.php
@@ -28,6 +28,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\UpdateProductImageCo
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Query\GetProductImage;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -73,6 +74,7 @@ class ProductImage
 
     public string $thumbnailUrl;
 
+    #[LocalizedValue]
     public array $legends;
 
     public bool $cover;

--- a/src/ApiPlatform/Resources/Product/ProductImageList.php
+++ b/src/ApiPlatform/Resources/Product/ProductImageList.php
@@ -25,6 +25,7 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Query\GetProductImages;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 
 #[ApiResource(
     operations: [
@@ -53,6 +54,7 @@ class ProductImageList
 
     public string $thumbnailUrl;
 
+    #[LocalizedValue]
     public array $legends;
 
     public bool $cover;

--- a/src/ApiPlatform/Resources/Product/ProductImageList.php
+++ b/src/ApiPlatform/Resources/Product/ProductImageList.php
@@ -45,6 +45,8 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
 )]
 class ProductImageList
 {
+    public int $productId;
+
     public int $imageId;
 
     public string $imageUrl;

--- a/tests/Integration/ApiPlatform/CustomerGroupApiTest.php
+++ b/tests/Integration/ApiPlatform/CustomerGroupApiTest.php
@@ -73,7 +73,7 @@ class CustomerGroupApiTest extends ApiTestCase
             'auth_bearer' => $bearerToken,
             'json' => [
                 'localizedNames' => [
-                    1 => 'test1',
+                    'en-US' => 'test1',
                 ],
                 'reductionPercent' => 10.3,
                 'displayPriceTaxExcluded' => true,
@@ -92,7 +92,7 @@ class CustomerGroupApiTest extends ApiTestCase
             [
                 'customerGroupId' => $customerGroupId,
                 'localizedNames' => [
-                    1 => 'test1',
+                    'en-US' => 'test1',
                 ],
                 'reductionPercent' => 10.3,
                 'displayPriceTaxExcluded' => true,
@@ -114,7 +114,7 @@ class CustomerGroupApiTest extends ApiTestCase
             'auth_bearer' => $bearerToken,
             'json' => [
                 'localizedNames' => [
-                    1 => 'test1',
+                    'en-US' => 'test1',
                 ],
                 'reductionPercent' => 10.3,
                 'displayPriceTaxExcluded' => true,
@@ -132,7 +132,7 @@ class CustomerGroupApiTest extends ApiTestCase
             [
                 'customerGroupId' => $customerGroupId,
                 'localizedNames' => [
-                    1 => 'test1',
+                    'en-US' => 'test1',
                 ],
                 'reductionPercent' => 10.3,
                 'displayPriceTaxExcluded' => true,
@@ -162,7 +162,7 @@ class CustomerGroupApiTest extends ApiTestCase
             'auth_bearer' => $bearerToken,
             'json' => [
                 'localizedNames' => [
-                    1 => 'new_test1',
+                    'en-US' => 'new_test1',
                 ],
                 'displayPriceTaxExcluded' => false,
                 'shopIds' => [1],
@@ -179,7 +179,7 @@ class CustomerGroupApiTest extends ApiTestCase
             [
                 'customerGroupId' => $customerGroupId,
                 'localizedNames' => [
-                    1 => 'new_test1',
+                    'en-US' => 'new_test1',
                 ],
                 'reductionPercent' => 10.3,
                 'displayPriceTaxExcluded' => false,
@@ -214,7 +214,7 @@ class CustomerGroupApiTest extends ApiTestCase
             [
                 'customerGroupId' => $customerGroupId,
                 'localizedNames' => [
-                    1 => 'new_test1',
+                    'en-US' => 'new_test1',
                 ],
                 'reductionPercent' => 10.3,
                 'displayPriceTaxExcluded' => false,

--- a/tests/Integration/ApiPlatform/ProductEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductEndpointTest.php
@@ -33,16 +33,13 @@ use Tests\Resources\ResourceResetter;
 
 class ProductEndpointTest extends ApiTestCase
 {
-    protected const EN_LANG_ID = 1;
-    protected static int $frenchLangId;
-
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         (new ResourceResetter())->backupTestModules();
         ProductResetter::resetProducts();
         LanguageResetter::resetLanguages();
-        self::$frenchLangId = self::addLanguageByLocale('fr-FR');
+        self::addLanguageByLocale('fr-FR');
         self::createApiClient(['product_write', 'product_read']);
     }
 
@@ -110,8 +107,8 @@ class ProductEndpointTest extends ApiTestCase
             'json' => [
                 'type' => ProductType::TYPE_STANDARD,
                 'names' => [
-                    self::EN_LANG_ID => 'product name',
-                    self::$frenchLangId => 'nom produit',
+                    'en-US' => 'product name',
+                    'fr-FR' => 'nom produit',
                 ],
             ],
         ]);
@@ -128,12 +125,12 @@ class ProductEndpointTest extends ApiTestCase
                 'type' => ProductType::TYPE_STANDARD,
                 'productId' => $productId,
                 'names' => [
-                    self::EN_LANG_ID => 'product name',
-                    self::$frenchLangId => 'nom produit',
+                    'en-US' => 'product name',
+                    'fr-FR' => 'nom produit',
                 ],
                 'descriptions' => [
-                    self::EN_LANG_ID => '',
-                    self::$frenchLangId => '',
+                    'en-US' => '',
+                    'fr-FR' => '',
                 ],
                 'active' => false,
             ],
@@ -163,10 +160,10 @@ class ProductEndpointTest extends ApiTestCase
             ],
             'json' => [
                 'names' => [
-                    self::$frenchLangId => 'nouveau nom',
+                    'fr-FR' => 'nouveau nom',
                 ],
                 'descriptions' => [
-                    self::EN_LANG_ID => 'new description',
+                    'en-US' => 'new description',
                 ],
                 'active' => true,
             ],
@@ -183,12 +180,12 @@ class ProductEndpointTest extends ApiTestCase
                 'type' => ProductType::TYPE_STANDARD,
                 'productId' => $productId,
                 'names' => [
-                    self::EN_LANG_ID => 'product name',
-                    self::$frenchLangId => 'nouveau nom',
+                    'en-US' => 'product name',
+                    'fr-FR' => 'nouveau nom',
                 ],
                 'descriptions' => [
-                    self::EN_LANG_ID => 'new description',
-                    self::$frenchLangId => '',
+                    'en-US' => 'new description',
+                    'fr-FR' => '',
                 ],
                 'active' => true,
             ],
@@ -203,7 +200,7 @@ class ProductEndpointTest extends ApiTestCase
             ],
             'json' => [
                 'names' => [
-                    self::EN_LANG_ID => 'new product name',
+                    'en-US' => 'new product name',
                 ],
             ],
         ]);
@@ -216,12 +213,12 @@ class ProductEndpointTest extends ApiTestCase
                 'type' => ProductType::TYPE_STANDARD,
                 'productId' => $productId,
                 'names' => [
-                    self::EN_LANG_ID => 'new product name',
-                    self::$frenchLangId => 'nouveau nom',
+                    'en-US' => 'new product name',
+                    'fr-FR' => 'nouveau nom',
                 ],
                 'descriptions' => [
-                    self::EN_LANG_ID => 'new description',
-                    self::$frenchLangId => '',
+                    'en-US' => 'new description',
+                    'fr-FR' => '',
                 ],
                 'active' => true,
             ],
@@ -252,12 +249,12 @@ class ProductEndpointTest extends ApiTestCase
                 'type' => ProductType::TYPE_STANDARD,
                 'productId' => $productId,
                 'names' => [
-                    self::EN_LANG_ID => 'new product name',
-                    self::$frenchLangId => 'nouveau nom',
+                    'en-US' => 'new product name',
+                    'fr-FR' => 'nouveau nom',
                 ],
                 'descriptions' => [
-                    self::EN_LANG_ID => 'new description',
-                    self::$frenchLangId => '',
+                    'en-US' => 'new description',
+                    'fr-FR' => '',
                 ],
                 'active' => true,
             ],
@@ -302,8 +299,8 @@ class ProductEndpointTest extends ApiTestCase
         $this->assertMatchesRegularExpression('@/img/p[/0-9]+/' . $imageId . '-small_default\.jpg@', $decodedResponse['thumbnailUrl']);
         $this->assertArrayHasKey('legends', $decodedResponse);
         $this->assertEquals([
-            self::EN_LANG_ID => '',
-            self::$frenchLangId => '',
+            'en-US' => '',
+            'fr-FR' => '',
         ], $decodedResponse['legends']);
         $this->assertArrayHasKey('cover', $decodedResponse);
         $this->assertIsBool($decodedResponse['cover']);
@@ -337,8 +334,8 @@ class ProductEndpointTest extends ApiTestCase
         $this->assertMatchesRegularExpression('@/img/p[/0-9]+/' . $imageId . '-small_default\.jpg@', $decodedResponse['thumbnailUrl']);
         $this->assertArrayHasKey('legends', $decodedResponse);
         $this->assertEquals([
-            self::EN_LANG_ID => '',
-            self::$frenchLangId => '',
+            'en-US' => '',
+            'fr-FR' => '',
         ], $decodedResponse['legends']);
         $this->assertArrayHasKey('cover', $decodedResponse);
         $this->assertIsBool($decodedResponse['cover']);
@@ -369,8 +366,8 @@ class ProductEndpointTest extends ApiTestCase
             'extra' => [
                 'parameters' => [
                     'legends' => [
-                        self::EN_LANG_ID => 'legend en',
-                        self::$frenchLangId => 'legend fr',
+                        'en-US' => 'legend en',
+                        'fr-FR' => 'legend fr',
                     ],
                 ],
                 'files' => [
@@ -392,8 +389,8 @@ class ProductEndpointTest extends ApiTestCase
         $this->assertMatchesRegularExpression('@/img/p[/0-9]+/' . $imageId . '-small_default\.jpg@', $decodedResponse['thumbnailUrl']);
         $this->assertArrayHasKey('legends', $decodedResponse);
         $this->assertEquals([
-            self::EN_LANG_ID => 'legend en',
-            self::$frenchLangId => 'legend fr',
+            'en-US' => 'legend en',
+            'fr-FR' => 'legend fr',
         ], $decodedResponse['legends']);
         $this->assertArrayHasKey('cover', $decodedResponse);
         $this->assertIsBool($decodedResponse['cover']);
@@ -443,8 +440,8 @@ class ProductEndpointTest extends ApiTestCase
                 'imageUrl' => 'http://myshop.com/img/p/' . $this->getImagePath($imageId, false),
                 'thumbnailUrl' => 'http://myshop.com/img/p/' . $this->getImagePath($imageId, true),
                 'legends' => [
-                    self::EN_LANG_ID => 'legend en',
-                    self::$frenchLangId => 'legend fr',
+                    'en-US' => 'legend en',
+                    'fr-FR' => 'legend fr',
                 ],
                 'cover' => true,
                 'position' => 1,
@@ -457,8 +454,8 @@ class ProductEndpointTest extends ApiTestCase
                 'imageUrl' => 'http://myshop.com/img/p/' . $this->getImagePath($newImageId, false),
                 'thumbnailUrl' => 'http://myshop.com/img/p/' . $this->getImagePath($newImageId, true),
                 'legends' => [
-                    self::EN_LANG_ID => '',
-                    self::$frenchLangId => '',
+                    'en-US' => '',
+                    'fr-FR' => '',
                 ],
                 'cover' => false,
                 'position' => 2,
@@ -496,8 +493,8 @@ class ProductEndpointTest extends ApiTestCase
                 'imageUrl' => 'http://myshop.com/img/p/' . $this->getImagePath($newImageId, false),
                 'thumbnailUrl' => 'http://myshop.com/img/p/' . $this->getImagePath($newImageId, true),
                 'legends' => [
-                    self::EN_LANG_ID => '',
-                    self::$frenchLangId => '',
+                    'en-US' => '',
+                    'fr-FR' => '',
                 ],
                 'cover' => true,
                 'position' => 1,
@@ -510,8 +507,8 @@ class ProductEndpointTest extends ApiTestCase
                 'imageUrl' => 'http://myshop.com/img/p/' . $this->getImagePath($imageId, false),
                 'thumbnailUrl' => 'http://myshop.com/img/p/' . $this->getImagePath($imageId, true),
                 'legends' => [
-                    self::EN_LANG_ID => 'legend en',
-                    self::$frenchLangId => 'legend fr',
+                    'en-US' => 'legend en',
+                    'fr-FR' => 'legend fr',
                 ],
                 'cover' => false,
                 'position' => 2,

--- a/tests/Integration/ApiPlatform/ProductMultiShopEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductMultiShopEndpointTest.php
@@ -36,9 +36,6 @@ use Tests\Resources\ResourceResetter;
 
 class ProductMultiShopEndpointTest extends ApiTestCase
 {
-    protected const EN_LANG_ID = 1;
-    protected static int $frenchLangId;
-
     protected const DEFAULT_SHOP_GROUP_ID = 1;
     protected static int $secondShopGroupId;
 
@@ -58,7 +55,7 @@ class ProductMultiShopEndpointTest extends ApiTestCase
         ShopResetter::resetShops();
         ConfigurationResetter::resetConfiguration();
 
-        self::$frenchLangId = self::addLanguageByLocale('fr-FR');
+        self::addLanguageByLocale('fr-FR');
 
         self::updateConfiguration(MultistoreConfig::FEATURE_STATUS, 1);
         // Disable secure protection for the tests (the configuration reset forced the default config back)
@@ -72,12 +69,12 @@ class ProductMultiShopEndpointTest extends ApiTestCase
         self::$defaultProductData = [
             'type' => ProductType::TYPE_STANDARD,
             'names' => [
-                self::EN_LANG_ID => 'product name',
-                self::$frenchLangId => 'nom produit',
+                'en-US' => 'product name',
+                'fr-FR' => 'nom produit',
             ],
             'descriptions' => [
-                self::EN_LANG_ID => '',
-                self::$frenchLangId => '',
+                'en-US' => '',
+                'fr-FR' => '',
             ],
             'active' => false,
         ];
@@ -114,8 +111,8 @@ class ProductMultiShopEndpointTest extends ApiTestCase
             'json' => [
                 'type' => ProductType::TYPE_STANDARD,
                 'names' => [
-                    self::EN_LANG_ID => 'product name',
-                    self::$frenchLangId => 'nom produit',
+                    'en-US' => 'product name',
+                    'fr-FR' => 'nom produit',
                 ],
             ],
         ]);
@@ -132,8 +129,8 @@ class ProductMultiShopEndpointTest extends ApiTestCase
             'json' => [
                 'type' => ProductType::TYPE_STANDARD,
                 'names' => [
-                    self::EN_LANG_ID => 'product name',
-                    self::$frenchLangId => 'nom produit',
+                    'en-US' => 'product name',
+                    'fr-FR' => 'nom produit',
                 ],
             ],
             'extra' => [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | - Add `NewProductImage:productId` and `ProductImageList::productId` property to fix some casting problems<br/>- Adapt localized resources to rely on string locale values
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | CI green
