### PR TITLE
feat: add Product extended API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductAttachments.php
+++ b/src/ApiPlatform/Resources/Product/ProductAttachments.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Exception\AttachmentNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Attachment\Command\RemoveAllAssociatedProductAttachmentsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Attachment\Command\SetAssociatedProductAttachmentsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/attachments',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: SetAssociatedProductAttachmentsCommand::class,
+            scopes: [
+                'product_write',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/products/{productId}/attachments',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: RemoveAllAssociatedProductAttachmentsCommand::class,
+            scopes: [
+                'product_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        AttachmentNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductAttachments
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 2, 3]])]
+    public array $attachmentIds;
+}

--- a/src/ApiPlatform/Resources/Product/ProductCustomizations.php
+++ b/src/ApiPlatform/Resources/Product/ProductCustomizations.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\RemoveAllCustomizationFieldsFromProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\SetProductCustomizationFieldsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationFieldConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationFieldNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/customization-fields',
+            requirements: ['productId' => '\d+'],
+            CQRSQuery: GetProductCustomizationFields::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/customization-fields',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: SetProductCustomizationFieldsCommand::class,
+            CQRSQuery: GetProductCustomizationFields::class,
+            scopes: [
+                'product_write',
+            ],
+            CQRSCommandMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+            CQRSQueryMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/products/{productId}/customization-fields',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: RemoveAllCustomizationFieldsFromProductCommand::class,
+            scopes: [
+                'product_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomizationFieldNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomizationFieldConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ProductCustomizations
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer', 'nullable' => true],
+                'type' => ['type' => 'integer', 'description' => '0 = file, 1 = text'],
+                'localized_names' => [
+                    'type' => 'object',
+                    'additionalProperties' => ['type' => 'string'],
+                ],
+                'is_required' => ['type' => 'boolean'],
+                'added_by_module' => ['type' => 'boolean'],
+            ],
+        ],
+        'example' => [
+            [
+                'id' => null,
+                'type' => 1,
+                'localized_names' => ['1' => 'Custom text'],
+                'is_required' => true,
+                'added_by_module' => false,
+            ],
+        ],
+    ])]
+    public array $customizationFields;
+}

--- a/src/ApiPlatform/Resources/Product/ProductDefaultSupplier.php
+++ b/src/ApiPlatform/Resources/Product/ProductDefaultSupplier.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\SetProductDefaultSupplierCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Exception\ProductSupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetAssociatedSuppliers;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/default-suppliers',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: SetProductDefaultSupplierCommand::class,
+            CQRSQuery: GetAssociatedSuppliers::class,
+            scopes: [
+                'product_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ProductSupplierException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        SupplierNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductDefaultSupplier
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    public int $defaultSupplierId;
+}

--- a/src/ApiPlatform/Resources/Product/ProductPack.php
+++ b/src/ApiPlatform/Resources/Product/ProductPack.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\RemoveAllProductsFromPackCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\SetPackProductsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Exception\ProductPackConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Exception\ProductPackException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query\GetPackedProducts;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/packs',
+            requirements: ['productId' => '\d+'],
+            CQRSQuery: GetPackedProducts::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: [
+                '[packId]' => '[productId]',
+                '[_context][shopConstraint]' => '[shopConstraint]',
+                '[_context][langId]' => '[languageId]',
+            ],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/packs',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: SetPackProductsCommand::class,
+            CQRSQuery: GetPackedProducts::class,
+            scopes: [
+                'product_write',
+            ],
+            CQRSCommandMapping: [
+                '[productId]' => '[packId]',
+            ],
+            CQRSQueryMapping: [
+                '[packId]' => '[productId]',
+                '[_context][shopConstraint]' => '[shopConstraint]',
+                '[_context][langId]' => '[languageId]',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/products/{productId}/packs',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: RemoveAllProductsFromPackCommand::class,
+            scopes: [
+                'product_write',
+            ],
+            CQRSCommandMapping: [
+                '[productId]' => '[packId]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ProductPackException::class => Response::HTTP_NOT_FOUND,
+        ProductPackConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        ShopAssociationNotFound::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductPack
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'productId' => ['type' => 'integer'],
+                'quantity' => ['type' => 'integer'],
+                'combinationId' => ['type' => 'integer'],
+                'productName' => ['type' => 'string'],
+                'reference' => ['type' => 'string'],
+                'imageUrl' => ['type' => 'string'],
+            ],
+        ],
+        'example' => [
+            [
+                'productId' => 1,
+                'quantity' => 2,
+                'combinationId' => 0,
+                'productName' => 'Product Name',
+                'reference' => 'Ref: ABC123',
+                'imageUrl' => 'https://example.com/image.jpg',
+            ],
+        ],
+    ])]
+    public array $packedProducts;
+
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'product_id' => ['type' => 'integer'],
+                'quantity' => ['type' => 'integer'],
+                'combination_id' => ['type' => 'integer'],
+            ],
+        ],
+        'example' => [
+            [
+                'product_id' => 1,
+                'quantity' => 2,
+                'combination_id' => 0,
+            ],
+        ],
+    ])]
+    public array $products;
+}

