### PR TITLE
Fix hook update-status route

### DIFF
--- a/src/ApiPlatform/Resources/Hook.php
+++ b/src/ApiPlatform/Resources/Hook.php
@@ -36,7 +36,7 @@ use PrestaShopBundle\ApiPlatform\Provider\QueryListProvider;
 #[ApiResource(
     operations: [
         new CQRSUpdate(
-            uriTemplate: '/hook-status/{hookId}',
+            uriTemplate: '/hook/{hookId}/status',
             CQRSCommand: UpdateHookStatusCommand::class,
             CQRSQuery: GetHook::class,
             scopes: ['hook_write'],

--- a/tests/Integration/ApiPlatform/HookEndpointTest.php
+++ b/tests/Integration/ApiPlatform/HookEndpointTest.php
@@ -52,7 +52,7 @@ class HookEndpointTest extends ApiTestCase
 
         yield 'put endpoint' => [
             'PUT',
-            '/hook-status/1',
+            '/hook/1/status',
         ];
 
         yield 'list endpoint' => [
@@ -89,7 +89,7 @@ class HookEndpointTest extends ApiTestCase
      */
     public function testUpdateHookStatus(int $hookId): int
     {
-        $updatedHook = $this->updateItem('/hook-status/' . $hookId, ['active' => false], ['hook_write']);
+        $updatedHook = $this->updateItem('/hook/' . $hookId . '/status', ['active' => false], ['hook_write']);
         $expectedHook = [
             'hookId' => $hookId,
             'name' => 'testHook',
@@ -100,7 +100,7 @@ class HookEndpointTest extends ApiTestCase
         $this->assertEquals($expectedHook, $updatedHook);
         $this->assertEquals($expectedHook, $this->getItem('/hook/' . $hookId, ['hook_read']));
 
-        $updatedHook = $this->updateItem('/hook-status/' . $hookId, ['active' => true], ['hook_write']);
+        $updatedHook = $this->updateItem('/hook/' . $hookId . '/status', ['active' => true], ['hook_write']);
         $expectedHook['active'] = true;
         $this->assertEquals($expectedHook, $updatedHook);
         $this->assertEquals($expectedHook, $this->getItem('/hook/' . $hookId, ['hook_read']));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix hook update-status route:<br>`PUT /hook/{hookId}/update-status` instead of `PUT /hook-status`
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/34507
| Sponsor company   | PrestaShop SA
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/34507
