### PR TITLE
feat: add Currency, Country, ImageSettings and Shop API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Country/Country.php
+++ b/src/ApiPlatform/Resources/Country/Country.php
@@ -24,25 +24,41 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Country;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\EditCountryCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Country\Query\GetCountryForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Country\Query\GetCountryRequiredFields;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use Symfony\Component\HttpFoundation\Response;
 
 #[ApiResource(
     operations: [
         new CQRSGet(
+            uriTemplate: '/countries/{countryId}/required-fields',
+            requirements: ['countryId' => '\d+'],
+            openapiContext: ['summary' => 'Get country required fields', 'description' => 'Retrieves the required fields for a country'],
+            CQRSQuery: GetCountryRequiredFields::class,
+            scopes: [
+                'country_read',
+            ],
+        ),
+        new CQRSPartialUpdate(
             uriTemplate: '/countries/{countryId}',
             requirements: ['countryId' => '\d+'],
+            openapiContext: ['summary' => 'Edit country', 'description' => 'Updates a country configuration'],
+            CQRSCommand: EditCountryCommand::class,
             CQRSQuery: GetCountryForEditing::class,
-            scopes: ['country_read'],
-            CQRSQueryMapping: self::QUERY_MAPPING,
+            scopes: [
+                'country_write',
+            ],
         ),
     ],
-    normalizationContext: ['skip_null_values' => false],
     exceptionToStatus: [
         CountryNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CountryConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
     ],
 )]
 class Country
@@ -51,19 +67,19 @@ class Country
     public int $countryId;
 
     #[LocalizedValue]
-    public array $names;
+    public array $localizedNames;
 
     public string $isoCode;
 
     public int $callPrefix;
 
-    public int $defaultCurrencyId;
+    public int $defaultCurrency;
 
-    public int $zoneId;
+    public ?int $zoneId = null;
 
     public bool $needZipCode;
 
-    public ?string $zipCodeFormat;
+    public ?string $zipCodeFormat = null;
 
     public string $addressFormat;
 
@@ -75,12 +91,6 @@ class Country
 
     public bool $displayTaxLabel;
 
-    public array $shopIds;
-
-    public const QUERY_MAPPING = [
-        '[localizedNames]' => '[names]',
-        '[defaultCurrency]' => '[defaultCurrencyId]',
-        '[zone]' => '[zoneId]',
-        '[shopAssociation]' => '[shopIds]',
-    ];
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 2]])]
+    public array $shopAssociation;
 }

--- a/src/ApiPlatform/Resources/Currency/CurrencyQueries.php
+++ b/src/ApiPlatform/Resources/Currency/CurrencyQueries.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Currency;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\ExchangeRateNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Query\GetCurrencyExchangeRate;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Query\GetReferenceCurrency;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/currencies/exchange-rates/{isoCode}',
+            requirements: ['isoCode' => '[A-Z]{3}'],
+            openapiContext: ['summary' => 'Get currency exchange rate', 'description' => 'Retrieves the exchange rate for a currency compared to the default shop currency'],
+            CQRSQuery: GetCurrencyExchangeRate::class,
+            scopes: [
+                'currency_read',
+            ],
+        ),
+        new CQRSGet(
+            uriTemplate: '/currencies/references/{isoCode}',
+            requirements: ['isoCode' => '[A-Z]{3}'],
+            openapiContext: ['summary' => 'Get reference currency', 'description' => 'Retrieves reference currency data from the CLDR database'],
+            CQRSQuery: GetReferenceCurrency::class,
+            scopes: [
+                'currency_read',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CurrencyNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ExchangeRateNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CurrencyQueries
+{
+    #[ApiProperty(identifier: true)]
+    public string $isoCode;
+}

--- a/src/ApiPlatform/Resources/ImageSettings/ImageSettings.php
+++ b/src/ApiPlatform/Resources/ImageSettings/ImageSettings.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\ImageSettings;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\EditImageSettingsCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageSettingsForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/image-settings',
+            openapiContext: ['summary' => 'Get image settings', 'description' => 'Retrieves current image settings configuration'],
+            CQRSQuery: GetImageSettingsForEditing::class,
+            scopes: [
+                'image_settings_read',
+            ],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/image-settings',
+            openapiContext: ['summary' => 'Edit image settings', 'description' => 'Updates image settings configuration'],
+            CQRSCommand: EditImageSettingsCommand::class,
+            CQRSQuery: GetImageSettingsForEditing::class,
+            scopes: [
+                'image_settings_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ImageTypeException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ImageSettings
+{
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'string'], 'example' => ['jpg', 'webp', 'avif']])]
+    public array $formats;
+
+    public string $baseFormat;
+
+    public int $avifQuality;
+
+    public int $jpegQuality;
+
+    public int $pngQuality;
+
+    public int $webpQuality;
+
+    public int $generationMethod;
+
+    public int $pictureMaxSize;
+
+    public int $pictureMaxWidth;
+
+    public int $pictureMaxHeight;
+}

--- a/src/ApiPlatform/Resources/Shop/ShopLogos.php
+++ b/src/ApiPlatform/Resources/Shop/ShopLogos.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Shop;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Query\GetLogosPaths;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/shops/logos',
+            openapiContext: ['summary' => 'Get shop logos', 'description' => 'Retrieves paths to header, email, invoice and favicon logos'],
+            CQRSQuery: GetLogosPaths::class,
+            scopes: [
+                'shop_read',
+            ],
+        ),
+    ],
+)]
+class ShopLogos
+{
+    public ?string $headerLogoPath = null;
+
+    public ?string $mailLogoPath = null;
+
+    public ?string $invoiceLogoPath = null;
+
+    public ?string $faviconPath = null;
+}

--- a/tests/Integration/ApiPlatform/SettingsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SettingsEndpointTest.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class SettingsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['currency_read', 'image_settings_read', 'image_settings_write', 'shop_read', 'country_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get image settings endpoint' => ['GET', '/image-settings'];
+        yield 'update image settings endpoint' => ['PUT', '/image-settings'];
+        yield 'get shop logos endpoint' => ['GET', '/shops/logos'];
+    }
+}


### PR DESCRIPTION
## Summary
Add various settings API endpoints:
- CurrencyQueries: get exchange rate and reference currency
- Country: get required fields and edit configuration
- ImageSettings: get/edit image settings
- ShopLogos: get shop logos paths

## Related
Contributes to #39630 - Split from #167