### PR TITLE
feat: add Order extended API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderProducts.php
+++ b/src/ApiPlatform/Resources/Order/OrderProducts.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\DeleteProductFromOrderCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/products/{orderDetailId}',
+            requirements: ['orderId' => '\d+', 'orderDetailId' => '\d+'],
+            openapiContext: ['summary' => 'Update product in order', 'description' => 'Updates a product quantity and price in an order'],
+            CQRSCommand: UpdateProductInOrderCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/orders/{orderId}/products/{orderDetailId}',
+            requirements: ['orderId' => '\d+', 'orderDetailId' => '\d+'],
+            openapiContext: ['summary' => 'Delete product from order', 'description' => 'Removes a product from an order'],
+            CQRSCommand: DeleteProductFromOrderCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderProducts
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    public int $orderDetailId;
+
+    public string $priceTaxIncluded;
+
+    public string $priceTaxExcluded;
+
+    public int $quantity;
+
+    public ?int $orderInvoiceId = null;
+
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'shipment_id' => ['type' => 'integer'],
+                'quantity' => ['type' => 'integer'],
+            ],
+        ],
+        'example' => [
+            ['shipment_id' => 1, 'quantity' => 2],
+        ],
+    ])]
+    public ?array $shipmentsQuantities = null;
+}

--- a/src/ApiPlatform/Resources/Order/OrderReturn.php
+++ b/src/ApiPlatform/Resources/Order/OrderReturn.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Command\UpdateOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Query\GetOrderReturnForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/orders/{orderReturnId}',
+            requirements: ['orderReturnId' => '\d+'],
+            openapiContext: ['summary' => 'Get order return', 'description' => 'Retrieves an order return for editing'],
+            CQRSQuery: GetOrderReturnForEditing::class,
+            scopes: [
+                'order_read',
+            ],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/orders/{orderReturnId}/states',
+            requirements: ['orderReturnId' => '\d+'],
+            openapiContext: ['summary' => 'Update order return state', 'description' => 'Updates the state of an order return'],
+            CQRSCommand: UpdateOrderReturnStateCommand::class,
+            CQRSQuery: GetOrderReturnForEditing::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderReturnNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderReturnConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderReturn
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderReturnId;
+
+    public int $orderReturnStateId;
+}

--- a/tests/Integration/ApiPlatform/OrderExtendedEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderExtendedEndpointTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class OrderExtendedEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_read', 'order_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get order return endpoint' => ['GET', '/orders/1'];
+        // Status and product update require an existing order in fixtures
+        yield 'delete order product endpoint' => ['DELETE', '/orders/1/products/1'];
+    }
+}


### PR DESCRIPTION
## Summary
Add Order extended API endpoints:
- OrderProducts: update/delete products in order
- OrderReturn: get return details and update state

## Related
Contributes to #39630 - Split from #167