### PR TITLE
Add Tag resource

### DIFF
--- a/src/ApiPlatform/Resources/Tag/BulkDeleteTags.php
+++ b/src/ApiPlatform/Resources/Tag/BulkDeleteTags.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Tag;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Tag\Command\BulkDeleteTagCommand;
+use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/tags/bulk-delete',
+            CQRSCommand: BulkDeleteTagCommand::class,
+            scopes: [
+                'tag_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        TagNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteTags
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $tagIds;
+}

--- a/src/ApiPlatform/Resources/Tag/BulkDeleteTags.php
+++ b/src/ApiPlatform/Resources/Tag/BulkDeleteTags.php
@@ -34,6 +34,10 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSDelete(
             uriTemplate: '/tags/bulk-delete',
+            // The Tag CQRS domain was introduced in 9.1.0
+            extraProperties: [
+                'minVersion' => '9.1.0',
+            ],
             CQRSCommand: BulkDeleteTagCommand::class,
             scopes: [
                 'tag_write',

--- a/src/ApiPlatform/Resources/Tag/Tag.php
+++ b/src/ApiPlatform/Resources/Tag/Tag.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Tag;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Tag\Command\AddTagCommand;
+use PrestaShop\PrestaShop\Core\Domain\Tag\Command\DeleteTagCommand;
+use PrestaShop\PrestaShop\Core\Domain\Tag\Command\EditTagCommand;
+use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Tag\Exception\TagNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Tag\Query\GetTagForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/tags',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddTagCommand::class,
+            scopes: ['tag_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/tags/{tagId}',
+            requirements: ['tagId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteTagCommand::class,
+            scopes: ['tag_write'],
+        ),
+        new CQRSGet(
+            uriTemplate: '/tags/{tagId}',
+            requirements: ['tagId' => '\d+'],
+            CQRSQuery: GetTagForEditing::class,
+            scopes: ['tag_read'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/tags/{tagId}',
+            requirements: ['tagId' => '\d+'],
+            read: false,
+            CQRSCommand: EditTagCommand::class,
+            CQRSQuery: GetTagForEditing::class,
+            scopes: ['tag_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        TagNotFoundException::class => Response::HTTP_NOT_FOUND,
+        TagConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class Tag
+{
+    #[ApiProperty(identifier: true)]
+    public int $tagId;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $name;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public int $languageId;
+
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    public ?array $productIds = null;
+
+    /**
+     * @var array<array{id: int, name: string, image: string}>
+     */
+    public array $products;
+}

--- a/src/ApiPlatform/Resources/Tag/Tag.php
+++ b/src/ApiPlatform/Resources/Tag/Tag.php
@@ -41,12 +41,19 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSCreate(
             uriTemplate: '/tags',
+            // The Tag CQRS domain was introduced in 9.1.0
+            extraProperties: [
+                'minVersion' => '9.1.0',
+            ],
             validationContext: ['groups' => ['Default', 'Create']],
             CQRSCommand: AddTagCommand::class,
             scopes: ['tag_write'],
         ),
         new CQRSDelete(
             uriTemplate: '/tags/{tagId}',
+            extraProperties: [
+                'minVersion' => '9.1.0',
+            ],
             requirements: ['tagId' => '\d+'],
             output: false,
             CQRSCommand: DeleteTagCommand::class,
@@ -54,12 +61,18 @@ use Symfony\Component\Validator\Constraints as Assert;
         ),
         new CQRSGet(
             uriTemplate: '/tags/{tagId}',
+            extraProperties: [
+                'minVersion' => '9.1.0',
+            ],
             requirements: ['tagId' => '\d+'],
             CQRSQuery: GetTagForEditing::class,
             scopes: ['tag_read'],
         ),
         new CQRSPartialUpdate(
             uriTemplate: '/tags/{tagId}',
+            extraProperties: [
+                'minVersion' => '9.1.0',
+            ],
             requirements: ['tagId' => '\d+'],
             read: false,
             CQRSCommand: EditTagCommand::class,

--- a/tests/Integration/ApiPlatform/TagEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TagEndpointTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class TagEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['tag', 'product_tag']);
+        self::createApiClient(['tag_write', 'tag_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['tag', 'product_tag']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => [
+            'POST',
+            '/tags',
+        ];
+
+        yield 'get endpoint' => [
+            'GET',
+            '/tags/1',
+        ];
+
+        yield 'update endpoint' => [
+            'PATCH',
+            '/tags/1',
+        ];
+
+        yield 'delete endpoint' => [
+            'DELETE',
+            '/tags/1',
+        ];
+
+        yield 'bulk delete endpoint' => [
+            'DELETE',
+            '/tags/bulk-delete',
+        ];
+    }
+
+    public function testAddTag(): int
+    {
+        $tag = $this->createItem('/tags', [
+            'name' => 'My Tag',
+            'languageId' => 1,
+        ], ['tag_write']);
+
+        $this->assertArrayHasKey('tagId', $tag);
+        $tagId = $tag['tagId'];
+        $this->assertEquals(['tagId' => $tagId], $tag);
+
+        return $tagId;
+    }
+
+    /**
+     * @depends testAddTag
+     */
+    public function testGetTag(int $tagId): int
+    {
+        $tag = $this->getItem('/tags/' . $tagId, ['tag_read']);
+        $this->assertEquals(
+            [
+                'tagId' => $tagId,
+                'name' => 'My Tag',
+                'languageId' => 1,
+                'products' => [],
+            ],
+            $tag
+        );
+
+        return $tagId;
+    }
+
+    /**
+     * @depends testGetTag
+     */
+    public function testEditTag(int $tagId): int
+    {
+        $updatedTag = $this->partialUpdateItem('/tags/' . $tagId, [
+            'name' => 'My Tag Updated',
+        ], ['tag_write']);
+        $this->assertEquals(
+            [
+                'tagId' => $tagId,
+                'name' => 'My Tag Updated',
+                'languageId' => 1,
+                'products' => [],
+            ],
+            $updatedTag
+        );
+
+        return $tagId;
+    }
+
+    /**
+     * @depends testEditTag
+     */
+    public function testDeleteTag(int $tagId): void
+    {
+        $return = $this->deleteItem('/tags/' . $tagId, ['tag_write']);
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+
+        // Getting the item should result in a 404 now
+        $this->getItem('/tags/' . $tagId, ['tag_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testBulkDeleteTags(): void
+    {
+        $firstTagId = $this->createItem('/tags', [
+            'name' => 'Bulk Tag 1',
+            'languageId' => 1,
+        ], ['tag_write'])['tagId'];
+        $secondTagId = $this->createItem('/tags', [
+            'name' => 'Bulk Tag 2',
+            'languageId' => 1,
+        ], ['tag_write'])['tagId'];
+
+        $this->bulkDeleteItems('/tags/bulk-delete', [
+            'tagIds' => [$firstTagId, $secondTagId],
+        ], ['tag_write']);
+
+        $this->getItem('/tags/' . $firstTagId, ['tag_read'], Response::HTTP_NOT_FOUND);
+        $this->getItem('/tags/' . $secondTagId, ['tag_read'], Response::HTTP_NOT_FOUND);
+    }
+}

--- a/tests/Integration/ApiPlatform/TagEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TagEndpointTest.php
@@ -28,9 +28,19 @@ use Tests\Resources\DatabaseDump;
 
 class TagEndpointTest extends ApiTestCase
 {
+    private const MIN_VERSION = '9.1.0';
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
+
+        // The whole Tag CQRS domain was introduced in 9.1.0. Below that version
+        // ApiResourceScopesExtractor drops every operation, so neither their routes nor the
+        // tag_read and tag_write scopes exist and even creating the API client fails.
+        if (self::isVersionUnder(self::MIN_VERSION)) {
+            static::markTestSkipped(sprintf('The Tag domain requires PrestaShop >= %s.', self::MIN_VERSION));
+        }
+
         DatabaseDump::restoreTables(['tag', 'product_tag']);
         self::createApiClient(['tag_write', 'tag_read']);
     }

--- a/tests/PHPStan/phpstan-9.0.3.neon
+++ b/tests/PHPStan/phpstan-9.0.3.neon
@@ -19,3 +19,9 @@ parameters:
             identifier: class.notFound
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
+        # The Tag CQRS domain was introduced in 9.1.0. The operations declare minVersion
+        # 9.1.0, so their classes are expected to be absent here.
+        -
+            message: "#Class .*Tag\\\\(Command|Exception|Query).* not found.#"
+            identifier: class.notFound
+            path: ../../src/ApiPlatform/Resources/Tag/*


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Tag resource (CRUD) to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints for the **Tag** domain, mirroring existing simple CRUD
resources (Title, SearchEngine):

- `POST /tags` — `AddTagCommand`
- `GET /tags/{tagId}` — `GetTagForEditing`
- `PATCH /tags/{tagId}` — `EditTagCommand`
- `DELETE /tags/{tagId}` — `DeleteTagCommand`
- `DELETE /tags/bulk-delete` — `BulkDeleteTagCommand`

A tag belongs to a single language, so the resource exposes `name` + `languageId`
(plus optional `productIds` on write, `products` on read). Resource property names match
the CQRS command/query fields, so no explicit mapping is needed (same as SearchEngine).

Adds an integration test covering the full CRUD + bulk delete, and the `tag_read` /
`tag_write` scopes.
