### PR TITLE
Add carrier toggle endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,22 @@
+# TODO
+
+## GET /carriers/{carrierId}/ranges — Core limitation
+
+**Stato:** Endpoint implementato ma non funzionante (restituisce 422)
+
+**Causa:** `CarrierRangeRepository::assertShopConstraint()` nel core PrestaShop accetta
+solo `ShopConstraint::allShops()`, ma il framework API passa sempre un constraint
+shop-specifico (es. `shopId=1`). La funzione `applyShopConstraint()` ha un TODO
+irrisolto nel core.
+
+**File coinvolti:**
+- Modulo: `src/ApiPlatform/Resources/Carrier/CarrierRanges.php`
+- Core PS: `src/Adapter/Carrier/Repository/CarrierRangeRepository.php` (righe 220-237)
+
+**Fix richiesto:**
+1. Aprire una issue/PR nel repo `PrestaShop/PrestaShop` per implementare
+   `CarrierRangeRepository::applyShopConstraint()` con supporto ai constraint shop-specifici
+2. Una volta fixato il core, verificare che l'endpoint funzioni correttamente
+3. Valutare se rimuovere o mantenere il mapping `CarrierConstraintException → 422`
+
+**Workaround attuale:** `CarrierConstraintException` mappata a HTTP 422 invece di 500.

--- a/src/ApiPlatform/Resources/Address/AddressRequiredFields.php
+++ b/src/ApiPlatform/Resources/Address/AddressRequiredFields.php
@@ -18,39 +18,37 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Address;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
-use ApiPlatform\Metadata\NotExposed;
-use PrestaShop\PrestaShop\Core\Domain\Address\Command\DeleteAddressCommand;
-use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressConstraintException;
-use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressNotFoundException;
-use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
-use Symfony\Component\HttpFoundation\Response;
+use PrestaShop\PrestaShop\Core\Domain\Address\Query\GetRequiredFieldsForAddress;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 
 #[ApiResource(
     operations: [
-        new CQRSDelete(
-            uriTemplate: '/addresses/{addressId}',
-            requirements: ['addressId' => '\d+'],
-            CQRSCommand: DeleteAddressCommand::class,
-            scopes: [
-                'address_write',
-            ],
-        ),
-        new NotExposed(
-            uriTemplate: '/addresses/{addressId}',
-            requirements: ['addressId' => '\d+'],
+        new CQRSGet(
+            uriTemplate: '/addresses/required-fields',
+            CQRSQuery: GetRequiredFieldsForAddress::class,
+            scopes: ['address_read'],
+            CQRSQueryMapping: ['[@index]' => '[requiredFields][@index]'],
         ),
     ],
-    exceptionToStatus: [
-        AddressConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
-        AddressNotFoundException::class => Response::HTTP_NOT_FOUND,
-    ],
+    normalizationContext: ['skip_null_values' => false],
 )]
-class Address
+class AddressRequiredFields
 {
-    #[ApiProperty(identifier: true)]
-    public int $addressId;
+    /**
+     * @var string[]
+     */
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'array',
+            'items' => ['type' => 'string'],
+            'example' => ['phone', 'company'],
+        ]
+    )]
+    public array $requiredFields = [];
 }

--- a/src/ApiPlatform/Resources/Carrier/Carrier.php
+++ b/src/ApiPlatform/Resources/Carrier/Carrier.php
@@ -24,9 +24,12 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Carrier;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\ToggleCarrierIsFreeCommand;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Command\ToggleCarrierStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Query\GetCarrierForEditing;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -38,6 +41,22 @@ use Symfony\Component\HttpFoundation\Response;
             CQRSQuery: GetCarrierForEditing::class,
             scopes: ['carrier_read'],
             CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/carriers/{carrierId}/toggle-status',
