### PR TITLE
Add Tax set-status endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Tax/Tax.php
+++ b/src/ApiPlatform/Resources/Tax/Tax.php
@@ -29,6 +29,7 @@ use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Command\AddTaxCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Command\DeleteTaxCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Command\EditTaxCommand;
+use PrestaShop\PrestaShop\Core\Domain\Tax\Command\ToggleTaxStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Exception\TaxNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Tax\Query\GetTaxForEditing;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
@@ -71,6 +72,18 @@ use Symfony\Component\Validator\Constraints as Assert;
             CQRSQuery: GetTaxForEditing::class,
             CQRSQueryMapping: self::QUERY_MAPPING,
             scopes: ['tax_write'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/taxes/{taxId}/set-status',
+            requirements: ['taxId' => '\d+'],
+            output: false,
+            read: false,
+            CQRSCommand: ToggleTaxStatusCommand::class,
+            scopes: ['tax_write'],
+            // No output 204 code
+            CQRSCommandMapping: [
+                '[enabled]' => '[expectedStatus]',
+            ],
         ),
     ],
     normalizationContext: ['skip_null_values' => false],

--- a/tests/Integration/ApiPlatform/TaxEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TaxEndpointTest.php
@@ -82,6 +82,11 @@ class TaxEndpointTest extends ApiTestCase
             'PUT',
             '/taxes/bulk-set-status',
         ];
+
+        yield 'set status endpoint' => [
+            'PATCH',
+            '/taxes/1/set-status',
+        ];
     }
 
     public function testAddTax(): int
@@ -225,6 +230,58 @@ class TaxEndpointTest extends ApiTestCase
         );
 
         return $taxId;
+    }
+
+    /**
+     * @depends testGetUpdatedTax
+     *
+     * @param int $taxId
+     */
+    public function testSetStatusTax(int $taxId): void
+    {
+        $response = $this->partialUpdateItem(
+            '/taxes/' . $taxId . '/set-status',
+            ['enabled' => false],
+            ['tax_write'],
+            Response::HTTP_NO_CONTENT
+        );
+        $this->assertNull($response);
+
+        $tax = $this->getItem('/taxes/' . $taxId, ['tax_read']);
+        $this->assertEquals(
+            [
+                'taxId' => $taxId,
+                'names' => [
+                    'en-US' => 'My Tax Updated EN',
+                    'fr-FR' => 'My Tax Updated FR',
+                ],
+                'enabled' => false,
+                'rate' => 9.87,
+            ],
+            $tax
+        );
+
+        $response = $this->partialUpdateItem(
+            '/taxes/' . $taxId . '/set-status',
+            ['enabled' => true],
+            ['tax_write'],
+            Response::HTTP_NO_CONTENT
+        );
+        $this->assertNull($response);
+
+        $tax = $this->getItem('/taxes/' . $taxId, ['tax_read']);
+        $this->assertEquals(
+            [
+                'taxId' => $taxId,
+                'names' => [
+                    'en-US' => 'My Tax Updated EN',
+                    'fr-FR' => 'My Tax Updated FR',
+                ],
+                'enabled' => true,
+                'rate' => 9.87,
+            ],
+            $tax
+        );
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Tax set-status endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

This exposes `ToggleTaxStatusCommand` through **`PATCH /taxes/{taxId}/set-status`**.

The core `ToggleTaxStatusCommand($taxId, $expectedStatus)` requires an explicit
target status, so the endpoint follows the **set-status** convention (request body
`{ "enabled": true }`) — exactly like the existing `TaxRulesGroup` `/set-status`
operation and the Tax `bulk-set-status` endpoint — rather than the bodyless
`toggle-status` convention used by blind-toggle commands (Supplier, Store, Zone).

Adds an integration test covering enable/disable and a scopes (authorization) entry.
