### PR TITLE
add order customer message endpoint

### DIFF
--- a/src/ApiPlatform/Resources/CustomerMessage/OrderCustomerMessage.php
+++ b/src/ApiPlatform/Resources/CustomerMessage/OrderCustomerMessage.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CustomerMessage;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CustomerMessage\Command\AddOrderCustomerMessageCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/customer-messages',
+            CQRSCommand: AddOrderCustomerMessageCommand::class,
+            scopes: ['order_message_write'],
+        ),
+    ],
+    exceptionToStatus: [],
+)]
+class OrderCustomerMessage
+{
+    #[Assert\NotBlank()]
+    public string $message;
+
+    #[Assert\NotBlank()]
+    public int $orderId;
+
+    public bool $isPrivate;
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add AddOrderCustomerMessageCommand endpoint. This PR seems blocked by core as the handler need variables from the Context which is not set.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| Sponsor company   | Mademoiselle bio
| How to test?      | TODO
