### PR TITLE
Add cms page category

### DIFF
--- a/src/ApiPlatform/Resources/CmsPageCategory/BulkDeleteCmsPageCategories.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/BulkDeleteCmsPageCategories.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\BulkDeleteCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/cms-page-categories/bulk-delete',
+            CQRSCommand: BulkDeleteCmsPageCategoryCommand::class,
+            scopes: ['cms_page_category_write'],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageCategoryNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteCmsPageCategories
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $cmsPageCategoryIds;
+}

--- a/src/ApiPlatform/Resources/CmsPageCategory/BulkUpdateStatusCmsPageCategories.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/BulkUpdateStatusCmsPageCategories.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\BulkDisableCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\BulkEnableCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/cms-page-categories/bulk-enable',
+            output: false,
+            CQRSCommand: BulkEnableCmsPageCategoryCommand::class,
+            scopes: ['cms_page_category_write'],
+            allowEmptyBody: false,
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/cms-page-categories/bulk-disable',
+            output: false,
+            CQRSCommand: BulkDisableCmsPageCategoryCommand::class,
+            scopes: ['cms_page_category_write'],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageCategoryNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkUpdateStatusCmsPageCategories
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $cmsPageCategoryIds;
+}

--- a/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategory.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategory.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\TypedRegex;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\AddCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\DeleteCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\EditCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\ToggleCmsPageCategoryStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageCategoryForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}',
+            requirements: ['cmsPageCategoryId' => '\d+'],
+            CQRSQuery: GetCmsPageCategoryForEditing::class,
+            scopes: ['cms_page_category_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/cms-page-categories',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddCmsPageCategoryCommand::class,
+            CQRSQuery: GetCmsPageCategoryForEditing::class,
+            scopes: ['cms_page_category_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}',
+            requirements: ['cmsPageCategoryId' => '\d+'],
+            validationContext: ['groups' => ['Default', 'Update']],
+            CQRSCommand: EditCmsPageCategoryCommand::class,
+            CQRSQuery: GetCmsPageCategoryForEditing::class,
+            scopes: ['cms_page_category_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}/toggle-status',
+            requirements: ['cmsPageCategoryId' => '\d+'],
+            CQRSCommand: ToggleCmsPageCategoryStatusCommand::class,
+            CQRSQuery: GetCmsPageCategoryForEditing::class,
+            scopes: ['cms_page_category_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            allowEmptyBody: true,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}',
+            requirements: ['cmsPageCategoryId' => '\d+'],
+            CQRSCommand: DeleteCmsPageCategoryCommand::class,
+            scopes: ['cms_page_category_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageCategoryConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CmsPageCategoryNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CmsPageCategory
+{
+    #[ApiProperty(identifier: true)]
+    public int $cmsPageCategoryId;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'names')]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'names', allowNull: true)]
+    #[Assert\All(constraints: [
+        new TypedRegex(['type' => TypedRegex::TYPE_GENERIC_NAME]),
+    ])]
+    public array $names;
+
+    public bool $enabled;
+
+    public int $parentId;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'friendlyUrls')]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'friendlyUrls', allowNull: true)]
+    #[Assert\All(constraints: [
+        new TypedRegex(['type' => TypedRegex::TYPE_LINK_REWRITE]),
+    ])]
+    public array $friendlyUrls;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'descriptions', allowNull: true)]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'descriptions', allowNull: true)]
+    #[Assert\All(constraints: [
+        new TypedRegex(['type' => TypedRegex::TYPE_GENERIC_NAME]),
+    ])]
+    public ?array $descriptions = null;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'metaTitles', allowNull: true)]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'metaTitles', allowNull: true)]
+    #[Assert\All(constraints: [
+        new TypedRegex(['type' => TypedRegex::TYPE_GENERIC_NAME]),
+    ])]
+    public ?array $metaTitles = null;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'metaDescriptions', allowNull: true)]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'metaDescriptions', allowNull: true)]
+    #[Assert\All(constraints: [
+        new TypedRegex(['type' => TypedRegex::TYPE_GENERIC_NAME]),
+    ])]
+    public ?array $metaDescriptions = null;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank(allowNull: true)]
+    public ?array $shopIds = null;
+
+    public const QUERY_MAPPING = [
+        '[localisedName]' => '[names]',
+        '[displayed]' => '[enabled]',
+        '[parentId][cmsPageCategoryId]' => '[parentId]',
+        '[localisedDescription]' => '[descriptions]',
+        '[metaTitle]' => '[metaTitles]',
+        '[localisedMetaDescription]' => '[metaDescriptions]',
+        '[localisedFriendlyUrl]' => '[friendlyUrls]',
+    ];
+
+    public const COMMAND_MAPPING = [
+        '[names]' => '[localisedName]',
+        '[friendlyUrls]' => '[localisedFriendlyUrl]',
+        '[enabled]' => '[isDisplayed]',
+        '[descriptions]' => '[localisedDescription]',
+        '[metaTitles]' => '[localisedMetaTitle]',
+        '[metaDescriptions]' => '[localisedMetaDescription]',
+        '[shopIds]' => '[shopAssociation]',
+    ];
+}

