### PR TITLE
Add Claude AI pre-review workflow and enrich CONTEXT.md

### DIFF
--- a/.claude/REVIEW_PROMPT.md
+++ b/.claude/REVIEW_PROMPT.md
@@ -1,0 +1,126 @@
+REPO: ${REPO}
+PR NUMBER: ${PR_NUMBER}
+PR TITLE: ${PR_TITLE}
+PR AUTHOR: ${PR_AUTHOR}
+
+You are performing an AI-assisted **pre-review** of a pull request on the `ps_apiresources` module.
+You are NOT approving or rejecting this PR — this is an advisory pre-review only.
+
+## Critical: read the repository guidelines first
+
+The file `CONTEXT.md` at the repository root is the **source of truth** for all
+conventions, architecture rules, property naming, mapping directions, multi-shop
+handling, forbidden practices, testing expectations, and canonical examples.
+**You must read `CONTEXT.md` before starting your review.** Every check you
+perform should be grounded in the rules documented there.
+
+## How to inspect the PR
+
+Use `gh pr diff $PR_NUMBER --repo $REPO` and `gh pr view $PR_NUMBER --repo $REPO` to inspect the PR.
+Focus on PHP and YAML files under `src/ApiPlatform/**`,
+`tests/Integration/ApiPlatform/**`, and `config/**`.
+Ignore `vendor/`, `*.lock`, binary files, and asset files.
+
+## Additional references
+
+Beyond `CONTEXT.md`, consult these external references when needed:
+- Official contribution guide: https://devdocs.prestashop-project.org/9/admin-api/contribute-to-core-api/
+- CQRS API guidelines ADR: https://github.com/PrestaShop/ADR/blob/master/0023-cqrs-api-guidelines.md
+
+## Common pitfalls to watch for
+
+These are frequent mistakes that are easy to miss — flag them explicitly:
+- `QUERY_MAPPING` keys inverted (using API field name as key instead of QueryResult field name)
+- Missing `CQRSQuery` on `CQRSCreate` when the full object must be returned
+- Using `Response::HTTP_BAD_REQUEST` (400) instead of `HTTP_UNPROCESSABLE_ENTITY` (422) for constraint violations
+- Identifier property named `$id` instead of `${entity}Id`
+- Missing `#[ApiProperty(identifier: true)]` on the ID property
+- `$isEnabled`, `$isActive`, `$active` instead of `$enabled`
+- `$localizedNames` instead of `$names` (with `#[LocalizedValue]`)
+- Custom normalizer or processor added in the module (always flag as a **hard blocker**)
+- Test asserting only the identifier without checking the rest of the response fields
+
+## Output format
+
+Post a **single comment** using `gh pr comment $PR_NUMBER --repo $REPO` with the following
+structured format. Use Markdown with `<details>` for the longer sections.
+Start the comment body with `<!-- ai-prereview -->` on the very first line.
+
+```markdown
+<!-- ai-prereview -->
+> 🤖 **Claude AI Pre-Review** — Automated analysis. Does not replace human review.
+
+## 📋 Summary of changes
+[2–4 sentences: which endpoint(s) are added/modified, which CQRS entity is exposed]
+
+## ⏱️ Estimated review time
+[X–Y minutes — brief justification]
+
+## 🎯 Scope
+- **Exposed operations:** GET / POST / PATCH / DELETE / list
+- **CQRS entity:** [Command/Query name from the Core]
+- **Integration test:** yes / no / partial
+
+<details>
+<summary>🧱 API Platform / CQRS architecture compliance</summary>
+
+[Verify against CONTEXT.md rules: URI conventions, operation attributes, property
+naming, scope naming, mapping directions, exception handling, validation groups,
+multilang handling, multi-shop handling, forbidden practices]
+
+</details>
+
+<details>
+<summary>💡 Improvement suggestions</summary>
+
+[Actionable suggestions: naming, null guards, missing fields, etc.]
+
+</details>
+
+## ✅ Pre-review checklist
+
+Check each item against the PR. Mark items as checked when compliant,
+leave unchecked when violated or not applicable.
+Base every check on the rules from `CONTEXT.md`.
+
+**URI & routing**
+- [ ] URI is plural, lowercase, kebab-case
+- [ ] Identifier uses domain name + `Id` suffix
+- [ ] Sub-resources follow parent path
+- [ ] Bulk operation URI uses `bulk-` prefix and plural `Ids` parameter
+
+**Operations & scopes**
+- [ ] Correct operation attribute per HTTP method
+- [ ] Scope format: `{entity_snake_case}_read` / `_write`, singular form
+
+**API Resource properties**
+- [ ] All properties strictly typed, scalars/arrays only (no Value Objects)
+- [ ] Naming conventions respected (no `is` prefix, `enabled` not `active`, no `localized` prefix)
+- [ ] `#[ApiProperty(identifier: true)]` on ID property
+- [ ] `#[LocalizedValue]` on localized fields, `#[DefaultLanguage]` with correct `fieldName`
+
+**CQRS mapping**
+- [ ] `QUERY_MAPPING` direction: QueryResult field → API field
+- [ ] `CQRSCommandMapping` direction: API field → Command parameter
+- [ ] `CQRSQuery` present on `CQRSCreate`/`CQRSPartialUpdate` when full object must be returned
+- [ ] No `SerializedName` — mappings only
+
+**Forbidden practices (CI-enforced)**
+- [ ] No custom normalizers or processors in the module
+- [ ] No Value Objects in properties
+
+**Exception handling & validation**
+- [ ] `ConstraintException` → 422, `NotFoundException` → 404
+- [ ] Correct `validationContext` groups on Create / Update operations
+
+**Multi-shop**
+- [ ] `shopIds` present and mapped if entity is shop-associated, absent otherwise
+- [ ] Shop context (`[_context][shopId]`, `[_context][shopConstraint]`) passed when needed
+
+**Integration test**
+- [ ] Extends `ApiTestCase`, `@depends` chain, asserts all fields
+- [ ] `testInvalid*` with `assertValidationErrors`
+- [ ] `getProtectedEndpoints()` lists all URIs
+- [ ] `DatabaseDump::restoreTables()` covers all affected tables
+- [ ] `declare(strict_types=1)` present
+```

--- a/.claude/REVIEW_PROMPT.md
+++ b/.claude/REVIEW_PROMPT.md
@@ -40,6 +40,22 @@ These are frequent mistakes that are easy to miss — flag them explicitly:
 - Custom normalizer or processor added in the module (always flag as a **hard blocker**)
 - Test asserting only the identifier without checking the rest of the response fields
 
+### Listing endpoints (`PaginatedList` / `CQRSPaginate`)
+
+When the PR adds or modifies a list endpoint, cross-check the DTO against
+the data source (see "Field alignment" in `CONTEXT.md`):
+
+- Trace the `gridDataFactory` to its query builder; compare SQL SELECT
+  fields with DTO properties. Flag missing DTO properties (data the grid
+  returns but the API silently drops) and orphan DTO properties (no
+  matching query field → always `null`).
+- When a SQL column name differs from the DTO property, verify an
+  `ApiResourceMapping` entry covers the rename.
+- Check `filtersMapping` covers every filterable field whose API name
+  differs from the grid filter name.
+- For `CQRSPaginate`: same checks, but against the CQRS query result DTO
+  instead of the query builder.
+
 ## Output format
 
 Post a **single comment** using `gh pr comment $PR_NUMBER --repo $REPO` with the following
@@ -116,6 +132,12 @@ Base every check on the rules from `CONTEXT.md`.
 **Multi-shop**
 - [ ] `shopIds` present and mapped if entity is shop-associated, absent otherwise
 - [ ] Shop context (`[_context][shopId]`, `[_context][shopConstraint]`) passed when needed
+
+**Listing field alignment** (when PR includes a list endpoint)
+- [ ] DTO properties match fields from the grid query builder / CQRS query result
+- [ ] `ApiResourceMapping` covers every name mismatch between source fields and DTO
+- [ ] `filtersMapping` covers every filter name that differs from the API field name
+- [ ] No orphan DTO property (property with no matching source field → always `null`)
 
 **Integration test**
 - [ ] Extends `ApiTestCase`, `@depends` chain, asserts all fields

--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -1,0 +1,96 @@
+name: Claude Pre-Review
+
+on:
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: ai-prereview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  check-diff:
+    if: github.event.label.name == 'Need AI review'
+    runs-on: ubuntu-latest
+    outputs:
+      has-code-changes: ${{ steps.check.outputs.has-code-changes }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Check for code changes
+        id: check
+        run: |
+          CODE=$(gh pr diff ${{ github.event.pull_request.number }} --repo "${{ github.repository }}" --name-only | \
+            grep -vE '\.(lock|md)$|^vendor/' | wc -l | tr -d ' ')
+          if [ "$CODE" = "0" ]; then
+            echo "has-code-changes=false" >> "$GITHUB_OUTPUT"
+            echo "💤 No PHP/YAML changes — skipping Claude." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "has-code-changes=true" >> "$GITHUB_OUTPUT"
+            echo "📝 $CODE file(s) with code changes detected." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  check-guard:
+    needs: check-diff
+    if: needs.check-diff.outputs.has-code-changes == 'true'
+    # TODO: uses: PrestaShop/.github/.github/workflows/ai-prereview-guard.yml@main
+    uses: jolelievre/.github/.github/workflows/ai-prereview-guard.yml@ai-prereview-guard
+    with:
+      team-slug: prestashop-sa
+      actor: ${{ github.event.sender.login }}
+      pr-number: ${{ github.event.pull_request.number }}
+      repository: ${{ github.repository }}
+    secrets:
+      org-read-token: ${{ secrets.JARVIS_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  ai-prereview:
+    needs: check-guard
+    if: needs.check-guard.outputs.can-run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Load review prompt
+        id: prompt
+        env:
+          REPO: ${{ github.repository }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          PROMPT=$(envsubst '${PR_NUMBER} ${REPO} ${PR_TITLE} ${PR_AUTHOR}' < .claude/REVIEW_PROMPT.md)
+          {
+            echo "content<<PROMPT_EOF"
+            echo "$PROMPT"
+            echo "PROMPT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude pre-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: claude-sonnet-4-6
+          max_turns: "5"
+          allowed_tools: "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),WebFetch,Read"
+          prompt: ${{ steps.prompt.outputs.content }}
+
+      - name: Add AI reviewed label
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --add-label "AI reviewed"
+          echo "✅ Label 'AI reviewed' added." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summary
+        run: |
+          echo "## Pre-review summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **PR:** #$PR_NUMBER" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Actor:** ${{ github.event.sender.login }}" >> "$GITHUB_STEP_SUMMARY"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -136,6 +136,24 @@ the current usage pattern.
 - To find the correct `gridDataFactory` service name: look at the
   entity's Symfony controller → Grid factory definition → Grid data
   factory service.
+- **Field alignment for `PaginatedList` endpoints** — the DTO properties
+  must mirror the fields selected by the grid's underlying query builder.
+  To verify alignment:
+  1. Trace the `gridDataFactory` service to its query builder class in
+     PrestaShop Core (the class implementing `DoctrineQueryBuilderInterface`
+     or similar).
+  2. Read the SQL `SELECT` clause — each selected column is a field the
+     grid can return.
+  3. Every selected field should have a corresponding DTO property. If a
+     field is intentionally omitted, it should be a conscious decision
+     (not an oversight).
+  4. When the SQL column name differs from the DTO property name (e.g.
+     `id_contact` vs `contactId`, `firstname` vs `firstName`), an
+     `ApiResourceMapping` entry must cover the rename.
+  5. A DTO property with no matching query field will always be `null` at
+     runtime — this is almost certainly a bug.
+  The same principle applies to `CQRSPaginate`: compare the CQRS query's
+  result DTO fields against the ApiResource properties.
 - Do NOT use `SerializedName` — always use `CQRSQueryMapping`,
   `CQRSCommandMapping`, or `ApiResourceMapping`.
 - Nested fields use bracket notation:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,7 +66,8 @@ src/ApiPlatform/Resources/Attribute/
   `/products/{productId}/combinations`,
   `/categories/{categoryId}/cover`.
 - **Bulk operations** use the `bulk-` prefix: `/contacts/bulk-delete`,
-  `/attributes/groups/bulk-delete`.
+  `/attributes/groups/bulk-delete`. The bulk parameter name must be
+  plural domain + `Ids` (e.g. `attributeGroupIds`).
 - **URI parameters** use the domain identifier name, not `id`:
   `{contactId}`, `{attributeGroupId}`, `{taxRuleId}`.
 - The DTO property exposed as the identifier must match the URI
@@ -86,24 +87,41 @@ OAuth2 scope naming: `{entity_snake_case}_{action}`.
 
 | Rule                                          | Correct                  | Wrong                          |
 |-----------------------------------------------|--------------------------|--------------------------------|
-| Identifier — domain name + `Id`               | `$contactId`             | `$id`                          |
+| Identifier — domain name + `Id`, with `#[ApiProperty(identifier: true)]` | `$contactId` | `$id` |
 | Boolean — no `is` prefix                      | `$enabled`, `$ready`     | `$isEnabled`, `$isReady`       |
 | Status uses `enabled`, not `active` / `status`| `$enabled`               | `$active`, `$status`           |
 | Localized fields — no `localized` prefix      | `$names`                 | `$localizedNames`              |
 | All public properties strictly typed          | `public int $contactId`  | `public $contactId`            |
 | Decimals — use `DecimalNumber`, never `float` | `public DecimalNumber $price` | `public float $price`     |
 
