### PR TITLE
feat(TaxRulesGroup): Add partial update on status

### DIFF
--- a/src/ApiPlatform/Resources/TaxRulesGroup/TaxRulesGroup.php
+++ b/src/ApiPlatform/Resources/TaxRulesGroup/TaxRulesGroup.php
@@ -27,6 +27,7 @@ use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\AddTaxRulesGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\DeleteTaxRulesGroupCommand;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\EditTaxRulesGroupCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Command\SetTaxRulesGroupStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\CannotAddTaxRulesGroupException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Query\GetTaxRulesGroupForEditing;
@@ -69,6 +70,18 @@ use Symfony\Component\Validator\Constraints as Assert;
             CQRSQuery: GetTaxRulesGroupForEditing::class,
             CQRSQueryMapping: self::QUERY_MAPPING,
             scopes: ['tax_rules_group_write'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/tax-rules-groups/{taxRulesGroupId}/update-status',
+            requirements: ['taxRulesGroupId' => '\d+'],
+            output: false,
+            read: false,
+            CQRSCommand: SetTaxRulesGroupStatusCommand::class,
+            scopes: ['tax_rules_group_write'],
+            // No output 204 code
+            CQRSCommandMapping: [
+                '[enabled]' => '[expectedStatus]',
+            ],
         ),
     ],
     normalizationContext: ['skip_null_values' => false],

--- a/src/ApiPlatform/Resources/TaxRulesGroup/TaxRulesGroup.php
+++ b/src/ApiPlatform/Resources/TaxRulesGroup/TaxRulesGroup.php
@@ -72,7 +72,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             scopes: ['tax_rules_group_write'],
         ),
         new CQRSPartialUpdate(
-            uriTemplate: '/tax-rules-groups/{taxRulesGroupId}/update-status',
+            uriTemplate: '/tax-rules-groups/{taxRulesGroupId}/set-status',
             requirements: ['taxRulesGroupId' => '\d+'],
             output: false,
             read: false,

--- a/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
@@ -77,6 +77,11 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
             'PUT',
             '/tax-rules-groups/bulk-update-status',
         ];
+
+        yield 'toggle status endpoint' => [
+            'PATCH',
+            '/tax-rules-groups/1/update-status',
+        ];
     }
 
     public function testAddTaxRulesGroup(): int
@@ -185,6 +190,54 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
         );
 
         return $taxRulesGroupId;
+    }
+
+    /**
+     * @depends testGetTaxRulesGroup
+     *
+     * @param int $taxRulesGroupId
+     *
+     * @return int
+     */
+    public function testToggleTaxRulesGroupStatus(int $taxRulesGroupId): void
+    {
+        $response = $this->partialUpdateItem(
+            '/tax-rules-groups/' . $taxRulesGroupId . '/update-status',
+            ['enabled' => false],
+            ['tax_rules_group_write'],
+            Response::HTTP_NO_CONTENT
+        );
+        $this->assertNull($response);
+
+        $taxRulesGroup = $this->getItem('/tax-rules-groups/' . $taxRulesGroupId, ['tax_rules_group_read']);
+        $this->assertEquals(
+            [
+                'taxRulesGroupId' => $taxRulesGroupId,
+                'name' => 'My Tax Rules Group updated',
+                'enabled' => false,
+                'shopIds' => [1],
+            ],
+            $taxRulesGroup
+        );
+
+        $response = $this->partialUpdateItem(
+            '/tax-rules-groups/' . $taxRulesGroupId . '/update-status',
+            ['enabled' => true],
+            ['tax_rules_group_write'],
+            Response::HTTP_NO_CONTENT
+        );
+        $this->assertNull($response);
+
+        $taxRulesGroup = $this->getItem('/tax-rules-groups/' . $taxRulesGroupId, ['tax_rules_group_read']);
+        $this->assertEquals(
+            [
+                'taxRulesGroupId' => $taxRulesGroupId,
+                'name' => 'My Tax Rules Group updated',
+                'enabled' => true,
+                'shopIds' => [1],
+            ],
+            $taxRulesGroup
+        );
     }
 
     /**

--- a/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
@@ -202,7 +202,7 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
     public function testToggleTaxRulesGroupStatus(int $taxRulesGroupId): void
     {
         $response = $this->partialUpdateItem(
-            '/tax-rules-groups/' . $taxRulesGroupId . '/update-status',
+            '/tax-rules-groups/' . $taxRulesGroupId . '/set-status',
             ['enabled' => false],
             ['tax_rules_group_write'],
             Response::HTTP_NO_CONTENT
@@ -221,7 +221,7 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
         );
 
         $response = $this->partialUpdateItem(
-            '/tax-rules-groups/' . $taxRulesGroupId . '/update-status',
+            '/tax-rules-groups/' . $taxRulesGroupId . '/set-status',
             ['enabled' => true],
             ['tax_rules_group_write'],
             Response::HTTP_NO_CONTENT

--- a/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
@@ -80,7 +80,7 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
 
         yield 'toggle status endpoint' => [
             'PATCH',
-            '/tax-rules-groups/1/update-status',
+            '/tax-rules-groups/1/set-status',
         ];
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add partial update for tax rules group on status property (enabled)
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | NA
| Sponsor company   | Evolutive
| How to test?      | Try via the swagger doc to edit the status of an existing tax rule group. Switch it to disabled then enabled.