--- a/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryList.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryList.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryNotFoundException;
+use PrestaShop\PrestaShop\Core\Search\Filters\CmsPageCategoryFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+use PrestaShopBundle\ApiPlatform\Provider\QueryListProvider;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/cms-page-categories',
+            provider: QueryListProvider::class,
+            scopes: ['cms_page_category_read'],
+            ApiResourceMapping: [
+                '[id_cms_category]' => '[cmsPageCategoryId]',
+                '[id_parent]' => '[parentId]',
+                '[active]' => '[enabled]',
+            ],
+            gridDataFactory: 'prestashop.core.grid.data_provider.cms_page_category',
+            filtersClass: CmsPageCategoryFilters::class,
+            filtersMapping: [
+                '[cmsPageCategoryId]' => '[id_cms_category]',
+                '[enabled]' => '[active]',
+                '[parentId]' => '[id_cms_category_parent]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageCategoryNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CmsPageCategoryList
+{
+    #[ApiProperty(identifier: true)]
+    public int $cmsPageCategoryId;
+
+    public bool $enabled;
+
+    public int $parentId;
+
+    public string $name;
+
+    public string $description;
+
+    public int $position;
+}

--- a/tests/Integration/ApiPlatform/CmsPageCategoryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CmsPageCategoryEndpointTest.php
@@ -1,0 +1,411 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+use Tests\Resources\Resetter\LanguageResetter;
+
+class CmsPageCategoryEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        LanguageResetter::resetLanguages();
+        self::addLanguageByLocale('fr-FR');
+        self::resetTables();
+        self::createApiClient(['cms_page_category_read', 'cms_page_category_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        LanguageResetter::resetLanguages();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'cms_category',
+            'cms_category_lang',
+            'cms_category_shop',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get endpoint' => [
+            'GET',
+            '/cms-page-categories/1',
+        ];
+
+        yield 'create endpoint' => [
+            'POST',
+            '/cms-page-categories',
+        ];
+
+        yield 'patch endpoint' => [
+            'PATCH',
+            '/cms-page-categories/1',
+        ];
+
+        yield 'toggle-status endpoint' => [
+            'PUT',
+            '/cms-page-categories/1/toggle-status',
+        ];
+
+        yield 'delete endpoint' => [
+            'DELETE',
+            '/cms-page-categories/1',
+        ];
+
+        yield 'list endpoint' => [
+            'GET',
+            '/cms-page-categories',
+        ];
+
+        yield 'bulk delete endpoint' => [
+            'DELETE',
+            '/cms-page-categories/bulk-delete',
+        ];
+
+        yield 'bulk enable endpoint' => [
+            'PUT',
+            '/cms-page-categories/bulk-enable',
+        ];
+
+        yield 'bulk disable endpoint' => [
+            'PUT',
+            '/cms-page-categories/bulk-disable',
+        ];
+    }
+
+    public function testAddCmsPageCategory(): int
+    {
+        $itemsCount = $this->countItems('/cms-page-categories', ['cms_page_category_read']);
+
+        $postData = [
+            'names' => [
+                'en-US' => 'Test Category EN',
+                'fr-FR' => 'Catégorie test FR',
+            ],
+            'friendlyUrls' => [
+                'en-US' => 'test-category-en',
+                'fr-FR' => 'categorie-test-fr',
+            ],
+            'enabled' => true,
+            'parentId' => 1,
+            'descriptions' => [
+                'en-US' => 'Description EN',
+                'fr-FR' => 'Description FR',
+            ],
+            'metaTitles' => [
+                'en-US' => 'Meta Title EN',
+                'fr-FR' => 'Meta Title FR',
+            ],
+            'metaDescriptions' => [
+                'en-US' => 'Meta Description EN',
+                'fr-FR' => 'Meta Description FR',
+            ],
+            'shopIds' => [1],
+        ];
+
+        $category = $this->createItem('/cms-page-categories', $postData, ['cms_page_category_write']);
+        $this->assertArrayHasKey('cmsPageCategoryId', $category);
+        $cmsPageCategoryId = $category['cmsPageCategoryId'];
+
+        $this->assertEquals(
+            ['cmsPageCategoryId' => $cmsPageCategoryId] + $postData,
+            $category
+        );
+
+        $newItemsCount = $this->countItems('/cms-page-categories', ['cms_page_category_read']);
+        $this->assertEquals($itemsCount + 1, $newItemsCount);
+
+        return $cmsPageCategoryId;
+    }
+
+    /**
+     * @depends testAddCmsPageCategory
+     */
+    public function testGetCmsPageCategory(int $cmsPageCategoryId): int
+    {
+        $category = $this->getItem('/cms-page-categories/' . $cmsPageCategoryId, ['cms_page_category_read']);
+
+        $this->assertEquals([
+            'cmsPageCategoryId' => $cmsPageCategoryId,
+            'names' => [
+                'en-US' => 'Test Category EN',
+                'fr-FR' => 'Catégorie test FR',
+            ],
+            'friendlyUrls' => [
+                'en-US' => 'test-category-en',
+                'fr-FR' => 'categorie-test-fr',
+            ],
+            'enabled' => true,
+            'parentId' => 1,
+            'descriptions' => [
+                'en-US' => 'Description EN',
+                'fr-FR' => 'Description FR',
+            ],
+            'metaTitles' => [
+                'en-US' => 'Meta Title EN',
+                'fr-FR' => 'Meta Title FR',
+            ],
+            'metaDescriptions' => [
+                'en-US' => 'Meta Description EN',
+                'fr-FR' => 'Meta Description FR',
+            ],
+            'shopIds' => [1],
+        ], $category);
+
+        return $cmsPageCategoryId;
+    }
+
+    /**
+     * @depends testGetCmsPageCategory
+     */
+    public function testPartialUpdateCmsPageCategory(int $cmsPageCategoryId): int
+    {
+        $patchData = [
+            'names' => [
+                'en-US' => 'Updated Category EN',
+                'fr-FR' => 'Catégorie mise à jour FR',
+            ],
+            'friendlyUrls' => [
+                'en-US' => 'updated-category-en',
+                'fr-FR' => 'categorie-mise-a-jour-fr',
+            ],
+            'enabled' => false,
+            'parentId' => 1,
+            'descriptions' => [
+                'en-US' => 'Updated Description EN',
+                'fr-FR' => 'Description mise à jour FR',
+            ],
+            'metaTitles' => [
+                'en-US' => 'Updated Meta Title EN',
+                'fr-FR' => 'Meta Title mis à jour FR',
+            ],
+            'metaDescriptions' => [
+                'en-US' => 'Updated Meta Description EN',
+                'fr-FR' => 'Meta Description mise à jour FR',
+            ],
+            'shopIds' => [1],
+        ];
+
+        $updated = $this->partialUpdateItem(
+            '/cms-page-categories/' . $cmsPageCategoryId,
+            $patchData,
+            ['cms_page_category_write']
+        );
+        $this->assertEquals(['cmsPageCategoryId' => $cmsPageCategoryId] + $patchData, $updated);
+
+        // Verify GET reflects the update
+        $fetched = $this->getItem('/cms-page-categories/' . $cmsPageCategoryId, ['cms_page_category_read']);
+        $this->assertEquals(['cmsPageCategoryId' => $cmsPageCategoryId] + $patchData, $fetched);
+
+        return $cmsPageCategoryId;
+    }
+
+    /**
+     * @depends testPartialUpdateCmsPageCategory
+     */
+    public function testToggleCmsPageCategoryStatus(int $cmsPageCategoryId): int
+    {
+        // Category is currently disabled (from previous test), toggle should enable it
+        $toggled = $this->updateItem(
+            '/cms-page-categories/' . $cmsPageCategoryId . '/toggle-status',
+            [],
+            ['cms_page_category_write']
+        );
+        $this->assertTrue($toggled['enabled']);
+
+        // Toggle again — should disable
+        $toggled = $this->updateItem(
+            '/cms-page-categories/' . $cmsPageCategoryId . '/toggle-status',
+            [],
+            ['cms_page_category_write']
+        );
+        $this->assertFalse($toggled['enabled']);
+
+        return $cmsPageCategoryId;
+    }
+
+    /**
+     * @depends testToggleCmsPageCategoryStatus
+     */
+    public function testListCmsPageCategories(int $cmsPageCategoryId): int
+    {
+        $paginated = $this->listItems(
+            '/cms-page-categories?orderBy=cmsPageCategoryId&sortOrder=desc',
+            ['cms_page_category_read']
+        );
+        $this->assertGreaterThanOrEqual(1, $paginated['totalItems']);
+
+        // The test category should be first (highest ID)
+        $first = $paginated['items'][0];
+        $this->assertEquals($cmsPageCategoryId, $first['cmsPageCategoryId']);
+        $this->assertArrayHasKey('name', $first);
+        $this->assertArrayHasKey('enabled', $first);
+        $this->assertArrayHasKey('parentId', $first);
+        $this->assertArrayHasKey('position', $first);
+
+        // Filter by ID
+        $filtered = $this->listItems('/cms-page-categories', ['cms_page_category_read'], [
+            'cmsPageCategoryId' => $cmsPageCategoryId,
+        ]);
+        $this->assertEquals(1, $filtered['totalItems']);
+        $this->assertEquals($cmsPageCategoryId, $filtered['items'][0]['cmsPageCategoryId']);
+
+        return $cmsPageCategoryId;
+    }
+
+    /**
+     * @depends testListCmsPageCategories
+     */
+    public function testDeleteCmsPageCategory(int $cmsPageCategoryId): void
+    {
+        $this->deleteItem('/cms-page-categories/' . $cmsPageCategoryId, ['cms_page_category_write']);
+
+        $this->getItem(
+            '/cms-page-categories/' . $cmsPageCategoryId,
+            ['cms_page_category_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+
+    public function testBulkEnableDisableCmsPageCategories(): void
+    {
+        [$id1, $id2] = $this->createTwoCategories();
+
+        // Bulk disable
+        $this->updateItem(
+            '/cms-page-categories/bulk-disable',
+            ['cmsPageCategoryIds' => [$id1, $id2]],
+            ['cms_page_category_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        foreach ([$id1, $id2] as $id) {
+            $category = $this->getItem('/cms-page-categories/' . $id, ['cms_page_category_read']);
+            $this->assertFalse($category['enabled']);
+        }
+
+        // Bulk enable
+        $this->updateItem(
+            '/cms-page-categories/bulk-enable',
+            ['cmsPageCategoryIds' => [$id1, $id2]],
+            ['cms_page_category_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        foreach ([$id1, $id2] as $id) {
+            $category = $this->getItem('/cms-page-categories/' . $id, ['cms_page_category_read']);
+            $this->assertTrue($category['enabled']);
+        }
+    }
+
+    public function testBulkDeleteCmsPageCategories(): void
+    {
+        [$id1, $id2] = $this->createTwoCategories();
+
+        $this->bulkDeleteItems(
+            '/cms-page-categories/bulk-delete',
+            ['cmsPageCategoryIds' => [$id1, $id2]],
+            ['cms_page_category_write']
+        );
+
+        foreach ([$id1, $id2] as $id) {
+            $this->getItem('/cms-page-categories/' . $id, ['cms_page_category_read'], Response::HTTP_NOT_FOUND);
+        }
+    }
+
+    public function testInvalidCmsPageCategory(): void
+    {
+        // Missing required names (default language) and friendlyUrls
+        $invalidData = [
+            'names' => [
+                'fr-FR' => 'Name with invalid char <',
+            ],
+            'friendlyUrls' => [
+                'fr-FR' => 'invalid url with spaces',
+            ],
+            'enabled' => true,
+            'parentId' => 1,
+        ];
+
+        $response = $this->createItem(
+            '/cms-page-categories',
+            $invalidData,
+            ['cms_page_category_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'names',
+                'message' => 'The field names is required at least in your default language.',
+            ],
+            [
+                'propertyPath' => 'names[fr-FR]',
+                'message' => '"Name with invalid char <" is invalid',
+            ],
+            [
+                'propertyPath' => 'friendlyUrls',
+                'message' => 'The field friendlyUrls is required at least in your default language.',
+            ],
+            [
+                'propertyPath' => 'friendlyUrls[fr-FR]',
+                'message' => '"invalid url with spaces" is invalid',
+            ],
+        ], $response);
+    }
+
+    /**
+     * @return int[] Two newly created category IDs
+     */
+    private function createTwoCategories(): array
+    {
+        $base = [
+            'enabled' => true,
+            'parentId' => 1,
+            'shopIds' => [1],
+            'descriptions' => [],
+            'metaTitles' => [],
+            'metaDescriptions' => [],
+        ];
+
+        $cat1 = $this->createItem('/cms-page-categories', $base + [
+            'names' => ['en-US' => 'Bulk Test Cat 1'],
+            'friendlyUrls' => ['en-US' => 'bulk-test-cat-1'],
+        ], ['cms_page_category_write']);
+
+        $cat2 = $this->createItem('/cms-page-categories', $base + [
+            'names' => ['en-US' => 'Bulk Test Cat 2'],
+            'friendlyUrls' => ['en-US' => 'bulk-test-cat-2'],
+        ], ['cms_page_category_write']);
+
+        return [$cat1['cmsPageCategoryId'], $cat2['cmsPageCategoryId']];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | New endpoint CmsPageCategory, with unit testing. Please note that some endpoints need https://github.com/PrestaShop/PrestaShop/pull/41273 on PrestaShop Core to work without 500 error
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Sponsor company   | Your company or customer's name goes here (if applicable).
| How to test?      | See below

All endpoints have been manually tested. A small fix in the core is needed for it to work correctly:

https://github.com/PrestaShop/PrestaShop/pull/41273

| Endpoint | How to test |
|---|---|
| `GET /cms-page-categories/{id}` | `curl -X GET /admin-api/cms-page-categories/2`, returns full details (names, descriptions, etc.) of a category. Returns 404 if the ID does not exist. |
| `POST /cms-page-categories` | JSON body with `names`, `friendlyUrls`, `enabled`, `parentId`, `shopIds` (required). `descriptions`, `metaTitles`, `metaDescriptions` are optional. Returns the created category with its `cmsPageCategoryId`. |
| `PATCH /cms-page-categories/{id}` | JSON body with only the fields to update (partial update). Returns the updated category. |
| `PUT /cms-page-categories/{id}/toggle-status` | Empty body `{}`. Toggles the `enabled` status of the category. Returns the category with the new status. |
| `DELETE /cms-page-categories/{id}` | Deletes the category. Returns HTTP 204 (empty body). Returns 404 if the ID does not exist. |
| `GET /cms-page-categories` | Paginated list. Optional query params: `orderBy`, `sortOrder`, `limit`, `page`. Filters: `cmsPageCategoryId`, `enabled`, `parentId`. |
| `DELETE /cms-page-categories/bulk-delete` | JSON body `{"cmsPageCategoryIds": [2, 3]}`. Deletes multiple categories in one request. Returns HTTP 204. |
| `PUT /cms-page-categories/bulk-enable` | JSON body `{"cmsPageCategoryIds": [2, 3]}`. Enables multiple categories. Returns HTTP 204. |
| `PUT /cms-page-categories/bulk-disable` | JSON body `{"cmsPageCategoryIds": [2, 3]}`. Disables multiple categories. Returns HTTP 204. |

## Required scopes

| Scope | Endpoints |
|---|---|
| `cms_page_category_read` | GET (single), GET (list) |
| `cms_page_category_write` | POST, PATCH, PUT toggle-status, DELETE, bulk-delete, bulk-enable, bulk-disable |

## Running integration tests

```bash
php bin/console cache:clear --env=test

php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit \
  -c modules/ps_apiresources/tests/Integration/phpunit-ci.xml \
  --filter=CmsPageCategoryEndpointTest
```


