### PR TITLE
Add Category get-status endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Category/Category.php
+++ b/src/ApiPlatform/Resources/Category/Category.php
@@ -33,6 +33,7 @@ use PrestaShop\PrestaShop\Core\Domain\Category\Command\SetCategoryIsEnabledComma
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoryIsEnabled;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
@@ -83,6 +84,17 @@ use Symfony\Component\Validator\Constraints as Assert;
             CQRSQueryMapping: self::QUERY_MAPPING,
             CQRSCommandMapping: [
                 '[enabled]' => '[isEnabled]',
+            ],
+        ),
+        new CQRSGet(
+            uriTemplate: '/categories/{categoryId}/status',
+            requirements: ['categoryId' => '\d+'],
+            CQRSQuery: GetCategoryIsEnabled::class,
+            scopes: [
+                'category_read',
+            ],
+            CQRSQueryMapping: [
+                '[_queryResult]' => '[enabled]',
             ],
         ),
         new CQRSDelete(

--- a/tests/Integration/ApiPlatform/CategoryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CategoryEndpointTest.php
@@ -85,6 +85,11 @@ class CategoryEndpointTest extends ApiTestCase
             '/categories/3/status',
         ];
 
+        yield 'get status endpoint' => [
+            'GET',
+            '/categories/3/status',
+        ];
+
         yield 'delete thumbnail endpoint' => [
             'DELETE',
             '/categories/3/thumbnail',
@@ -218,6 +223,35 @@ class CategoryEndpointTest extends ApiTestCase
 
         $category = $this->getItem('/categories/3', ['category_read']);
         $this->assertTrue($category['enabled']);
+    }
+
+    public function testGetCategoryStatus(): void
+    {
+        // Force a known status, then read it back through the dedicated status endpoint
+        $this->requestApi(
+            Request::METHOD_PATCH,
+            '/categories/3/status',
+            ['enabled' => false],
+            ['category_write'],
+            Response::HTTP_OK
+        );
+
+        $status = $this->getItem('/categories/3/status', ['category_read']);
+        $this->assertEquals(3, $status['categoryId']);
+        $this->assertFalse($status['enabled']);
+
+        // Re-enable and assert the status endpoint reflects the change
+        $this->requestApi(
+            Request::METHOD_PATCH,
+            '/categories/3/status',
+            ['enabled' => true],
+            ['category_write'],
+            Response::HTTP_OK
+        );
+
+        $status = $this->getItem('/categories/3/status', ['category_read']);
+        $this->assertEquals(3, $status['categoryId']);
+        $this->assertTrue($status['enabled']);
     }
 
     public function testDeleteCategoryThumbnail(): void


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Category get-status endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `GetCategoryIsEnabled` through **`GET /categories/{categoryId}/status`**, the read
counterpart of the existing `PATCH /categories/{categoryId}/status`. The query returns a
scalar boolean, mapped to the resource via `[_queryResult] => [enabled]` (same pattern as
the ShowcaseCard endpoint); the GET and PATCH share a path within the same resource class,
like the Hook `/status` operations.

Adds an integration test and a scopes (authorization) entry.