-Localized properties must be marked with `#[LocalizedValue]`. To require
-the default language on create / update, add `#[DefaultLanguage]` with
-the appropriate validation `groups`. See
-`src/ApiPlatform/Resources/Contact/Contact.php` for the current usage
-pattern.
+Array fields representing complex structures must include
+`#[ApiProperty(openapiContext: ['type' => 'array', 'items' => [...]])]`
+for OpenAPI schema documentation.
+
+Localized properties must be marked with `#[LocalizedValue]` — this
+triggers automatic locale↔languageId conversion on both read and write.
+Single-entity endpoints return localized fields as locale-indexed arrays
+(e.g. `{"names": {"en-US": "Size", "fr-FR": "Taille"}}`); list endpoints
+return a single language string (default shop language, or via `langId`
+query param). Never return language IDs as keys — always locale strings
+like `en-US`.
+
+To require the default language on create / update, add
+`#[DefaultLanguage]` with the appropriate validation `groups`. Set the
+`fieldName` argument to the **API field name** so the validation error
+message includes a meaningful field reference (the auto-detection
+fallback only works in Form contexts, not on ApiResource attributes).
+Use `allowNull: true` on the Update group so the field is optional on
+partial update. See `src/ApiPlatform/Resources/Contact/Contact.php` for
+the current usage pattern.
 
 ## Field mapping
 
 - `CQRSQueryMapping` (often defined as a `QUERY_MAPPING` constant) maps
