### PR TITLE
Add Country required-fields endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Country/CountryRequiredFields.php
+++ b/src/ApiPlatform/Resources/Country/CountryRequiredFields.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Country;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Query\GetCountryRequiredFields;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/countries/{countryId}/required-fields',
+            requirements: ['countryId' => '\d+'],
+            CQRSQuery: GetCountryRequiredFields::class,
+            scopes: ['country_read'],
+        ),
+    ],
+    exceptionToStatus: [
+        CountryNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CountryRequiredFields
+{
+    #[ApiProperty(identifier: true, openapiContext: ['type' => 'integer', 'example' => 1])]
+    public int $countryId;
+
+    public bool $stateRequired;
+
+    public bool $dniRequired;
+}

--- a/tests/Integration/ApiPlatform/CountryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CountryEndpointTest.php
@@ -58,6 +58,18 @@ class CountryEndpointTest extends ApiTestCase
         yield 'get endpoint' => ['GET', '/countries/1'];
         yield 'update endpoint' => ['PATCH', '/countries/1'];
         yield 'delete endpoint' => ['DELETE', '/countries/1'];
+        yield 'get required fields endpoint' => ['GET', '/countries/1/required-fields'];
+    }
+
+    public function testGetCountryRequiredFields(): void
+    {
+        $requiredFields = $this->getItem('/countries/1/required-fields', ['country_read']);
+
+        $this->assertSame(1, $requiredFields['countryId']);
+        $this->assertArrayHasKey('stateRequired', $requiredFields);
+        $this->assertArrayHasKey('dniRequired', $requiredFields);
+        $this->assertIsBool($requiredFields['stateRequired']);
+        $this->assertIsBool($requiredFields['dniRequired']);
     }
 
     public function testAddCountry(): int


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Country required-fields endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `GetCountryRequiredFields` through **`GET /countries/{countryId}/required-fields`**,
in a dedicated resource class (like `CustomerDetails` / `SupplierDetails`). The query
returns a small object `{stateRequired, dniRequired}`, mapped by matching field names
(no explicit mapping needed, same as `SearchEngine`).

Adds an integration test and a scopes (authorization) entry.
