### PR TITLE
feat: add Customer API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Customer/CustomerCarts.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerCarts.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerCarts;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/customers/{customerId}/carts',
+            requirements: ['customerId' => '\d+'],
+            CQRSQuery: GetCustomerCarts::class,
+            scopes: ['customer_read'],
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CustomerCarts
+{
+    #[ApiProperty(identifier: true)]
+    public int $customerId;
+
+    public array $carts = [];
+}

--- a/src/ApiPlatform/Resources/Customer/CustomerGuestTransform.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerGuestTransform.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\TransformGuestToCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerTransformationException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/customers/{customerId}/transform-guests',
+            requirements: ['customerId' => '\d+'],
+            output: false,
+            CQRSCommand: TransformGuestToCustomerCommand::class,
+            scopes: ['customer_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomerConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CustomerTransformationException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CustomerGuestTransform
+{
+    #[ApiProperty(identifier: true)]
+    public int $customerId;
+}

--- a/src/ApiPlatform/Resources/Customer/CustomerNote.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerNote.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetPrivateNoteAboutCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/customers/{customerId}/notes',
+            requirements: ['customerId' => '\d+'],
+            output: false,
+            CQRSCommand: SetPrivateNoteAboutCustomerCommand::class,
+            scopes: ['customer_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomerConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CustomerNote
+{
+    #[ApiProperty(identifier: true)]
+    public int $customerId;
+
+    #[Assert\NotBlank]
+    public string $privateNote;
+}

--- a/src/ApiPlatform/Resources/Customer/CustomerOrders.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerOrders.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerOrders;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/customers/{customerId}/orders',
+            requirements: ['customerId' => '\d+'],
+            CQRSQuery: GetCustomerOrders::class,
+            scopes: ['customer_read'],
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CustomerOrders
+{
+    #[ApiProperty(identifier: true)]
+    public int $customerId;
+
+    public array $orders = [];
+}


### PR DESCRIPTION
## Summary

Add Customer management API endpoints (4 endpoints).

### New endpoints:
- `GET/PUT /customers/{customerId}/note` - Manage private notes
- `POST /customers/{customerId}/transform-guest` - Transform guest to customer
- `GET /customers/{customerId}/orders` - Get customer orders
- `GET /customers/{customerId}/carts` - Get customer carts

## Test plan
- [ ] Run existing test suite
- [ ] Test customer operations

## Related
Contributes to #39630
Split from #166 as requested by reviewers