-  **query result field → API field**. Read the `Get{Entity}ForEditing`
-  query result class in PrestaShop Core to find source field names.
+  **query result field → API field**. A common mistake is inverting the
+  direction (using API field name as key instead of QueryResult field
+  name). Read the `Get{Entity}ForEditing` query result class in
+  PrestaShop Core to find source field names.
 - `CQRSCommandMapping` (often `CREATE_COMMAND_MAPPING` /
   `UPDATE_COMMAND_MAPPING`, or a shared `COMMAND_MAPPING` when both
   commands accept the same parameters) maps **API field → command
@@ -113,9 +131,72 @@ pattern.
   query result fields) to API fields. For `PaginatedList`, the source
   field names can often be read directly from the related query builder
   service wired via `gridDataFactory` — you only need to map the fields
-  whose names don't already match the DTO.
+  whose names don't already match the DTO. `filtersMapping` must be
+  provided when filter parameter names differ from API field names.
+- To find the correct `gridDataFactory` service name: look at the
+  entity's Symfony controller → Grid factory definition → Grid data
+  factory service.
+- Do NOT use `SerializedName` — always use `CQRSQueryMapping`,
+  `CQRSCommandMapping`, or `ApiResourceMapping`.
 - Nested fields use bracket notation:
   `'[basicInformation][localizedNames]' => '[names]'`.
