### PR TITLE
Add cartRuleId in PUT CartRule endpoint

### DIFF
--- a/src/ApiPlatform/Resources/CartRule.php
+++ b/src/ApiPlatform/Resources/CartRule.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources;
 
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\CartRule\Command\EditCartRuleCommand;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
@@ -30,7 +31,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 #[ApiResource(
     operations: [
         new CQRSUpdate(
-            uriTemplate: '/cart-rule',
+            uriTemplate: '/cart-rule/{cartRuleId}',
             CQRSCommand: EditCartRuleCommand::class,
             scopes: [
                 'cart_rule_write',
@@ -41,6 +42,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 )]
 class CartRule
 {
+    #[ApiProperty(identifier: true)]
     public int $cartRuleId;
 
     public string $description;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add cartRuleId in PUT CartRule endpoint. (`cartRuleId` isn't now mandatory in the request body!)
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | PrestaShop SA
| How to test?      | 1. Create a cart rule<br>2. Make a `PUT /cart-rule/1` request as describe in swagger.<br>3. We must have a response with 200 code.<br>(4. If we make a `PUT /cart-rule/2` request, we need to have a 404!)
