### PR TITLE
Add Profile bulk-delete endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Profile/BulkDeleteProfiles.php
+++ b/src/ApiPlatform/Resources/Profile/BulkDeleteProfiles.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Profile;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Command\BulkDeleteProfileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Exception\ProfileNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/profiles/bulk-delete',
+            CQRSCommand: BulkDeleteProfileCommand::class,
+            scopes: [
+                'profile_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        ProfileNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteProfiles
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $profileIds;
+}

--- a/tests/Integration/ApiPlatform/ProfileEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProfileEndpointTest.php
@@ -56,6 +56,11 @@ class ProfileEndpointTest extends ApiTestCase
             'DELETE',
             '/profiles/1',
         ];
+
+        yield 'bulk delete endpoint' => [
+            'DELETE',
+            '/profiles/bulk-delete',
+        ];
     }
 
     public function testCreateProfile(): int
@@ -104,5 +109,28 @@ class ProfileEndpointTest extends ApiTestCase
     {
         $this->deleteItem('/profiles/' . $profileId, ['profile_write']);
         $this->getItem('/profiles/' . $profileId, ['profile_read'], 404);
+    }
+
+    public function testBulkDeleteProfiles(): void
+    {
+        $firstProfileId = $this->createItem('/profiles', [
+            'names' => [
+                'en-US' => 'Bulk Profile 1 En',
+                'fr-FR' => 'Bulk Profile 1 Fr',
+            ],
+        ], ['profile_write'])['profileId'];
+        $secondProfileId = $this->createItem('/profiles', [
+            'names' => [
+                'en-US' => 'Bulk Profile 2 En',
+                'fr-FR' => 'Bulk Profile 2 Fr',
+            ],
+        ], ['profile_write'])['profileId'];
+
+        $this->bulkDeleteItems('/profiles/bulk-delete', [
+            'profileIds' => [$firstProfileId, $secondProfileId],
+        ], ['profile_write']);
+
+        $this->getItem('/profiles/' . $firstProfileId, ['profile_read'], 404);
+        $this->getItem('/profiles/' . $secondProfileId, ['profile_read'], 404);
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Profile bulk-delete endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `BulkDeleteProfileCommand` through **`DELETE /profiles/bulk-delete`**, following
the same `CQRSDelete` bulk pattern as the other bulk-delete endpoints (Zone, Customer…).
The request body carries the `profileIds` array.

Adds a self-contained integration test and a scopes (authorization) entry.
