### PR TITLE
feat(composer): Add no-timeout option to long running script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
     "scripts": {
         "clear-test-cache": "PsApiResourcesTest\\EnvironmentBuilder::clearCache",
         "create-test-db": [
+            "Composer\\Config::disableProcessTimeout",
             "@composer clear-test-cache",
             "@composer setup-local-tests -- --build-db"
         ],


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The edited composer script may take a long time to run. I added a composer directive to disallow the script timeout.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | NA
| Sponsor company   | Evolutive
| How to test?      | Don't know
