### PR TITLE
Fix claude-code-action inputs and label management

### DIFF
--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -88,12 +88,34 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Run Claude pre-review
+        id: claude
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--model claude-sonnet-4-6 --max-turns 5 --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),WebFetch,Read"'
           prompt: ${{ steps.prompt.outputs.content }}
+
+      - name: Validate Claude execution
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: |
+          if [ ! -f "$EXECUTION_FILE" ]; then
+            echo "::error::Claude execution output file not found."
+            exit 1
+          fi
+          IS_ERROR=$(jq -r '.is_error // false' "$EXECUTION_FILE")
+          NUM_TURNS=$(jq -r '.num_turns // 0' "$EXECUTION_FILE")
+          DENIALS=$(jq -r '.permission_denials_count // 0' "$EXECUTION_FILE")
+          echo "📋 **Claude execution:** turns=$NUM_TURNS, permission_denials=$DENIALS, is_error=$IS_ERROR" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$IS_ERROR" = "true" ]; then
+            echo "::error::Claude reported an error during execution."
+            exit 1
+          fi
+          if [ "$DENIALS" -gt 0 ] && [ "$DENIALS" -ge "$NUM_TURNS" ]; then
+            echo "::error::Claude was denied permissions on almost every turn ($DENIALS/$NUM_TURNS). The review likely failed — check allowed_tools configuration."
+            exit 1
+          fi
 
       - name: Update labels
         run: |

--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -92,16 +92,15 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: claude-sonnet-4-6
-          max_turns: "5"
-          allowed_tools: "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),WebFetch,Read"
+          claude_args: '--model claude-sonnet-4-6 --max-turns 5 --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),WebFetch,Read"'
           prompt: ${{ steps.prompt.outputs.content }}
 
-      - name: Add AI reviewed label
+      - name: Update labels
         run: |
           gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" \
-            --add-label "AI reviewed"
-          echo "✅ Label 'AI reviewed' added." >> "$GITHUB_STEP_SUMMARY"
+            --add-label "AI reviewed" \
+            --remove-label "Need AI review"
+          echo "✅ Label 'AI reviewed' added, 'Need AI review' removed." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Summary
         run: |


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix invalid inputs for `claude-code-action@v1` and improve label management after review
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#41245
| Sponsor company   | PrestaShop SA
| How to test?      | 1. Merge this PR 2. On a fork PR, add the `Need AI review` label as a team member 3. Verify Claude actually posts a review comment on the PR 4. Verify the `Need AI review` label is removed and `AI reviewed` is added after success 5. Test with a non-team-member: verify the `Need AI review` label is removed and the workflow fails with an error

## Details

### Fix `claude-code-action` inputs

The `model`, `max_turns`, and `allowed_tools` parameters are not valid direct inputs for `anthropics/claude-code-action@v1`. The action was silently ignoring them, resulting in 10/11 permission denials and no review being posted. These are now passed via `claude_args` as CLI arguments.

### Label management

- On successful review: add `AI reviewed` label **and remove `Need AI review`**
- On guard failure: remove `Need AI review` label (already in place from PR #195)