+            requirements: ['carrierId' => '\d+'],
+            output: false,
+            allowEmptyBody: true,
+            CQRSCommand: ToggleCarrierStatusCommand::class,
+            scopes: ['carrier_write'],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/carriers/{carrierId}/toggle-is-free',
+            requirements: ['carrierId' => '\d+'],
+            output: false,
+            allowEmptyBody: true,
+            CQRSCommand: ToggleCarrierIsFreeCommand::class,
+            scopes: ['carrier_write'],
         ),
     ],
     normalizationContext: ['skip_null_values' => false],

--- a/src/ApiPlatform/Resources/Carrier/Carrier.php
+++ b/src/ApiPlatform/Resources/Carrier/Carrier.php
@@ -24,7 +24,6 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Carrier;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
-use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Query\GetCarrierForEditing;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
@@ -72,7 +71,7 @@ class Carrier
 
     public int $maxDepth;
 
-    public DecimalNumber $maxWeight;
+    public float $maxWeight;
 
     #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
     public array $associatedGroupIds;
@@ -96,7 +95,8 @@ class Carrier
     public int $ordersCount;
 
     public const QUERY_MAPPING = [
-        '[carrierId]' => '[getCarrierId]',
+        '[_context][shopConstraint]' => '[shopConstraint]',
+        '[carrierId]' => '[getCarrierId][getValue]',
         '[name]' => '[getName]',
         '[grade]' => '[getGrade]',
         '[trackingUrl]' => '[getTrackingUrl]',
@@ -111,9 +111,9 @@ class Carrier
         '[associatedGroupIds]' => '[getAssociatedGroupIds]',
         '[hasAdditionalHandlingFee]' => '[hasAdditionalHandlingFee]',
         '[isFree]' => '[isFree]',
-        '[shippingMethod]' => '[getShippingMethod]',
+        '[shippingMethod]' => '[getShippingMethod][getValue]',
         '[idTaxRuleGroup]' => '[getIdTaxRuleGroup]',
-        '[rangeBehavior]' => '[getRangeBehavior]',
+        '[rangeBehavior]' => '[getRangeBehavior][getValue]',
         '[associatedShopIds]' => '[getAssociatedShopIds]',
         '[zones]' => '[getZones]',
         '[ordersCount]' => '[getOrdersCount]',

--- a/src/ApiPlatform/Resources/Carrier/Carrier.php
+++ b/src/ApiPlatform/Resources/Carrier/Carrier.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Carrier;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Query\GetCarrierForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/carriers/{carrierId}',
+            requirements: ['carrierId' => '\d+'],
+            CQRSQuery: GetCarrierForEditing::class,
+            scopes: ['carrier_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        CarrierNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class Carrier
+{
+    #[ApiProperty(identifier: true)]
+    public int $carrierId;
+
+    public string $name;
+
+    public int $grade;
+
+    public string $trackingUrl;
+
+    public int $position;
+
+    public bool $active;
+
+    #[LocalizedValue]
+    public array $delay;
+
+    public ?string $logoPath;
+
+    public int $maxWidth;
+
+    public int $maxHeight;
+
+    public int $maxDepth;
+
+    public DecimalNumber $maxWeight;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    public array $associatedGroupIds;
+
+    public bool $hasAdditionalHandlingFee;
+
+    public bool $isFree;
+
+    public int $shippingMethod;
+
+    public int $idTaxRuleGroup;
+
+    public int $rangeBehavior;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    public array $associatedShopIds;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'object']])]
+    public array $zones;
+
+    public int $ordersCount;
+
+    public const QUERY_MAPPING = [
+        '[carrierId]' => '[getCarrierId]',
+        '[name]' => '[getName]',
+        '[grade]' => '[getGrade]',
+        '[trackingUrl]' => '[getTrackingUrl]',
+        '[position]' => '[getPosition]',
+        '[active]' => '[isActive]',
+        '[delay]' => '[getLocalizedDelay]',
+        '[logoPath]' => '[getLogoPath]',
+        '[maxWidth]' => '[getMaxWidth]',
+        '[maxHeight]' => '[getMaxHeight]',
+        '[maxDepth]' => '[getMaxDepth]',
+        '[maxWeight]' => '[getMaxWeight]',
+        '[associatedGroupIds]' => '[getAssociatedGroupIds]',
+        '[hasAdditionalHandlingFee]' => '[hasAdditionalHandlingFee]',
+        '[isFree]' => '[isFree]',
+        '[shippingMethod]' => '[getShippingMethod]',
+        '[idTaxRuleGroup]' => '[getIdTaxRuleGroup]',
+        '[rangeBehavior]' => '[getRangeBehavior]',
+        '[associatedShopIds]' => '[getAssociatedShopIds]',
+        '[zones]' => '[getZones]',
+        '[ordersCount]' => '[getOrdersCount]',
+    ];
+}

