### PR TITLE
fix(category): rename parentId to parentCategoryId

### DIFF
--- a/src/ApiPlatform/Resources/Category/Category.php
+++ b/src/ApiPlatform/Resources/Category/Category.php
@@ -174,7 +174,7 @@ class Category
 
     public int $position;
 
-    public int $parentId;
+    public int $parentCategoryId;
 
     public string $redirectType;
 
@@ -194,6 +194,7 @@ class Category
         '[metaTitle]' => '[metaTitles]',
         '[metaDescription]' => '[metaDescriptions]',
         '[linkRewrite]' => '[linkRewrites]',
+        '[parentId]' => '[parentCategoryId]',
     ];
 
     public const COMMAND_MAPPING = [

--- a/tests/Integration/ApiPlatform/CategoryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CategoryEndpointTest.php
@@ -124,6 +124,7 @@ class CategoryEndpointTest extends ApiTestCase
 
         $this->assertSame($postData['names'], $category['names']);
         $this->assertSame($postData['linkRewrites'], $category['linkRewrites']);
+        $this->assertSame($postData['parentCategoryId'], $category['parentCategoryId']);
 
         return $categoryId;
     }
@@ -150,6 +151,8 @@ class CategoryEndpointTest extends ApiTestCase
                 'fr-FR' => 'categorie-fr',
             ]
         );
+
+        $this->assertSame(2, $category['parentCategoryId']);
 
         return $categoryId;
     }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | The resource field was named `parentId` instead of `parentCategoryId`, causing it to be exposed incorrectly in the API schema and mismatched with `AddCategoryCommand` and `EditCategoryCommand` which both use `parentCategoryId`. The `QUERY_MAPPING` was missing the `parentId` → `parentCategoryId` translation, so `GET /categories/{id}` never returned the parent category value since `EditableCategory` exposes it as `parentId`.
| Type?             | bug fix
| BC breaks?        | no — `parentId` was never functional, no client could rely on it
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | N/A
| How to test?      | 1. Tests assert `parentCategoryId` on both POST and GET responses. 2. Call POST /categories with parentCategoryId : 2 and verify the created category has the correct parent. 3. Call GET /categories/{id} and verify parentCategoryId is returned with the correct value.