### PR TITLE
Endpoint `/products/search` : Set `orderId` as required

### DIFF
--- a/src/ApiPlatform/Resources/Product/FoundProduct.php
+++ b/src/ApiPlatform/Resources/Product/FoundProduct.php
@@ -95,7 +95,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
                     [
                         'name' => 'orderId',
                         'in' => 'query',
-                        'required' => false,
+                        'required' => true,
                         'schema' => [
                             'type' => 'integer',
                         ],


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | Endpoint `/products/search` : Set orderId as required
| Type?             | bug fix
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | lefevre.dev