### PR TITLE
Add explicit guard failure and use official guard workflow

### DIFF
--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -33,7 +33,7 @@ jobs:
   check-guard:
     needs: check-diff
     if: needs.check-diff.outputs.has-code-changes == 'true'
-    uses: PrestaShop/.github/.github/workflows/ai-prereview-guard.yml@master
+    uses: jolelievre/.github/.github/workflows/ai-prereview-guard.yml@debug-guard-workflow
     with:
       team-slug: prestashop-sa
       actor: ${{ github.event.sender.login }}

--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -33,7 +33,8 @@ jobs:
   check-guard:
     needs: check-diff
     if: needs.check-diff.outputs.has-code-changes == 'true'
-    uses: jolelievre/.github/.github/workflows/ai-prereview-guard.yml@debug-guard-workflow
+    # Reusable guard: checks team membership + duplicate review label
+    uses: PrestaShop/.github/.github/workflows/ai-prereview-guard.yml@master
     with:
       team-slug: prestashop-sa
       actor: ${{ github.event.sender.login }}

--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -47,11 +47,15 @@ jobs:
     needs: check-guard
     if: needs.check-guard.outputs.can-run != 'true'
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Guard blocked
+      - name: Remove label and fail
         run: |
+          gh pr edit ${{ github.event.pull_request.number }} --repo "${{ github.repository }}" \
+            --remove-label "Need AI review"
           echo "::error::Guard check failed — the actor is not a member of the required team or the PR was already reviewed."
-          echo "⛔ Guard check failed — Claude pre-review will not run." >> "$GITHUB_STEP_SUMMARY"
+          echo "⛔ Guard check failed — Claude pre-review will not run. Label 'Need AI review' removed." >> "$GITHUB_STEP_SUMMARY"
           exit 1
 
   ai-prereview:

--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -44,6 +44,17 @@ jobs:
       org-read-token: ${{ secrets.JARVIS_TOKEN }}
       github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  guard-failed:
+    needs: check-guard
+    if: needs.check-guard.outputs.can-run != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard blocked
+        run: |
+          echo "::error::Guard check failed — the actor is not a member of the required team or the PR was already reviewed."
+          echo "⛔ Guard check failed — Claude pre-review will not run." >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
   ai-prereview:
     needs: check-guard
     if: needs.check-guard.outputs.can-run == 'true'

--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -33,7 +33,6 @@ jobs:
   check-guard:
     needs: check-diff
     if: needs.check-diff.outputs.has-code-changes == 'true'
-    # Reusable guard: checks team membership + duplicate review label
     uses: PrestaShop/.github/.github/workflows/ai-prereview-guard.yml@master
     with:
       team-slug: prestashop-sa


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use the official guard workflow from `PrestaShop/.github@master` (which now includes debug output) and add an explicit `guard-failed` job so the workflow shows a red error instead of a silent skip when the guard check is not fulfilled.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#41245
| Sponsor company   | PrestaShop SA
| How to test?      | 1. Merge this PR 2. On any fork PR, have a non-team-member add the `Need AI review` label 3. Verify the workflow fails with a clear error message instead of silently skipping 4. Have a team member add the label and verify the full workflow runs successfully

## Details

- **Guard workflow reference**: Points to `PrestaShop/.github@master` which now includes diagnostic output (token availability, HTTP status, membership role/state) in the step summary
- **Explicit failure job**: Added a `guard-failed` job that runs when `can-run != 'true'`, producing a visible red error with a clear message explaining why the pre-review was blocked
- **Comment on guard call**: Added a descriptive comment for the reusable workflow reference