+
+## Multi-shop
+
+When PrestaShop's multistore feature is **disabled**, the API
+automatically uses the default shop — no extra parameters are needed.
+
+When multistore is **enabled**, every API request **must** include a shop
+context parameter (otherwise the API returns 400). The
+`ShopContextListener` in the Core reads these parameters from the
+request and builds a `ShopConstraint` that CQRS commands/queries use:
+
+| Request parameter | Context built | Use case |
+|---|---|---|
+| `shopId` | `ShopConstraint::shop($id)` | Target a single specific shop |
+| `shopGroupId` | `ShopConstraint::shopGroup($id)` | Target all shops in a group |
+| `shopIds` (comma-separated or array) | `ShopCollection::shops([...])` | Target a specific set of shops |
+| `allShops` (presence is enough, value ignored) | `ShopConstraint::allShops()` | Target all shops |
+
+These are **request-level context parameters** (query string or request
+body) that determine *which shop(s) the operation runs against*. They
+are distinct from the `shopIds` DTO property described below.
+
+### Shop association property
+
+Entities that have a shop association (e.g. contacts, attributes,
+categories) expose a `public array $shopIds` property on the DTO. This
+represents the list of shops the entity is associated with, and must be
+mapped in both directions:
+
+- **Query mapping** (read): map the Core field (often `associatedShops`,
+  `associatedShopIds`, or `shopAssociation`) → API field `shopIds`.
+- **Command mapping** (write): map API field `shopIds` → Core parameter
+  (often `shopAssociation` or `associatedShopIds`).
+
+If the entity has no shop association, the `shopIds` property must be
+absent from the DTO.
+
+### Passing shop context to CQRS commands/queries
+
+Some commands/queries need the current shop context (e.g. to filter
+results by shop). This is done via the special `[_context]` prefix in
+mappings, which injects the request's shop context parameters:
+
+```php
+// In a CQRSCommandMapping or CQRSQueryMapping:
+'[_context][shopId]' => '[shopId]',              // single shop ID (int)
+'[_context][shopIds]' => '[shopIds]',            // multiple shop IDs (array)
+'[_context][shopConstraint]' => '[shopConstraint]', // full ShopConstraint object
+```
+
+Use `[_context][shopConstraint]` when the CQRS command/query accepts a
+`ShopConstraint` value object directly (common for Product-related
+commands). Use `[_context][shopId]` or `[_context][shopIds]` when the
+command expects plain integer IDs.
+
+See `Product.php`, `Combination.php`, `CombinationList.php`, and
+`CustomerGroup.php` for examples of these patterns.
 
 ## Do / Don't
 
