### PR TITLE
Add Customer private-note endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Customer/CustomerPrivateNote.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerPrivateNote.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetPrivateNoteAboutCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSPartialUpdate(
+            uriTemplate: '/customers/{customerId}/private-notes',
+            requirements: ['customerId' => '\d+'],
+            output: false,
+            read: false,
+            CQRSCommand: SetPrivateNoteAboutCustomerCommand::class,
+            scopes: ['customer_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomerConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CustomerPrivateNote
+{
+    #[ApiProperty(identifier: true)]
+    public int $customerId;
+
+    #[Assert\NotNull]
+    public string $privateNote;
+}

--- a/tests/Integration/ApiPlatform/CustomerEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerEndpointTest.php
@@ -64,6 +64,11 @@ class CustomerEndpointTest extends ApiTestCase
             '/customers/1',
         ];
 
+        yield 'set private note endpoint' => [
+            'PATCH',
+            '/customers/1/private-notes',
+        ];
+
         yield 'delete customer endpoint' => [
             'DELETE',
             '/customers/1',
@@ -516,6 +521,21 @@ class CustomerEndpointTest extends ApiTestCase
         $this->assertArrayHasKey('email', $customer);
         $this->assertArrayHasKey('defaultGroupId', $customer);
         $this->assertArrayHasKey('groupIds', $customer);
+    }
+
+    /**
+     * @depends testAddCustomer
+     */
+    public function testSetCustomerPrivateNote(int $customerId): void
+    {
+        $return = $this->partialUpdateItem(
+            '/customers/' . $customerId . '/private-notes',
+            ['privateNote' => 'A private note about this customer'],
+            ['customer_write'],
+            Response::HTTP_NO_CONTENT
+        );
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Customer private-note endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `SetPrivateNoteAboutCustomerCommand` through
**`PATCH /customers/{customerId}/private-notes`**, in a dedicated resource class so the
rich `Customer` resource is left untouched. The body carries the `privateNote` string
(mapped by matching field name). The URI uses the plural `private-notes` to satisfy the
module's `ApiResourceUriTemplateRector` convention.

Adds an integration test and a scopes (authorization) entry.