### PR TITLE
Add Notification last-elements endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Notification/EmployeeNotificationLastElement.php
+++ b/src/ApiPlatform/Resources/Notification/EmployeeNotificationLastElement.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Notification;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Notification\Command\UpdateEmployeeNotificationLastElementCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/notifications/last-elements',
+            output: false,
+            CQRSCommand: UpdateEmployeeNotificationLastElementCommand::class,
+            scopes: ['notification_write'],
+        ),
+    ],
+)]
+class EmployeeNotificationLastElement
+{
+    /**
+     * The notification type to acknowledge: "order", "customer" or "customer_message".
+     */
+    #[Assert\NotBlank]
+    #[Assert\Choice(choices: ['order', 'customer', 'customer_message'])]
+    public string $type;
+}

--- a/src/ApiPlatform/Resources/Notification/NotificationLastElements.php
+++ b/src/ApiPlatform/Resources/Notification/NotificationLastElements.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Notification;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Notification\Query\GetNotificationLastElements;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/notifications/{employeeId}/last-elements',
+            requirements: ['employeeId' => '\d+'],
+            CQRSQuery: GetNotificationLastElements::class,
+            scopes: ['notification_read'],
+        ),
+    ],
+)]
+class NotificationLastElements
+{
+    #[ApiProperty(identifier: true)]
+    public int $employeeId;
+
+    /**
+     * @var array<array{type: string, total: int, notifications: array}>
+     */
+    public array $notificationsResults;
+}

--- a/tests/Integration/ApiPlatform/NotificationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/NotificationEndpointTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class NotificationEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['notification_write', 'notification_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get last elements endpoint' => [
+            'GET',
+            '/notifications/1/last-elements',
+        ];
+
+        yield 'update last element endpoint' => [
+            'PUT',
+            '/notifications/last-elements',
+        ];
+    }
+
+    public function testGetNotificationLastElements(): void
+    {
+        $notifications = $this->getItem('/notifications/1/last-elements', ['notification_read']);
+
+        $this->assertSame(1, $notifications['employeeId']);
+        $this->assertArrayHasKey('notificationsResults', $notifications);
+        $this->assertIsArray($notifications['notificationsResults']);
+    }
+
+    public function testUpdateEmployeeNotificationLastElement(): void
+    {
+        $return = $this->updateItem(
+            '/notifications/last-elements',
+            ['type' => 'order'],
+            ['notification_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add Notification last-elements endpoints to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes the employee notification helpers:

- `GET /notifications/{employeeId}/last-elements` — `GetNotificationLastElements`: latest
  orders / customers / customer-messages notifications for the given employee.
- `PUT /notifications/last-elements` — `UpdateEmployeeNotificationLastElementCommand`:
  acknowledges the last seen element of a given type (`order`, `customer`, `customer_message`).

Adds an integration test and the `notification_read` / `notification_write` scopes.
