### PR TITLE
Add MailTemplate generate endpoint

### DIFF
--- a/src/ApiPlatform/Resources/MailTemplate/GenerateThemeMailTemplates.php
+++ b/src/ApiPlatform/Resources/MailTemplate/GenerateThemeMailTemplates.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\MailTemplate;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\GenerateThemeMailTemplatesCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/mail-templates',
+            output: false,
+            CQRSCommand: GenerateThemeMailTemplatesCommand::class,
+            scopes: ['mail_template_write'],
+        ),
+    ],
+)]
+class GenerateThemeMailTemplates
+{
+    #[Assert\NotBlank]
+    public string $themeName;
+
+    /**
+     * Language locale, e.g. "en".
+     */
+    #[Assert\NotBlank]
+    public string $language;
+
+    public ?bool $overwriteTemplates = null;
+}

--- a/tests/Integration/ApiPlatform/MailTemplateEndpointTest.php
+++ b/tests/Integration/ApiPlatform/MailTemplateEndpointTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class MailTemplateEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['mail_template_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'generate theme mail templates endpoint' => [
+            'PUT',
+            '/mail-templates',
+        ];
+    }
+
+    public function testGenerateThemeMailTemplates(): void
+    {
+        $return = $this->updateItem(
+            '/mail-templates',
+            [
+                'themeName' => 'classic',
+                'language' => 'en',
+                'overwriteTemplates' => false,
+            ],
+            ['mail_template_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a MailTemplate generate endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `GenerateThemeMailTemplatesCommand` through **`PUT /mail-templates`**, which
(re)generates the mail templates of a theme for a given language. Body: `themeName`,
`language` (locale, e.g. `en`) and optional `overwriteTemplates`.

Adds an integration test and the `mail_template_write` scope.
