### PR TITLE
Add Supplier details endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Supplier/SupplierDetails.php
+++ b/src/ApiPlatform/Resources/Supplier/SupplierDetails.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Supplier;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Exception\SupplierNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Supplier\Query\GetSupplierForViewing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/suppliers/{supplierId}/details',
+            requirements: ['supplierId' => '\d+'],
+            CQRSQuery: GetSupplierForViewing::class,
+            scopes: [
+                'supplier_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        SupplierNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class SupplierDetails
+{
+    #[ApiProperty(identifier: true, openapiContext: ['type' => 'integer', 'example' => 1])]
+    public int $supplierId;
+
+    public string $name;
+
+    public array $supplierProducts;
+
+    public const QUERY_MAPPING = [
+        '[_context][langId]' => '[languageId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/SupplierEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SupplierEndpointTest.php
@@ -59,6 +59,11 @@ class SupplierEndpointTest extends ApiTestCase
             '/suppliers/1',
         ];
 
+        yield 'get details endpoint' => [
+            'GET',
+            '/suppliers/1/details',
+        ];
+
         yield 'update endpoint' => [
             'PATCH',
             '/suppliers/1',
@@ -184,6 +189,24 @@ class SupplierEndpointTest extends ApiTestCase
         );
 
         return $supplierId;
+    }
+
+    /**
+     * @depends testGetSupplier
+     *
+     * @param int $supplierId
+     */
+    public function testGetSupplierDetails(int $supplierId): void
+    {
+        $supplierDetails = $this->getItem('/suppliers/' . $supplierId . '/details', ['supplier_read']);
+        $this->assertEquals(
+            [
+                'supplierId' => $supplierId,
+                'name' => 'My Supplier',
+                'supplierProducts' => [],
+            ],
+            $supplierDetails
+        );
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Supplier details endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

This exposes `GetSupplierForViewing` through **`GET /suppliers/{supplierId}/details`**,
mirroring the existing Customer `/details` operation.

The core query requires a language id, which is injected from the request context via
the `[_context][langId] => [languageId]` mapping (same pattern as the `Product` resource).
The response returns the supplier `name` and its associated `supplierProducts`.

Adds an integration test and a scopes (authorization) entry.
