### PR TITLE
Added endpoints for domain "WebserviceKey" (Delete & BulkDelete)

### DIFF
--- a/src/ApiPlatform/Resources/WebserviceKey/BulkWebserviceKeysDelete.php
+++ b/src/ApiPlatform/Resources/WebserviceKey/BulkWebserviceKeysDelete.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\WebserviceKey;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Webservice\Command\BulkDeleteWebserviceKeyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceKeyNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/webservice-keys/bulk-delete',
+            // No output 204 code
+            output: false,
+            CQRSCommand: BulkDeleteWebserviceKeyCommand::class,
+            scopes: [
+                'webservice_key_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        WebserviceKeyNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkWebserviceKeysDelete
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $webserviceKeyIds;
+}

--- a/src/ApiPlatform/Resources/WebserviceKey/WebserviceKey.php
+++ b/src/ApiPlatform/Resources/WebserviceKey/WebserviceKey.php
@@ -25,11 +25,13 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\WebserviceKey;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Command\AddWebserviceKeyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Webservice\Command\DeleteWebserviceKeyCommand;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Command\EditWebserviceKeyCommand;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceKeyNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Query\GetWebserviceKeyForEditing;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
@@ -47,6 +49,13 @@ use Symfony\Component\Validator\Constraints as Assert;
                 '[shopIds]' => '[associatedShops]',
                 '[enabled]' => '[status]',
             ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/webservice-keys/{webserviceKeyId}',
+            requirements: ['webserviceKeyId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteWebserviceKeyCommand::class,
+            scopes: ['webservice_key_write']
         ),
         new CQRSGet(
             uriTemplate: '/webservice-keys/{webserviceKeyId}',


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | Added endpoints for domain "WebserviceKey" (Delete & BulkDelete)
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | :arrow_down: 
| Fixed issue or discussion?     | N/A
| Related PRs       | * PrestaShop/PrestaShop/pull/39748<br>* PrestaShop/PrestaShop/pull/42266
| Sponsor company   | lefevre.dev

## How to test ?
* Create 3 webservice keys in backoffice and keep their IDs {idWSK1} {idWSK2}  {idWSK3}
* Create an API Client with these scopes : `webservice_key_write`
* Query 1 : 
  * Method : `DELETE`
  * URI : `/webservice-keys/{idWSK1}`
  * Response : 
    * HTTP Code : 204
* Check in the BO : the WS Key `idWSK1` is not found (it is deleted)
* Query 2 : 
  * Method : `PUT`
  * URI : `/webservice-keys/bulk-delete`
  * Body : 
  ```json
  {"webserviceKeyIds": [{idWSK2}, {idWSK3}]}
  ```
  * Response : 
    * HTTP Code : 204
* Check in the BO : WS Keys `idWSK2` & `idWSK3` are not found (they are deleted)