### PR TITLE
Add Profile edit endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Profile/Profile.php
+++ b/src/ApiPlatform/Resources/Profile/Profile.php
@@ -26,11 +26,13 @@ use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Command\AddProfileCommand;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Command\DeleteProfileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Command\EditProfileCommand;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Profile\Query\GetProfileForEditing;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -46,6 +48,16 @@ use Symfony\Component\HttpFoundation\Response;
         new CQRSCreate(
             uriTemplate: '/profiles',
             CQRSCommand: AddProfileCommand::class,
+            CQRSQuery: GetProfileForEditing::class,
+            scopes: ['profile_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/profiles/{profileId}',
+            requirements: ['profileId' => '\d+'],
+            read: false,
+            CQRSCommand: EditProfileCommand::class,
             CQRSQuery: GetProfileForEditing::class,
             scopes: ['profile_write'],
             CQRSQueryMapping: self::QUERY_MAPPING,

--- a/tests/Integration/ApiPlatform/ProfileEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProfileEndpointTest.php
@@ -52,6 +52,11 @@ class ProfileEndpointTest extends ApiTestCase
             '/profiles',
         ];
 
+        yield 'patch endpoint' => [
+            'PATCH',
+            '/profiles/1',
+        ];
+
         yield 'delete endpoint' => [
             'DELETE',
             '/profiles/1',
@@ -99,6 +104,29 @@ class ProfileEndpointTest extends ApiTestCase
 
     /**
      * @depends testGetProfile
+     */
+    public function testEditProfile(int $profileId): int
+    {
+        $response = $this->partialUpdateItem('/profiles/' . $profileId, [
+            'names' => [
+                'en-US' => 'Profile En Updated',
+                'fr-FR' => 'Profile Fr Updated',
+            ],
+        ], ['profile_write']);
+
+        $this->assertEquals([
+            'profileId' => $profileId,
+            'names' => [
+                'en-US' => 'Profile En Updated',
+                'fr-FR' => 'Profile Fr Updated',
+            ],
+        ], $response);
+
+        return $profileId;
+    }
+
+    /**
+     * @depends testEditProfile
      */
     public function testDeleteProfile(int $profileId): void
     {


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Profile edit endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `EditProfileCommand` through **`PATCH /profiles/{profileId}`**, completing the
Profile CRUD (create / get / delete were already available). Follows the same
`CQRSPartialUpdate` pattern as the other edit endpoints (Tax, Supplier…), reusing the
existing localized-names command/query mappings.

Adds an integration test and a scopes (authorization) entry.
