### PR TITLE
Add OrderMessage resource

### DIFF
--- a/src/ApiPlatform/Resources/OrderMessage/BulkDeleteOrderMessages.php
+++ b/src/ApiPlatform/Resources/OrderMessage/BulkDeleteOrderMessages.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderMessage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Command\BulkDeleteOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Exception\OrderMessageNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/order-messages/bulk-delete',
+            CQRSCommand: BulkDeleteOrderMessageCommand::class,
+            scopes: [
+                'order_message_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        OrderMessageNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteOrderMessages
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $orderMessageIds;
+}

--- a/src/ApiPlatform/Resources/OrderMessage/OrderMessage.php
+++ b/src/ApiPlatform/Resources/OrderMessage/OrderMessage.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderMessage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Command\AddOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Command\DeleteOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Command\EditOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Exception\OrderMessageConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Exception\OrderMessageNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Query\GetOrderMessageForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/order-messages',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddOrderMessageCommand::class,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            scopes: ['order_message_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/order-messages/{orderMessageId}',
+            requirements: ['orderMessageId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteOrderMessageCommand::class,
+            scopes: ['order_message_write'],
+        ),
+        new CQRSGet(
+            uriTemplate: '/order-messages/{orderMessageId}',
+            requirements: ['orderMessageId' => '\d+'],
+            CQRSQuery: GetOrderMessageForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            scopes: ['order_message_read'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/order-messages/{orderMessageId}',
+            requirements: ['orderMessageId' => '\d+'],
+            read: false,
+            CQRSCommand: EditOrderMessageCommand::class,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            CQRSQuery: GetOrderMessageForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            scopes: ['order_message_write'],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        OrderMessageNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderMessageConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderMessage
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderMessageId;
+
+    #[LocalizedValue]
+    #[Assert\NotBlank(groups: ['Create'])]
+    public array $names;
+
+    #[LocalizedValue]
+    #[Assert\NotBlank(groups: ['Create'])]
+    public array $messages;
+
+    public const QUERY_MAPPING = [
+        '[localizedName]' => '[names]',
+        '[localizedMessage]' => '[messages]',
+    ];
+
+    public const COMMAND_MAPPING = [
+        '[names]' => '[localizedName]',
+        '[messages]' => '[localizedMessage]',
+    ];
+}

--- a/src/ApiPlatform/Resources/OrderMessage/OrderMessageList.php
+++ b/src/ApiPlatform/Resources/OrderMessage/OrderMessageList.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderMessage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Exception\OrderMessageNotFoundException;
+use PrestaShop\PrestaShop\Core\Search\Filters\OrderMessageFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+use PrestaShopBundle\ApiPlatform\Provider\QueryListProvider;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/order-messages',
+            provider: QueryListProvider::class,
+            scopes: ['order_message_read'],
+            ApiResourceMapping: [
+                '[id_order_message]' => '[orderMessageId]',
+            ],
+            gridDataFactory: 'prestashop.core.grid.data.factory.order_message',
+            filtersClass: OrderMessageFilters::class,
+        ),
+    ],
+    exceptionToStatus: [
+        OrderMessageNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class OrderMessageList
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderMessageId;
+
+    public string $name;
+
+    public string $message;
+}

