### PR TITLE
Add resource for Discount Type

### DIFF
--- a/src/ApiPlatform/Resources/DiscountType/DiscountTypeList.php
+++ b/src/ApiPlatform/Resources/DiscountType/DiscountTypeList.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\DiscountType;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Discount\Query\GetDiscountTypes;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/discount-types',
+            CQRSQuery: GetDiscountTypes::class,
+            scopes: ['discount_read'],
+            CQRSQueryMapping: [],
+            ApiResourceMapping: [
+                '[type]' => '[type]',
+                '[localizedNames]' => '[names]',
+                '[localizedDescriptions]' => '[descriptions]',
+                '[core]' => '[core]',
+                '[enabled]' => '[enabled]',
+            ],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+)]
+class DiscountTypeList
+{
+    #[ApiProperty(identifier: true)]
+    public int $discountTypeId;
+
+    public string $type;
+
+    #[LocalizedValue]
+    public array $names;
+
+    #[LocalizedValue]
+    public array $descriptions;
+
+    public bool $core;
+
+    public bool $enabled;
+}

--- a/tests/Integration/ApiPlatform/DiscountTypeEndpointTest.php
+++ b/tests/Integration/ApiPlatform/DiscountTypeEndpointTest.php
@@ -20,12 +20,26 @@
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use PrestaShop\PrestaShop\Core\Domain\Discount\Command\AddDiscountCommand;
+
 class DiscountTypeEndpointTest extends ApiTestCase
 {
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
-        self::createApiClient();
+        // Check if the command exists, if it doesn't the tests won't run so nothing to init
+        if (class_exists(AddDiscountCommand::class)) {
+            self::createApiClient();
+        }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // If the discount domain does not exist we can skip all the tests here
+        if (!class_exists(AddDiscountCommand::class)) {
+            $this->markTestSkipped('AddDiscountCommand class does not exist');
+        }
     }
 
     public static function getProtectedEndpoints(): iterable

--- a/tests/Integration/ApiPlatform/DiscountTypeEndpointTest.php
+++ b/tests/Integration/ApiPlatform/DiscountTypeEndpointTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class DiscountTypeEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get endpoint' => [
+            'GET',
+            '/discount-types',
+        ];
+    }
+
+    public function testGetDiscountTypes(): void
+    {
+        $discountTypes = $this->getItem('/discount-types', ['discount_read']);
+        $this->assertIsArray($discountTypes);
+        $this->assertGreaterThanOrEqual(1, count($discountTypes));
+
+        $discountType = null;
+        foreach ($discountTypes as $type) {
+            if ($type['type'] === 'cart_level') {
+                $discountType = $type;
+                break;
+            }
+        }
+        $this->assertNotNull($discountType, 'Expected at least a discount type with cart_level type');
+
+        $expectedCartLevelType = [
+            'discountTypeId' => 2,
+            'type' => 'cart_level',
+            'names' => [
+                'en-US' => 'On cart amount',
+            ],
+            'descriptions' => [
+                'en-US' => 'Discount applied to cart',
+            ],
+            'core' => true,
+            'enabled' => true,
+        ];
+
+        $this->assertEquals($expectedCartLevelType, $discountType);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add resource for Discount Type, see https://github.com/PrestaShop/PrestaShop/pull/40536
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | PrestaShop SA 
| How to test?      | `GET http://myshop/admin-api/discount-types` should return a json with discount types (see below)

Example of json response

```
[
	{
		"discountTypeId": 1,
		"type": "free_shipping",
		"names": {
			"en-US": "On free shipping",
			"fr-FR": "On free shipping"
		},
		"descriptions": {
			"en-US": "Discount that provides free shipping to the order",
			"fr-FR": "Discount that provides free shipping to the order"
		},
		"active": true
	},
	{
		"discountTypeId": 2,
		"type": "cart_level",
		"names": {
			"en-US": "On cart amount",
			"fr-FR": "On cart amount"
		},
		"descriptions": {
			"en-US": "Discount applied to cart",
			"fr-FR": "Discount applied to cart"
		},
		"active": true
	},
	{
		"discountTypeId": 3,
		"type": "order_level",
		"names": {
			"en-US": "On total order",
			"fr-FR": "On total order"
		},
		"descriptions": {
			"en-US": "Discount applied to the order",
			"fr-FR": "Discount applied to the order"
		},
		"active": true
	},
	{
		"discountTypeId": 4,
		"type": "product_level",
		"names": {
			"en-US": "On catalog products",
			"fr-FR": "On catalog products"
		},
		"descriptions": {
			"en-US": "Discount applied to specific products",
			"fr-FR": "Discount applied to specific products"
		},
		"active": true
	},
	{
		"discountTypeId": 5,
		"type": "free_gift",
		"names": {
			"en-US": "On free gift",
			"fr-FR": "On free gift"
		},
		"descriptions": {
			"en-US": "Discount that provides a free gift product",
			"fr-FR": "Discount that provides a free gift product"
		},
		"active": true
	}
]
```