@@ -123,13 +204,22 @@ pattern.
 
 - Define `exceptionToStatus` for every domain exception the operations
   can throw — at minimum the entity's `…ConstraintException` →
-  `HTTP_UNPROCESSABLE_ENTITY` and `…NotFoundException` → `HTTP_NOT_FOUND`.
+  `HTTP_UNPROCESSABLE_ENTITY` (422) and `…NotFoundException` →
+  `HTTP_NOT_FOUND` (404). Do not add other exceptions unless clearly
+  justified. Never use `HTTP_BAD_REQUEST` (400) for constraint
+  violations — always 422.
 - Use a `CQRSQuery` on `CQRSCreate` and `CQRSPartialUpdate` when the
   endpoint should return the full updated state, not just an identifier.
 - Use `#[LocalizedValue]` for any field stored as `array<locale, value>`.
 - Split single / list / bulk operations into separate classes inside the
   same domain folder.
 - Add an integration test for every new endpoint (see Testing below).
+- Use `validationContext: ['groups' => ['Default', 'Create']]` on
+  `CQRSCreate` and `validationContext: ['groups' => ['Default', 'Update']]`
+  on `CQRSPartialUpdate`. `#[Assert\NotBlank]` must be present on
+  required fields for the Create group. Constraints should match the
+  associated Symfony form type (check the entity's FormType for
+  reference).
 
 ### Don't
 
