### PR TITLE
Add endpoints for category image delete

### DIFF
--- a/src/ApiPlatform/Resources/Category/Category.php
+++ b/src/ApiPlatform/Resources/Category/Category.php
@@ -27,6 +27,8 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\AddCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\DeleteCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\DeleteCategoryCoverImageCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\DeleteCategoryThumbnailImageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Command\EditCategoryCommand;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
@@ -75,6 +77,20 @@ use Symfony\Component\Validator\Constraints as Assert;
         new CQRSDelete(
             uriTemplate: '/category/{categoryId}',
             CQRSCommand: DeleteCategoryCommand::class,
+            scopes: [
+                'category_write',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/category/{categoryId}/delete_cover',
+            CQRSCommand: DeleteCategoryCoverImageCommand::class,
+            scopes: [
+                'category_write',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/category/{categoryId}/delete_thumbnail',
+            CQRSCommand: DeleteCategoryThumbnailImageCommand::class,
             scopes: [
                 'category_write',
             ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Please be specific when describing this change. What did you change? Why?
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| Sponsor company   | @codencode
| How to test?      | 


# How to test Category API

* Create an API Client with these scopes : `category_read` & `category_write`  
* Request an access token  

## Query 1 - Delete Category Cover
* **Method** : `DELETE`  
* **URI** : `/category/{theCategoryId}/delete_cover`  
* **Body** :  

## Query 2 - Delete Category Thumbnail
* **Method** : `DELETE`  
* **URI** : `/category/{theCategoryId}/delete_thumbnail`  
* **Body** :  