--- a/src/ApiPlatform/Resources/Carrier/CarrierList.php
+++ b/src/ApiPlatform/Resources/Carrier/CarrierList.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Carrier;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierNotFoundException;
+use PrestaShop\PrestaShop\Core\Search\Filters\CarrierFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+use PrestaShopBundle\ApiPlatform\Provider\QueryListProvider;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/carriers',
+            provider: QueryListProvider::class,
+            scopes: ['carrier_read'],
+            ApiResourceMapping: [
+                '[id_carrier]' => '[carrierId]',
+                '[is_free]' => '[isFree]',
+            ],
+            gridDataFactory: 'prestashop.core.grid.data.factory.carrier_decorator',
+            filtersClass: CarrierFilters::class,
+        ),
+    ],
+    exceptionToStatus: [
+        CarrierNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CarrierList
+{
+    #[ApiProperty(identifier: true)]
+    public int $carrierId;
+
+    public string $name;
+
+    public ?string $delay;
+
+    public bool $active;
+
+    public bool $isFree;
+
+    public int $position;
+
+    public ?string $logo;
+}

--- a/src/ApiPlatform/Resources/Carrier/CarrierList.php
+++ b/src/ApiPlatform/Resources/Carrier/CarrierList.php
@@ -40,7 +40,7 @@ use Symfony\Component\HttpFoundation\Response;
                 '[id_carrier]' => '[carrierId]',
                 '[is_free]' => '[isFree]',
             ],
-            gridDataFactory: 'prestashop.core.grid.data.factory.carrier_decorator',
+            gridDataFactory: 'prestashop.core.grid.data.factory.carrier',
             filtersClass: CarrierFilters::class,
         ),
     ],

