### PR TITLE
feat: add SearchCartRules Query

### DIFF
--- a/src/ApiPlatform/Resources/CartRule/FoundCartRule.php
+++ b/src/ApiPlatform/Resources/CartRule/FoundCartRule.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CartRule;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\CartRule\Query\SearchCartRules;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/cart-rules/search',
+            scopes: [
+                'cart_rule_read',
+            ],
+            CQRSQuery: SearchCartRules::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'phrase',
+                    required: true,
+                    description: 'Search phrase to find cart rules by name or code'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    [
+                        'name' => 'phrase',
+                        'in' => 'query',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                        'description' => 'Search phrase to find cart rules by name or code',
+                    ],
+                ],
+            ],
+        ),
+    ],
+)]
+class FoundCartRule
+{
+    #[ApiProperty(identifier: true)]
+    public int $cartRuleId;
+
+    public string $name;
+
+    public string $code;
+
+    public const QUERY_MAPPING = [
+        '[phrase]' => '[searchPhrase]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CartRuleSearchEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CartRuleSearchEndpointTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CartRuleSearchEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient(['cart_rule_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'cart_rule',
+            'cart_rule_lang',
+            'cart_rule_shop',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'search cart rules endpoint' => [
+            'GET',
+            '/cart-rules/search?phrase=test',
+        ];
+    }
+
+    public function testSearchCartRules(): void
+    {
+        $searchResults = $this->getItem('/cart-rules/search?phrase=test', ['cart_rule_read']);
+
+        $this->assertIsArray($searchResults);
+
+        foreach ($searchResults as $result) {
+            $this->assertArrayHasKey('cartRuleId', $result);
+            $this->assertArrayHasKey('name', $result);
+            $this->assertArrayHasKey('code', $result);
+        }
+    }
+
+    public function testSearchCartRulesWithNoResults(): void
+    {
+        $searchResults = $this->getItem('/cart-rules/search?phrase=nonexistentcartrule999', ['cart_rule_read']);
+
+        $this->assertIsArray($searchResults);
+        $this->assertEmpty($searchResults);
+    }
+
+    public function testSearchCartRulesMissingPhrase(): void
+    {
+        $this->requestApi('GET', '/cart-rules/search', null, ['cart_rule_read'], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}


### PR DESCRIPTION


| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add `CQRSGetCollection` operation on `CartRule` resource mapped to `SearchCartRules`
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of https://github.com/PrestaShop/PrestaShop/issues/39630
| Sponsor company   | Enkore
| How to test?      | Create a cart_rule from the back office with a name such as TestName and a code such as TestCode. Create another cart_rule with a different name and code, for example DoNotMatch. Go to the API documentation and authenticate by selecting the cart_rule_read scope. In the CartRule section, enter the phrase TestName; the response should be:
```
[
  {
    "cartRuleId": 1,
    "name": "TestName",
    "code": "TestCode"
  }
]
```