### PR TITLE
Improve Claude review: fix tools, increase turns, focus on PR diff

### DIFF
--- a/.claude/REVIEW_PROMPT.md
+++ b/.claude/REVIEW_PROMPT.md
@@ -16,10 +16,18 @@ perform should be grounded in the rules documented there.
 
 ## How to inspect the PR
 
-Use `gh pr diff $PR_NUMBER --repo $REPO` and `gh pr view $PR_NUMBER --repo $REPO` to inspect the PR.
+**Your review must focus on the code changed in the PR — not the entire codebase.**
+Start by fetching the diff and PR metadata:
+- `gh pr diff $PR_NUMBER --repo $REPO` — the changed lines are your primary review scope
+- `gh pr view $PR_NUMBER --repo $REPO` — PR description and metadata
+
+Only read other files when directly referenced or imported by the changed code.
 Focus on PHP and YAML files under `src/ApiPlatform/**`,
 `tests/Integration/ApiPlatform/**`, and `config/**`.
 Ignore `vendor/`, `*.lock`, binary files, and asset files.
+
+**Do not explore the full repository.** Use `Grep` or `Glob` only to verify
+specific conventions or check related code referenced by the diff.
 
 ## Additional references
 

--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--model claude-sonnet-4-6 --max-turns 15 --allowedTools "Read,Glob,Grep,LS,WebFetch,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"'
+          claude_args: '--model claude-sonnet-4-6 --max-turns 25 --allowedTools "Read,Glob,Grep,LS,WebFetch,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"'
           prompt: ${{ steps.prompt.outputs.content }}
 
       - name: Validate Claude execution
@@ -111,7 +111,14 @@ jobs:
           NUM_TURNS=$(jq -r '.num_turns // 0' "$EXECUTION_FILE")
           DENIALS=$(jq -r '.permission_denials_count // 0' "$EXECUTION_FILE")
           COST=$(jq -r '.total_cost_usd // 0' "$EXECUTION_FILE")
-          echo "📋 **Claude execution:** subtype=$SUBTYPE, turns=$NUM_TURNS, permission_denials=$DENIALS, cost=\$${COST}, is_error=$IS_ERROR" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Claude execution report" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Status | $SUBTYPE |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Turns used | $NUM_TURNS |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Permission denials | $DENIALS |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Cost | \$${COST} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Error | $IS_ERROR |" >> "$GITHUB_STEP_SUMMARY"
           FAILED=false
           if [ "$DENIALS" -gt 0 ] && [ "$DENIALS" -ge "$NUM_TURNS" ]; then
             echo "::error::Claude was denied permissions on almost every turn ($DENIALS/$NUM_TURNS). Check allowed_tools configuration."

--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -89,32 +89,42 @@ jobs:
 
       - name: Run Claude pre-review
         id: claude
+        continue-on-error: true
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--model claude-sonnet-4-6 --max-turns 5 --allowedTools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),WebFetch,Read"'
+          claude_args: '--model claude-sonnet-4-6 --max-turns 15 --allowedTools "Read,Glob,Grep,LS,WebFetch,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"'
           prompt: ${{ steps.prompt.outputs.content }}
 
       - name: Validate Claude execution
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+          STEP_OUTCOME: ${{ steps.claude.outcome }}
         run: |
           if [ ! -f "$EXECUTION_FILE" ]; then
             echo "::error::Claude execution output file not found."
             exit 1
           fi
           IS_ERROR=$(jq -r '.is_error // false' "$EXECUTION_FILE")
+          SUBTYPE=$(jq -r '.subtype // "unknown"' "$EXECUTION_FILE")
           NUM_TURNS=$(jq -r '.num_turns // 0' "$EXECUTION_FILE")
           DENIALS=$(jq -r '.permission_denials_count // 0' "$EXECUTION_FILE")