--- a/tests/Integration/ApiPlatform/OrderMessageEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderMessageEndpointTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderMessageEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['order_message', 'order_message_lang']);
+        self::createApiClient(['order_message_write', 'order_message_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['order_message', 'order_message_lang']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => [
+            'POST',
+            '/order-messages',
+        ];
+
+        yield 'get endpoint' => [
+            'GET',
+            '/order-messages/1',
+        ];
+
+        yield 'update endpoint' => [
+            'PATCH',
+            '/order-messages/1',
+        ];
+
+        yield 'delete endpoint' => [
+            'DELETE',
+            '/order-messages/1',
+        ];
+
+        yield 'bulk delete endpoint' => [
+            'DELETE',
+            '/order-messages/bulk-delete',
+        ];
+    }
+
+    public function testAddOrderMessage(): int
+    {
+        $orderMessage = $this->createItem('/order-messages', [
+            'names' => [
+                'en-US' => 'My Order Message EN',
+                'fr-FR' => 'My Order Message FR',
+            ],
+            'messages' => [
+                'en-US' => 'Message body EN',
+                'fr-FR' => 'Message body FR',
+            ],
+        ], ['order_message_write']);
+
+        $this->assertArrayHasKey('orderMessageId', $orderMessage);
+        $orderMessageId = $orderMessage['orderMessageId'];
+        $this->assertEquals(['orderMessageId' => $orderMessageId], $orderMessage);
+
+        return $orderMessageId;
+    }
+
+    /**
+     * @depends testAddOrderMessage
+     */
+    public function testGetOrderMessage(int $orderMessageId): int
+    {
+        $orderMessage = $this->getItem('/order-messages/' . $orderMessageId, ['order_message_read']);
+        $this->assertEquals(
+            [
+                'orderMessageId' => $orderMessageId,
+                'names' => [
+                    'en-US' => 'My Order Message EN',
+                    'fr-FR' => 'My Order Message FR',
+                ],
+                'messages' => [
+                    'en-US' => 'Message body EN',
+                    'fr-FR' => 'Message body FR',
+                ],
+            ],
+            $orderMessage
+        );
+
+        return $orderMessageId;
+    }
+
+    /**
+     * @depends testGetOrderMessage
+     */
+    public function testEditOrderMessage(int $orderMessageId): int
+    {
+        $updated = $this->partialUpdateItem('/order-messages/' . $orderMessageId, [
+            'names' => [
+                'en-US' => 'My Order Message EN Updated',
+                'fr-FR' => 'My Order Message FR Updated',
+            ],
+        ], ['order_message_write']);
+        $this->assertEquals(
+            [
+                'orderMessageId' => $orderMessageId,
+                'names' => [
+                    'en-US' => 'My Order Message EN Updated',
+                    'fr-FR' => 'My Order Message FR Updated',
+                ],
+                'messages' => [
+                    'en-US' => 'Message body EN',
+                    'fr-FR' => 'Message body FR',
+                ],
+            ],
+            $updated
+        );
+
+        return $orderMessageId;
+    }
+
+    /**
+     * @depends testEditOrderMessage
+     */
+    public function testDeleteOrderMessage(int $orderMessageId): void
+    {
+        $return = $this->deleteItem('/order-messages/' . $orderMessageId, ['order_message_write']);
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+
+        // Getting the item should result in a 404 now
+        $this->getItem('/order-messages/' . $orderMessageId, ['order_message_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testBulkDeleteOrderMessages(): void
+    {
+        $firstId = $this->createItem('/order-messages', [
+            'names' => ['en-US' => 'Bulk OM 1 EN', 'fr-FR' => 'Bulk OM 1 FR'],
+            'messages' => ['en-US' => 'Bulk body 1 EN', 'fr-FR' => 'Bulk body 1 FR'],
+        ], ['order_message_write'])['orderMessageId'];
+        $secondId = $this->createItem('/order-messages', [
+            'names' => ['en-US' => 'Bulk OM 2 EN', 'fr-FR' => 'Bulk OM 2 FR'],
+            'messages' => ['en-US' => 'Bulk body 2 EN', 'fr-FR' => 'Bulk body 2 FR'],
+        ], ['order_message_write'])['orderMessageId'];
+
+        $this->bulkDeleteItems('/order-messages/bulk-delete', [
+            'orderMessageIds' => [$firstId, $secondId],
+        ], ['order_message_write']);
+
+        $this->getItem('/order-messages/' . $firstId, ['order_message_read'], Response::HTTP_NOT_FOUND);
+        $this->getItem('/order-messages/' . $secondId, ['order_message_read'], Response::HTTP_NOT_FOUND);
+    }
+}

--- a/tests/Integration/ApiPlatform/OrderMessageEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderMessageEndpointTest.php
@@ -25,6 +25,7 @@ namespace PsApiResourcesTest\Integration\ApiPlatform;
 
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Resources\DatabaseDump;
+use Tests\Resources\Resetter\LanguageResetter;
 
 class OrderMessageEndpointTest extends ApiTestCase
 {
@@ -39,6 +40,7 @@ class OrderMessageEndpointTest extends ApiTestCase
     {
         parent::tearDownAfterClass();
         DatabaseDump::restoreTables(['order_message', 'order_message_lang']);
+        LanguageResetter::resetLanguages();
     }
 
     public static function getProtectedEndpoints(): iterable
@@ -66,6 +68,11 @@ class OrderMessageEndpointTest extends ApiTestCase
         yield 'bulk delete endpoint' => [
             'DELETE',
             '/order-messages/bulk-delete',
+        ];
+
+        yield 'list endpoint' => [
+            'GET',
+            '/order-messages',
         ];
     }
 
@@ -172,5 +179,33 @@ class OrderMessageEndpointTest extends ApiTestCase
 
         $this->getItem('/order-messages/' . $firstId, ['order_message_read'], Response::HTTP_NOT_FOUND);
         $this->getItem('/order-messages/' . $secondId, ['order_message_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testEditOrderMessageMessagesOnly(): void
+    {
+        $orderMessageId = $this->createItem('/order-messages', [
+            'names' => ['en-US' => 'Messages only EN', 'fr-FR' => 'Messages only FR'],
+            'messages' => ['en-US' => 'Body EN', 'fr-FR' => 'Body FR'],
+        ], ['order_message_write'])['orderMessageId'];
+
+        // Partial update with only the messages: the request must succeed and the names must be preserved
+        $updated = $this->partialUpdateItem('/order-messages/' . $orderMessageId, [
+            'messages' => ['en-US' => 'Updated body EN', 'fr-FR' => 'Updated body FR'],
+        ], ['order_message_write']);
+
+        $this->assertSame(['en-US' => 'Updated body EN', 'fr-FR' => 'Updated body FR'], $updated['messages']);
+        $this->assertSame(['en-US' => 'Messages only EN', 'fr-FR' => 'Messages only FR'], $updated['names']);
+    }
+
+    public function testListOrderMessages(): void
+    {
+        $orderMessageId = $this->createItem('/order-messages', [
+            'names' => ['en-US' => 'Listed OM EN', 'fr-FR' => 'Listed OM FR'],
+            'messages' => ['en-US' => 'Listed body EN', 'fr-FR' => 'Listed body FR'],
+        ], ['order_message_write'])['orderMessageId'];
+
+        $list = $this->listItems('/order-messages', ['order_message_read']);
+        $this->assertGreaterThanOrEqual(1, $list['totalItems']);
+        $this->assertContains($orderMessageId, array_column($list['items'], 'orderMessageId'));
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the OrderMessage resource (CRUD) to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints for the **OrderMessage** domain, mirroring the existing
localized CRUD resource (Title):

- `POST /order-messages` — `AddOrderMessageCommand`
- `GET /order-messages/{orderMessageId}` — `GetOrderMessageForEditing`
- `PATCH /order-messages/{orderMessageId}` — `EditOrderMessageCommand`
- `DELETE /order-messages/{orderMessageId}` — `DeleteOrderMessageCommand`
- `DELETE /order-messages/bulk-delete` — `BulkDeleteOrderMessageCommand`

An order message has a localized `names` and `messages`, mapped to the command/query
`localizedName` / `localizedMessage` fields.

Adds an integration test covering the full CRUD + bulk delete, and the
`order_message_read` / `order_message_write` scopes.
