### PR TITLE
feat: add CmsPage API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/CmsPage/BulkCmsPages.php
+++ b/src/ApiPlatform/Resources/CmsPage/BulkCmsPages.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkDeleteCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkDisableCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkEnableCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotDeleteCmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotDisableCmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotEnableCmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/cms-pages/bulk-delete',
+            CQRSCommand: BulkDeleteCmsPageCommand::class,
+            scopes: ['cms_page_write'],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/cms-pages/bulk-enable',
+            output: false,
+            CQRSCommand: BulkEnableCmsPageCommand::class,
+            scopes: ['cms_page_write'],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/cms-pages/bulk-disable',
+            output: false,
+            CQRSCommand: BulkDisableCmsPageCommand::class,
+            scopes: ['cms_page_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CannotDeleteCmsPageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CannotEnableCmsPageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CannotDisableCmsPageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkCmsPages
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $cmsPageIds;
+}

--- a/src/ApiPlatform/Resources/CmsPage/CmsPage.php
+++ b/src/ApiPlatform/Resources/CmsPage/CmsPage.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\AddCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\DeleteCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\EditCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\ToggleCmsPageStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotAddCmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotDeleteCmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotEditCmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CannotToggleCmsPageException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Query\GetCmsPageForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/cms-pages/{cmsPageId}',
+            requirements: ['cmsPageId' => '\d+'],
+            CQRSQuery: GetCmsPageForEditing::class,
+            scopes: ['cms_page_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/cms-pages',
+            CQRSCommand: AddCmsPageCommand::class,
+            CQRSQuery: GetCmsPageForEditing::class,
+            scopes: ['cms_page_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/cms-pages/{cmsPageId}',
+            requirements: ['cmsPageId' => '\d+'],
+            CQRSCommand: EditCmsPageCommand::class,
+            CQRSQuery: GetCmsPageForEditing::class,
+            scopes: ['cms_page_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/cms-pages/{cmsPageId}',
+            requirements: ['cmsPageId' => '\d+'],
+            CQRSCommand: DeleteCmsPageCommand::class,
+            scopes: ['cms_page_write'],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/cms-pages/{cmsPageId}/toggle-status',
+            requirements: ['cmsPageId' => '\d+'],
+            output: false,
+            CQRSCommand: ToggleCmsPageStatusCommand::class,
+            scopes: ['cms_page_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CannotAddCmsPageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CannotEditCmsPageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CannotDeleteCmsPageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CannotToggleCmsPageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CmsPage
+{
+    #[ApiProperty(identifier: true)]
+    public int $cmsPageId;
+
+    public int $cmsPageCategoryId;
+
+    #[LocalizedValue]
+    #[Assert\NotBlank]
+    public array $titles;
+
+    #[LocalizedValue]
+    public array $metaTitles;
+
+    #[LocalizedValue]
+    public array $metaDescriptions;
+
+    #[LocalizedValue]
+    public array $friendlyUrls;
+
+    #[LocalizedValue]
+    public array $contents;
+
+    public bool $indexedForSearch;
+
+    public bool $displayed;
+
+    /**
+     * @var int[]
+     */
+    public array $shopIds;
+
+    public string $previewUrl;
+
+    public const QUERY_MAPPING = [
+        '[localizedTitle]' => '[titles]',
+        '[localizedMetaTitle]' => '[metaTitles]',
+        '[localizedMetaDescription]' => '[metaDescriptions]',
+        '[localizedFriendlyUrl]' => '[friendlyUrls]',
+        '[localizedContent]' => '[contents]',
+        '[isIndexedForSearch]' => '[indexedForSearch]',
+        '[isDisplayed]' => '[displayed]',
+        '[shopAssociation]' => '[shopIds]',
+    ];
+
+    public const COMMAND_MAPPING = [
+        '[titles]' => '[localizedTitle]',
+        '[metaTitles]' => '[localizedMetaTitle]',
+        '[metaDescriptions]' => '[localizedMetaDescription]',
+        '[friendlyUrls]' => '[localizedFriendlyUrl]',
+        '[contents]' => '[localizedContent]',
+        '[shopIds]' => '[shopAssociation]',
+    ];
+}


### PR DESCRIPTION
## Summary

Add CmsPage management API endpoints (8 endpoints).

### New endpoints:
- `GET /cms-pages` - List CMS pages
- `GET /cms-pages/{cmsPageId}` - Get CMS page
- `POST /cms-pages` - Create CMS page
- `PATCH /cms-pages/{cmsPageId}` - Update CMS page
- `DELETE /cms-pages/{cmsPageId}` - Delete CMS page
- `DELETE /cms-pages/bulk` - Bulk delete
- `PATCH /cms-pages/{cmsPageId}/status` - Toggle status
- `PATCH /cms-pages/bulk/status` - Bulk toggle status

## ⚠️ Dependency

The `GET /cms-pages/{cmsPageId}` endpoint requires a fix in PrestaShop core:
- **PR**: https://github.com/PrestaShop/PrestaShop/pull/41128

Without this fix, the GET endpoint returns a 500 error.

## Test plan
- [ ] Run existing test suite
- [ ] Test CMS page CRUD operations (after core fix is merged)

## Related
Contributes to #39630
Split from #166 as requested by reviewers