@@ -215,8 +305,11 @@ Static helpers available for additional setup (call from
   (expecting `HTTP_UNPROCESSABLE_ENTITY`) and use
   `$this->assertValidationErrors([...], $response)` to check the error
   shape.
+- Include `LanguageResetter` only if the entity has localized fields.
+- `declare(strict_types=1)` must be present in the test file.
 - Restore relevant DB tables via `DatabaseDump::restoreTables([...])`
-  in `setUpBeforeClass` / `tearDownAfterClass`.
+  in `setUpBeforeClass` / `tearDownAfterClass` (include `_lang` table
+  if localized, `_shop` table if shop-associated).
 
 Run the suite with:
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | Add a GitHub Actions workflow that triggers a Claude AI pre-review when the `Need AI review` label is added to a PR. The review prompt is stored in a dedicated file for easy maintenance and references CONTEXT.md as the source of truth. CONTEXT.md is enriched with 24 previously undocumented rules.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Ensure the companion PR on `PrestaShop/.github` is merged first (guard workflow) 2. Configure `JARVIS_TOKEN` and `ANTHROPIC_API_KEY` org secrets with access to this repo 3. Create the `Need AI review` and `AI reviewed` labels in this repo (or run the label sync workflow) 4. Open a test PR with PHP changes, add `Need AI review` as a PrestaShop SA team member 5. Verify Claude posts a structured pre-review comment within a few minutes 6. Verify the `AI reviewed` label is added automatically after the review 7. Re-add `Need AI review` — verify the workflow skips since `AI reviewed` is present
| UI Tests          |
| Fixed issue or discussion? | Fixes PrestaShop/PrestaShop#41245
| Related PRs       | Companion PR on .github: PrestaShop/.github#42
| Sponsor company   | PrestaShop SA

## Details

### Workflow (`ai-prereview.yml`)

Three-job pipeline:
1. **`check-diff`** — skips entirely if the PR only touches `*.lock`, `*.md`, or `vendor/` files
2. **`check-guard`** — calls the reusable guard from `PrestaShop/.github` (team membership + duplicate review label check)
3. **`ai-prereview`** — loads the prompt from `.claude/REVIEW_PROMPT.md`, injects PR metadata via `envsubst`, runs Claude via `anthropics/claude-code-action@v1`, then adds the `AI reviewed` label

> **Note:** The workflow currently points to `jolelievre/.github@ai-prereview-guard` for testing. A TODO comment marks the line to update to `PrestaShop/.github@main` after the companion PR is merged.

### Review prompt (`.claude/REVIEW_PROMPT.md`)

Stored separately from the workflow for easier maintenance. References `CONTEXT.md` as the source of truth for all conventions, and adds:
- Common pitfalls to watch for (inverted mappings, wrong HTTP status codes, naming mistakes)
- Structured output format with summary, compliance check, suggestions, and checklist

### CONTEXT.md enrichments

Added 24 rules that were previously undocumented:
- Validation groups (`Create`/`Update`), `#[Assert\NotBlank]`, FormType matching
- Multilang response format (locale-indexed arrays vs single string for lists)
- `#[ApiProperty(identifier: true)]`, `#[DefaultLanguage]` fieldName, OpenAPI annotations
- `SerializedName` prohibition, `filtersMapping`, `gridDataFactory` lookup process
- **New dedicated Multi-shop section**: `ShopContextListener` parameters (`shopId`, `shopGroupId`, `shopIds`, `allShops`), shop association property mapping, `[_context][shopConstraint]` pattern
- Testing: `LanguageResetter`, `declare(strict_types=1)`, `_lang`/`_shop` tables