-          echo "📋 **Claude execution:** turns=$NUM_TURNS, permission_denials=$DENIALS, is_error=$IS_ERROR" >> "$GITHUB_STEP_SUMMARY"
-          if [ "$IS_ERROR" = "true" ]; then
-            echo "::error::Claude reported an error during execution."
+          COST=$(jq -r '.total_cost_usd // 0' "$EXECUTION_FILE")
+          echo "📋 **Claude execution:** subtype=$SUBTYPE, turns=$NUM_TURNS, permission_denials=$DENIALS, cost=\$${COST}, is_error=$IS_ERROR" >> "$GITHUB_STEP_SUMMARY"
+          FAILED=false
+          if [ "$DENIALS" -gt 0 ] && [ "$DENIALS" -ge "$NUM_TURNS" ]; then
+            echo "::error::Claude was denied permissions on almost every turn ($DENIALS/$NUM_TURNS). Check allowed_tools configuration."
+            FAILED=true
+          fi
+          if [ "$SUBTYPE" = "error_max_turns" ]; then
+            echo "::warning::Claude reached the maximum number of turns ($NUM_TURNS). The review may be incomplete."
+          fi
+          if [ "$IS_ERROR" = "true" ] && [ "$FAILED" = "true" ]; then
             exit 1
           fi
-          if [ "$DENIALS" -gt 0 ] && [ "$DENIALS" -ge "$NUM_TURNS" ]; then
-            echo "::error::Claude was denied permissions on almost every turn ($DENIALS/$NUM_TURNS). The review likely failed — check allowed_tools configuration."
-            exit 1
+          if [ "$IS_ERROR" = "true" ]; then
+            echo "::warning::Claude reported an error ($SUBTYPE) but may have posted partial results."
           fi
 
       - name: Update labels

--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          claude_args: '--model claude-sonnet-4-6 --max-turns 25 --allowedTools "Read,Glob,Grep,LS,WebFetch,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"'
+          claude_args: '--model claude-sonnet-4-6 --max-turns 30 --allowedTools "Read,Glob,Grep,LS,WebFetch,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*)"'
           prompt: ${{ steps.prompt.outputs.content }}
 
       - name: Validate Claude execution


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix Claude pre-review configuration: add missing tools, increase max turns, focus the prompt on the PR diff, and improve execution error handling
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#41245
| Sponsor company   | PrestaShop SA
| How to test?      | 1. Merge this PR 2. On a fork PR, add the `Need AI review` label as a team member 3. Verify Claude posts a structured review comment on the PR 4. Check the step summary for execution stats (turns, denials, cost) 5. Verify `Need AI review` is removed and `AI reviewed` is added

## Details

### Problem

The previous run (run 24785779539) failed with `error_max_turns` after 6 turns — 5 of which were permission denials. Claude tried to use `Grep`, `Glob`, and `LS` to search the codebase but these weren't in the allowed tools list. Each denial wasted a turn, so Claude never had enough turns to complete the review.

Additionally, the action crashed on `error_max_turns` and skipped label cleanup entirely.

### Fixes

**Workflow (`ai-prereview.yml`):**
- **Increased `max-turns` from 5 to 15** — a full review cycle (read context, fetch diff, search related code, analyze, post comment) needs 8-12 turns. 15 gives headroom while capping cost at ~$1
- **Added tools:** `Glob`, `Grep`, `LS` — Claude needs these to search the codebase when verifying conventions in the changed code
- **`continue-on-error: true`** on Claude step — so `error_max_turns` doesn't skip validation and label cleanup
- **Smarter validation:** distinguishes fatal errors (all turns denied = misconfiguration → hard fail) from soft errors (max turns reached = possibly incomplete review → warning only)

**Review prompt (`REVIEW_PROMPT.md`):**
- Explicit instruction: review must focus on the PR diff, not the entire codebase
- Start with diff and PR metadata before anything else
- Only read other files when directly referenced by changed code
- Use `Grep`/`Glob` only for targeted convention checks, not full repo exploration