### PR TITLE
Add OrderReturnState resource

### DIFF
--- a/src/ApiPlatform/Resources/OrderReturnState/BulkDeleteOrderReturnStates.php
+++ b/src/ApiPlatform/Resources/OrderReturnState/BulkDeleteOrderReturnStates.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderReturnState;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\BulkDeleteOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/order-return-states/bulk-delete',
+            CQRSCommand: BulkDeleteOrderReturnStateCommand::class,
+            scopes: [
+                'order_return_state_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        OrderReturnStateNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteOrderReturnStates
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $orderReturnStateIds;
+}

--- a/src/ApiPlatform/Resources/OrderReturnState/OrderReturnState.php
+++ b/src/ApiPlatform/Resources/OrderReturnState/OrderReturnState.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderReturnState;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\AddOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\DeleteOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Command\EditOrderReturnStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Query\GetOrderReturnStateForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/order-return-states',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddOrderReturnStateCommand::class,
+            CQRSCommandMapping: self::CREATE_COMMAND_MAPPING,
+            scopes: ['order_return_state_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/order-return-states/{orderReturnStateId}',
+            requirements: ['orderReturnStateId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteOrderReturnStateCommand::class,
+            scopes: ['order_return_state_write'],
+        ),
+        new CQRSGet(
+            uriTemplate: '/order-return-states/{orderReturnStateId}',
+            requirements: ['orderReturnStateId' => '\d+'],
+            CQRSQuery: GetOrderReturnStateForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            scopes: ['order_return_state_read'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/order-return-states/{orderReturnStateId}',
+            requirements: ['orderReturnStateId' => '\d+'],
+            read: false,
+            CQRSCommand: EditOrderReturnStateCommand::class,
+            CQRSCommandMapping: self::UPDATE_COMMAND_MAPPING,
+            CQRSQuery: GetOrderReturnStateForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            scopes: ['order_return_state_write'],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        OrderReturnStateNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderReturnStateConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderReturnState
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderReturnStateId;
+
+    #[LocalizedValue]
+    #[Assert\NotBlank(groups: ['Create'])]
+    public array $names;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $color;
+
+    public const QUERY_MAPPING = [
+        '[localizedNames]' => '[names]',
+    ];
+
+    // AddOrderReturnStateCommand expects "localizedNames"
+    public const CREATE_COMMAND_MAPPING = [
+        '[names]' => '[localizedNames]',
+    ];
+
+    // EditOrderReturnStateCommand expects "name"
+    public const UPDATE_COMMAND_MAPPING = [
+        '[names]' => '[name]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/OrderReturnStateEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderReturnStateEndpointTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderReturnStateEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['order_return_state', 'order_return_state_lang']);
+        self::createApiClient(['order_return_state_write', 'order_return_state_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['order_return_state', 'order_return_state_lang']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => [
+            'POST',
+            '/order-return-states',
+        ];
+
+        yield 'get endpoint' => [
+            'GET',
+            '/order-return-states/1',
+        ];
+
+        yield 'update endpoint' => [
+            'PATCH',
+            '/order-return-states/1',
+        ];
+
+        yield 'delete endpoint' => [
+            'DELETE',
+            '/order-return-states/1',
+        ];
+
+        yield 'bulk delete endpoint' => [
+            'DELETE',
+            '/order-return-states/bulk-delete',
+        ];
+    }
+
+    public function testAddOrderReturnState(): int
+    {
+        $orderReturnState = $this->createItem('/order-return-states', [
+            'names' => [
+                'en-US' => 'My Return State EN',
+                'fr-FR' => 'My Return State FR',
+            ],
+            'color' => '#112233',
+        ], ['order_return_state_write']);
+
+        $this->assertArrayHasKey('orderReturnStateId', $orderReturnState);
+        $orderReturnStateId = $orderReturnState['orderReturnStateId'];
+        $this->assertEquals(['orderReturnStateId' => $orderReturnStateId], $orderReturnState);
+
+        return $orderReturnStateId;
+    }
+
+    /**
+     * @depends testAddOrderReturnState
+     */
+    public function testGetOrderReturnState(int $orderReturnStateId): int
+    {
+        $orderReturnState = $this->getItem('/order-return-states/' . $orderReturnStateId, ['order_return_state_read']);
+        $this->assertEquals(
+            [
+                'orderReturnStateId' => $orderReturnStateId,
+                'names' => [
+                    'en-US' => 'My Return State EN',
+                    'fr-FR' => 'My Return State FR',
+                ],
+                'color' => '#112233',
+            ],
+            $orderReturnState
+        );
+
+        return $orderReturnStateId;
+    }
+
+    /**
+     * @depends testGetOrderReturnState
+     */
+    public function testEditOrderReturnState(int $orderReturnStateId): int
+    {
+        $updated = $this->partialUpdateItem('/order-return-states/' . $orderReturnStateId, [
+            'names' => [
+                'en-US' => 'My Return State EN Updated',
+                'fr-FR' => 'My Return State FR Updated',
+            ],
+            'color' => '#445566',
+        ], ['order_return_state_write']);
+        $this->assertEquals(
+            [
+                'orderReturnStateId' => $orderReturnStateId,
+                'names' => [
+                    'en-US' => 'My Return State EN Updated',
+                    'fr-FR' => 'My Return State FR Updated',
+                ],
+                'color' => '#445566',
+            ],
+            $updated
+        );
+
+        return $orderReturnStateId;
+    }
+
+    /**
+     * @depends testEditOrderReturnState
+     */
+    public function testDeleteOrderReturnState(int $orderReturnStateId): void
+    {
+        $return = $this->deleteItem('/order-return-states/' . $orderReturnStateId, ['order_return_state_write']);
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+
+        // Getting the item should result in a 404 now
+        $this->getItem('/order-return-states/' . $orderReturnStateId, ['order_return_state_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testBulkDeleteOrderReturnStates(): void
+    {
+        $firstId = $this->createItem('/order-return-states', [
+            'names' => ['en-US' => 'Bulk RS 1 EN', 'fr-FR' => 'Bulk RS 1 FR'],
+            'color' => '#101010',
+        ], ['order_return_state_write'])['orderReturnStateId'];
+        $secondId = $this->createItem('/order-return-states', [
+            'names' => ['en-US' => 'Bulk RS 2 EN', 'fr-FR' => 'Bulk RS 2 FR'],
+            'color' => '#202020',
+        ], ['order_return_state_write'])['orderReturnStateId'];
+
+        $this->bulkDeleteItems('/order-return-states/bulk-delete', [
+            'orderReturnStateIds' => [$firstId, $secondId],
+        ], ['order_return_state_write']);
+
+        $this->getItem('/order-return-states/' . $firstId, ['order_return_state_read'], Response::HTTP_NOT_FOUND);
+        $this->getItem('/order-return-states/' . $secondId, ['order_return_state_read'], Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the OrderReturnState resource (CRUD) to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints for the **OrderReturnState** domain, mirroring existing
localized CRUD resources:

- `POST /order-return-states` — `AddOrderReturnStateCommand`
- `GET /order-return-states/{orderReturnStateId}` — `GetOrderReturnStateForEditing`
- `PATCH /order-return-states/{orderReturnStateId}` — `EditOrderReturnStateCommand`
- `DELETE /order-return-states/{orderReturnStateId}` — `DeleteOrderReturnStateCommand`
- `DELETE /order-return-states/bulk-delete` — `BulkDeleteOrderReturnStateCommand`

An order return state has a localized `names` and a `color`. As with the Contact resource,
the create and update commands expect different field names (`localizedNames` vs `name`),
handled by two distinct command mappings.

Adds an integration test covering the full CRUD + bulk delete, and the
`order_return_state_read` / `order_return_state_write` scopes.
