### PR TITLE
Add State bulk-update-zone endpoint

### DIFF
--- a/src/ApiPlatform/Resources/State/BulkUpdateStateZone.php
+++ b/src/ApiPlatform/Resources/State/BulkUpdateStateZone.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\State;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\State\Command\BulkUpdateStateZoneCommand;
+use PrestaShop\PrestaShop\Core\Domain\State\Exception\StateNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/states/bulk-update-zone',
+            output: false,
+            CQRSCommand: BulkUpdateStateZoneCommand::class,
+            scopes: [
+                'state_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        StateNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkUpdateStateZone
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $stateIds;
+
+    #[Assert\NotNull]
+    public int $newZoneId;
+}

--- a/tests/Integration/ApiPlatform/StateZoneEndpointTest.php
+++ b/tests/Integration/ApiPlatform/StateZoneEndpointTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class StateZoneEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['state']);
+        self::createApiClient(['state_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['state']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'bulk update zone endpoint' => [
+            'PUT',
+            '/states/bulk-update-zone',
+        ];
+    }
+
+    public function testBulkUpdateStateZone(): void
+    {
+        // Move a couple of existing states (from the default fixtures) to another zone.
+        $return = $this->updateItem(
+            '/states/bulk-update-zone',
+            [
+                'stateIds' => [1, 2],
+                'newZoneId' => 1,
+            ],
+            ['state_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a State bulk-update-zone endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `BulkUpdateStateZoneCommand` through **`PUT /states/bulk-update-zone`**, moving
several states to a new zone in a single call (body: `stateIds`, `newZoneId`).

Implemented as a standalone resource with its own test class (`StateZoneEndpointTest`) so
it does not collide with the in-progress State resource PR (#88), which introduces the
base State CRUD in separate files.

Adds an integration test and the `state_write` scope.
