### PR TITLE
Fix folder name

### DIFF
--- a/tests/EnvironmentBuilder.php
+++ b/tests/EnvironmentBuilder.php
@@ -99,7 +99,7 @@ class EnvironmentBuilder
         $configFolder = $prestashopDir . '/app/config/';
         $localeParameters = $moduleDir . '/tests/local-parameters/';
         foreach (['parameters.php', 'parameters.yml'] as $parameterFile) {
-            if (!file_exists($configFolder . $parameterFile) || $arguments['update-local-parameters']) {
+            if (!file_exists($localeParameters . $parameterFile) || $arguments['update-local-parameters']) {
                 // Prefer using the local file if present, if not use the dist default configuration
                 $localFile = $localeParameters . $parameterFile;
                 if (!file_exists($localFile)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | We are currently checking the parameters file in the prestashop which is located in tmp. If we want to override it, we have to use the folder in the module (`$localeParameters`)
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | /
| Sponsor company   | Mademoiselle bio
| How to test?      | Edit `tests/local-parameters/parameters.yml` and execute `composer setup-local-tests`, your file will be ignored :'( 
