### PR TITLE
Add job display names and upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   check-diff:
+    name: Check for code changes
     if: github.event.label.name == 'Need AI review'
     runs-on: ubuntu-latest
     outputs:
@@ -31,13 +32,14 @@ jobs:
           fi
 
   load-prompt:
+    name: Load review prompt
     needs: check-diff
     if: needs.check-diff.outputs.has-code-changes == 'true'
     runs-on: ubuntu-latest
     outputs:
       prompt: ${{ steps.prompt.outputs.content }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Load review prompt
         id: prompt
@@ -55,6 +57,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   ai-guarded-review:
+    name: AI guarded review
     needs: load-prompt
     uses: PrestaShop/.github/.github/workflows/ai-guarded-review.yml@master
     with:


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add human-readable `name:` to all jobs in `ai-prereview.yml` and upgrade `actions/checkout` from v4 to v6 to fix Node.js 20 deprecation warning
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#41245
| Sponsor company   | PrestaShop SA
| How to test?      | 1. Merge companion PR PrestaShop/.github first 2. Merge this PR 3. Trigger a review and verify job names display as "Check for code changes", "Load review prompt", "AI guarded review" instead of kebab-case 4. Verify no Node.js 20 deprecation warning

## Details

- Added `name:` to all jobs: "Check for code changes", "Load review prompt", "AI guarded review"
- Upgraded `actions/checkout` from v4 to v6 (Node.js 20 → Node.js 24)