--- a/src/ApiPlatform/Resources/Product/ProductQueries.php
+++ b/src/ApiPlatform/Resources/Product/ProductQueries.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Query\GetCatalogPriceRuleListForProduct;
+use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Query\GetProductAttributeGroups;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Query\GetProductFeatureValues;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\Query\GetShopProductImages;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductIsEnabled;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Query\GetProductStockMovements;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/attribute-groups',
+            requirements: ['productId' => '\d+'],
+            openapiContext: ['summary' => 'Get product attribute groups', 'description' => 'Retrieves attribute groups associated with a product for combinations'],
+            CQRSQuery: GetProductAttributeGroups::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+        ),
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/feature-values',
+            requirements: ['productId' => '\d+'],
+            openapiContext: ['summary' => 'Get product feature values', 'description' => 'Retrieves feature values associated with a product'],
+            CQRSQuery: GetProductFeatureValues::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][shopId]' => '[shopId]',
+            ],
+        ),
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/is-enableds',
+            requirements: ['productId' => '\d+'],
+            openapiContext: ['summary' => 'Get product enabled status', 'description' => 'Checks if a product is enabled or disabled'],
+            CQRSQuery: GetProductIsEnabled::class,
+            scopes: [
+                'product_read',
+            ],
+        ),
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/stock-movements',
+            requirements: ['productId' => '\d+'],
+            openapiContext: ['summary' => 'Get product stock movements', 'description' => 'Retrieves stock movement history for a product'],
+            CQRSQuery: GetProductStockMovements::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][shopId]' => '[shopId]',
+            ],
+        ),
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/shop-images',
+            requirements: ['productId' => '\d+'],
+            openapiContext: ['summary' => 'Get product images for all shops', 'description' => 'Retrieves images associated with a product detailed for every shop'],
+            CQRSQuery: GetShopProductImages::class,
+            scopes: [
+                'product_read',
+            ],
+        ),
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/related-products',
+            requirements: ['productId' => '\d+'],
+            openapiContext: ['summary' => 'Get related products', 'description' => 'Retrieves products related to a given product'],
+            CQRSQuery: GetRelatedProducts::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][langId]' => '[languageId]',
+            ],
+        ),
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/catalog-price-rules',
+            requirements: ['productId' => '\d+'],
+            openapiContext: ['summary' => 'Get catalog price rules for product', 'description' => 'Retrieves catalog price rules applicable to a product'],
+            CQRSQuery: GetCatalogPriceRuleListForProduct::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][langId]' => '[langId]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductQueries
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    public int $offset;
+
+    public int $limit;
+}

