### PR TITLE
Fix execution file JSON parsing in validation step

### DIFF
--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -106,8 +106,14 @@ jobs:
             echo "::error::Claude execution output file not found."
             exit 1
           fi
-          # The execution file is a JSON array — the result object is the last element
-          RESULT=$(jq '.[-1]' "$EXECUTION_FILE")
+          # The execution file can be a JSON array (conversation log) or a single object.
+          # When it's an array, the result object is the last element.
+          FILE_TYPE=$(jq -r 'type' "$EXECUTION_FILE")
+          if [ "$FILE_TYPE" = "array" ]; then
+            RESULT=$(jq '.[-1]' "$EXECUTION_FILE")
+          else
+            RESULT=$(jq '.' "$EXECUTION_FILE")
+          fi
           IS_ERROR=$(echo "$RESULT" | jq -r '.is_error // false')
           SUBTYPE=$(echo "$RESULT" | jq -r '.subtype // "unknown"')
           NUM_TURNS=$(echo "$RESULT" | jq -r '.num_turns // 0')

--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -106,11 +106,13 @@ jobs:
             echo "::error::Claude execution output file not found."
             exit 1
           fi
-          IS_ERROR=$(jq -r '.is_error // false' "$EXECUTION_FILE")
-          SUBTYPE=$(jq -r '.subtype // "unknown"' "$EXECUTION_FILE")
-          NUM_TURNS=$(jq -r '.num_turns // 0' "$EXECUTION_FILE")
-          DENIALS=$(jq -r '.permission_denials_count // 0' "$EXECUTION_FILE")
-          COST=$(jq -r '.total_cost_usd // 0' "$EXECUTION_FILE")
+          # The execution file is a JSON array — the result object is the last element
+          RESULT=$(jq '.[-1]' "$EXECUTION_FILE")
+          IS_ERROR=$(echo "$RESULT" | jq -r '.is_error // false')
+          SUBTYPE=$(echo "$RESULT" | jq -r '.subtype // "unknown"')
+          NUM_TURNS=$(echo "$RESULT" | jq -r '.num_turns // 0')
+          DENIALS=$(echo "$RESULT" | jq -r '.permission_denials_count // 0')
+          COST=$(echo "$RESULT" | jq -r '.total_cost_usd // 0')
           echo "## Claude execution report" >> "$GITHUB_STEP_SUMMARY"
           echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix the validation step that was failing because the execution output file is a JSON array, not a single object
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#41245
| Sponsor company   | PrestaShop SA
| How to test?      | 1. Merge this PR 2. Trigger the Claude pre-review on any PR 3. Verify the validation step completes and the execution report table is displayed in the step summary

## Details

The `claude-code-action` execution output file is a JSON array containing the full conversation log. The result object (with `is_error`, `num_turns`, `total_cost_usd`, etc.) is the **last element** of that array.

The previous code used `jq -r '.is_error'` directly on the file, which failed with: `jq: error: Cannot index array with string "is_error"` (exit code 5).

Fixed by extracting the last element first with `jq '.[-1]'` before reading individual fields.