--- a/src/ApiPlatform/Resources/Carrier/CarrierRanges.php
+++ b/src/ApiPlatform/Resources/Carrier/CarrierRanges.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Carrier;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Query\GetCarrierRanges;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/carriers/{carrierId}/ranges',
+            requirements: ['carrierId' => '\d+'],
+            CQRSQuery: GetCarrierRanges::class,
+            scopes: ['carrier_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        CarrierNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CarrierRanges
+{
+    #[ApiProperty(identifier: true)]
+    public int $carrierId;
+
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'array',
+            'items' => [
+                'type' => 'object',
+                'properties' => [
+                    'zoneId' => ['type' => 'integer'],
+                    'ranges' => [
+                        'type' => 'array',
+                        'items' => [
+                            'type' => 'object',
+                            'properties' => [
+                                'from' => ['type' => 'string'],
+                                'to' => ['type' => 'string'],
+                                'price' => ['type' => 'string'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    )]
+    public array $zones = [];
+
+    public const QUERY_MAPPING = [
+        '[carrierId]' => '[getCarrierId]',
+        '[zones]' => '[getZones]',
+    ];
+}

--- a/src/ApiPlatform/Resources/Carrier/CarrierRanges.php
+++ b/src/ApiPlatform/Resources/Carrier/CarrierRanges.php
@@ -74,6 +74,7 @@ class CarrierRanges
     public array $zones = [];
 
     public const QUERY_MAPPING = [
+        '[_context][shopConstraint]' => '[shopConstraint]',
         '[carrierId]' => '[getCarrierId][getValue]',
         '[zones]' => '[getZones]',
     ];

--- a/src/ApiPlatform/Resources/Carrier/CarrierRanges.php
+++ b/src/ApiPlatform/Resources/Carrier/CarrierRanges.php
@@ -24,6 +24,7 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Carrier;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Exception\CarrierNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Carrier\Query\GetCarrierRanges;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
@@ -42,6 +43,8 @@ use Symfony\Component\HttpFoundation\Response;
     normalizationContext: ['skip_null_values' => false],
     exceptionToStatus: [
         CarrierNotFoundException::class => Response::HTTP_NOT_FOUND,
+        // GetCarrierRanges only supports ShopConstraint::allShops() - core limitation (TODO in CarrierRangeRepository)
+        CarrierConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
     ],
 )]
 class CarrierRanges

--- a/src/ApiPlatform/Resources/Carrier/CarrierRanges.php
+++ b/src/ApiPlatform/Resources/Carrier/CarrierRanges.php
@@ -74,7 +74,7 @@ class CarrierRanges
     public array $zones = [];
 
     public const QUERY_MAPPING = [
-        '[carrierId]' => '[getCarrierId]',
+        '[carrierId]' => '[getCarrierId][getValue]',
         '[zones]' => '[getZones]',
     ];
 }

--- a/tests/Integration/ApiPlatform/AddressEndpointTest.php
+++ b/tests/Integration/ApiPlatform/AddressEndpointTest.php
@@ -507,7 +507,6 @@ class AddressEndpointTest extends ApiTestCase
     public function testGetAddressRequiredFields(): void
     {
         $result = $this->getItem('/addresses/required-fields', ['address_read']);
-        
         $this->assertArrayHasKey('requiredFields', $result);
         $this->assertIsArray($result['requiredFields']);
         

--- a/tests/Integration/ApiPlatform/AddressEndpointTest.php
+++ b/tests/Integration/ApiPlatform/AddressEndpointTest.php
@@ -48,6 +48,11 @@ class AddressEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
+        yield 'get address required fields endpoint' => [
+            'GET',
+            '/addresses/required-fields',
+        ];
+
         yield 'get customer address endpoint' => [
             'GET',
             '/addresses/customers/1',
@@ -497,5 +502,19 @@ class AddressEndpointTest extends ApiTestCase
 
         // Use the createItem method but expect it to fail with validation error
         $this->createItem('/addresses/customers', $invalidData, ['address_write'], 422);
+    }
+
+    public function testGetAddressRequiredFields(): void
+    {
+        $result = $this->getItem('/addresses/required-fields', ['address_read']);
+        
+        $this->assertArrayHasKey('requiredFields', $result);
+        $this->assertIsArray($result['requiredFields']);
+        
+        // Assert some common required fields are present
+        if (!empty($result['requiredFields'])) {
+            // Just verifying it's an array of strings
+            $this->assertIsString($result['requiredFields'][0]);
+        }
     }
 }

--- a/tests/Integration/ApiPlatform/CarrierEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CarrierEndpointTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CarrierEndpointTest extends ApiTestCase
+{
+    public static \Carrier $carrier1;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['carrier_read', 'carrier_write']);
+
+        self::$carrier1 = new \Carrier();
+        self::$carrier1->name = 'Test Carrier 1';
+        self::$carrier1->delay = [1 => 'Delivery in 2-3 days'];
+        self::$carrier1->active = true;
+        self::$carrier1->is_free = false;
+        self::$carrier1->shipping_handling = false;
+        self::$carrier1->range_behavior = 0;
+        self::$carrier1->is_module = false;
+        self::$carrier1->save();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['carrier', 'carrier_lang', 'carrier_shop', 'carrier_group', 'carrier_zone', 'carrier_tax_rules_group_shop']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get endpoint' => [
+            'GET',
+            '/carriers/1',
+        ];
+
+        yield 'toggle status endpoint' => [
+            'PUT',
+            '/carriers/1/toggle-status',
+        ];
+
+        yield 'toggle is free endpoint' => [
+            'PUT',
+            '/carriers/1/toggle-is-free',
+        ];
+    }
+
+    public function testGetCarrier(): int
+    {
+        $carrierId = (int) self::$carrier1->id;
+
+        $carrier = $this->getItem('/carriers/' . $carrierId, ['carrier_read']);
+        $this->assertEquals($carrierId, $carrier['carrierId']);
+        $this->assertTrue($carrier['active']);
+        $this->assertFalse($carrier['isFree']);
+
+        return $carrierId;
+    }
+
+    /**
+     * @depends testGetCarrier
+     */
+    public function testToggleCarrierStatus(int $carrierId): int
+    {
+        $this->updateItem('/carriers/' . $carrierId . '/toggle-status', [], ['carrier_write'], Response::HTTP_NO_CONTENT);
+        $carrier = $this->getItem('/carriers/' . $carrierId, ['carrier_read']);
+        $this->assertFalse($carrier['active']);
+
+        // Toggle back
+        $this->updateItem('/carriers/' . $carrierId . '/toggle-status', [], ['carrier_write'], Response::HTTP_NO_CONTENT);
+        $carrier = $this->getItem('/carriers/' . $carrierId, ['carrier_read']);
+        $this->assertTrue($carrier['active']);
+
+        return $carrierId;
+    }
+
+    /**
+     * @depends testToggleCarrierStatus
+     */
+    public function testToggleCarrierIsFree(int $carrierId): int
+    {
+        $this->updateItem('/carriers/' . $carrierId . '/toggle-is-free', [], ['carrier_write'], Response::HTTP_NO_CONTENT);
+        $carrier = $this->getItem('/carriers/' . $carrierId, ['carrier_read']);
+        $this->assertTrue($carrier['isFree']);
+
+        // Toggle back
+        $this->updateItem('/carriers/' . $carrierId . '/toggle-is-free', [], ['carrier_write'], Response::HTTP_NO_CONTENT);
+        $carrier = $this->getItem('/carriers/' . $carrierId, ['carrier_read']);
+        $this->assertFalse($carrier['isFree']);
+
+        return $carrierId;
+    }
+
+    /**
+     * @depends testToggleCarrierIsFree
+     */
+    public function testToggleCarrierStatusNotFound(int $carrierId): void
+    {
+        $this->updateItem('/carriers/99999/toggle-status', [], ['carrier_write'], Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @depends testToggleCarrierStatusNotFound
+     */
+    public function testToggleCarrierIsFreeNotFound(): void
+    {
+        $this->updateItem('/carriers/99999/toggle-is-free', [], ['carrier_write'], Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
 | Questions         | Answers |                                                                                           
  | ------------------| ------------------------------------------------------- |
  | Description?      | Added two new PUT endpoints to toggle carrier status and isFree flag: `PUT /carriers/{carrierId}/toggle-status` (maps to `ToggleCarrierStatusCommand`) and `PUT /carriers/{carrierId}/toggle-is-free`   (maps to `ToggleCarrierIsFreeCommand`). Both endpoints return 204 No Content, require scope `carrier_write`, and return    404 if the carrier does not exist. Integration tests added for both endpoints. |
  | Type?             | new feature |
  | BC breaks?        | no |
  | Deprecations?     | no |
  | Fixed ticket?     | N/A |
  | Sponsor company   | bwlab (luigi massa) |
  | How to test?      | 1. Authenticate with scope `carrier_write` and `carrier_read`. 2. `PUT   /api/carriers/{id}/toggle-status` → expect 204; call `GET /api/carriers/{id}` and verify `active` has been toggled. 3.   `PUT /api/carriers/{id}/toggle-is-free` → expect 204; call `GET /api/carriers/{id}` and verify `isFree` has been toggled.   4. Call either endpoint with a non-existent carrier ID → expect 404. 5. Call either endpoint without `carrier_write` scope    → expect 401/403. Run integration tests: `vendor/bin/phpunit tests/Integration/ApiPlatform/CarrierEndpointTest.php` |