--- a/src/ApiPlatform/Resources/Product/ProductSuppliers.php
+++ b/src/ApiPlatform/Resources/Product/ProductSuppliers.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\RemoveAllAssociatedProductSuppliersCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\SetSuppliersCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\UpdateProductSuppliersCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Exception\ProductSupplierException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Exception\ProductSupplierNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetAssociatedSuppliers;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSupplierOptions;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/suppliers',
+            requirements: ['productId' => '\d+'],
+            CQRSQuery: GetAssociatedSuppliers::class,
+            scopes: [
+                'product_read',
+            ],
+        ),
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/supplier-options',
+            requirements: ['productId' => '\d+'],
+            openapiContext: ['summary' => 'Get product supplier options', 'description' => 'Retrieves all supplier options configured for a product'],
+            CQRSQuery: GetProductSupplierOptions::class,
+            scopes: [
+                'product_read',
+            ],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/suppliers',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: SetSuppliersCommand::class,
+            CQRSQuery: GetAssociatedSuppliers::class,
+            scopes: [
+                'product_write',
+            ],
+        ),
+        new CQRSCommand(
+            uriTemplate: '/products/{productId}/suppliers',
+            method: 'PATCH',
+            requirements: ['productId' => '\d+'],
+            openapiContext: ['summary' => 'Update product suppliers', 'description' => 'Updates product supplier details (reference, price, currency)'],
+            CQRSCommand: UpdateProductSuppliersCommand::class,
+            CQRSQuery: GetAssociatedSuppliers::class,
+            scopes: [
+                'product_write',
+            ],
+            CQRSCommandMapping: [
+                '[productSuppliers]' => '[productSuppliers]',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/products/{productId}/suppliers',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: RemoveAllAssociatedProductSuppliersCommand::class,
+            scopes: [
+                'product_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ProductSupplierNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ProductSupplierException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        SupplierNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductSuppliers
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 2, 3]])]
+    public array $supplierIds;
+
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'supplier_id' => ['type' => 'integer'],
+                'product_supplier_id' => ['type' => 'integer'],
+                'currency_id' => ['type' => 'integer'],
+                'reference' => ['type' => 'string'],
+                'price_tax_excluded' => ['type' => 'string'],
+            ],
+        ],
+        'example' => [
+            [
+                'supplier_id' => 1,
+                'product_supplier_id' => null,
+                'currency_id' => 1,
+                'reference' => 'SUPPLIER-REF-123',
+                'price_tax_excluded' => '10.50',
+            ],
+        ],
+    ])]
+    public array $productSuppliers;
+}

--- a/tests/Integration/ApiPlatform/ProductExtendedEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductExtendedEndpointTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ProductExtendedEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_read', 'product_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        // Attachments and packs endpoints return 404 (CQRS queries not available in test env)
+        yield 'get product packs endpoint' => ['GET', '/products/1/packs'];
+        yield 'delete product pack endpoint' => ['DELETE', '/products/1/packs'];
+        yield 'get product customization fields endpoint' => ['GET', '/products/1/customization-fields'];
+        yield 'update product customization fields endpoint' => ['PUT', '/products/1/customization-fields'];
+        yield 'delete product customization fields endpoint' => ['DELETE', '/products/1/customization-fields'];
+        yield 'get product suppliers endpoint' => ['GET', '/products/1/suppliers'];
+        yield 'update product suppliers endpoint' => ['PUT', '/products/1/suppliers'];
+        yield 'get product supplier options endpoint' => ['GET', '/products/1/supplier-options'];
+        yield 'update product default supplier endpoint' => ['PUT', '/products/1/default-suppliers'];
+        yield 'get product attribute groups endpoint' => ['GET', '/products/1/attribute-groups'];
+        yield 'get product feature values endpoint' => ['GET', '/products/1/feature-values'];
+        yield 'get product is enabled endpoint' => ['GET', '/products/1/is-enableds'];
+    }
+}


### PR DESCRIPTION
## Summary
Add Product extended API endpoints:
- ProductPack: manage packed products
- ProductSuppliers: manage product suppliers
- ProductDefaultSupplier: set default supplier
- ProductAttachments: manage attachments
- ProductCustomizations: manage customization fields
- ProductQueries: various product queries (attribute groups, features, stock, etc.)

## Related
Contributes to #39630 - Split from #167