### PR TITLE
Change return format for product available date

### DIFF
--- a/src/ApiPlatform/Resources/Product/Product.php
+++ b/src/ApiPlatform/Resources/Product/Product.php
@@ -31,6 +31,7 @@ use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductCommand;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
 use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
+use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
@@ -209,6 +210,7 @@ class Product
     #[LocalizedValue]
     public array $availableLaterLabels;
 
+    #[ApiProperty(openapiContext: ['type' => 'date', 'example' => DateTime::DEFAULT_DATE_FORMAT])]
     public ?\DateTimeImmutable $availableDate = null;
 
     public string $coverThumbnailUrl;


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change return format in documentation for product available date
| Type?             |  improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | PrestaShop SA
| How to test?      | Documentation is up to date 

Related to https://github.com/PrestaShop/PrestaShop/issues/38787

Before 

<img width="428" height="146" alt="Capture d’écran 2025-07-25 à 15 23 24" src="https://github.com/user-attachments/assets/65380297-c021-48a6-a87f-6859791a2c2b" />

After

<img width="354" height="177" alt="Capture d’écran 2025-07-25 à 15 22 36" src="https://github.com/user-attachments/assets/9a95d6c8-4bfe-45e9-ad32-a82f5294af0d" />
