### PR TITLE
Add Search indexation endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Search/SearchIndexation.php
+++ b/src/ApiPlatform/Resources/Search/SearchIndexation.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Search;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Search\Command\SearchIndexationCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/searches/indexations',
+            output: false,
+            CQRSCommand: SearchIndexationCommand::class,
+            scopes: ['search_write'],
+        ),
+    ],
+)]
+class SearchIndexation
+{
+    /**
+     * When true, rebuilds the whole search index; otherwise only missing products are indexed.
+     */
+    public bool $full = false;
+
+    /**
+     * Optionally restrict the (re)indexation to a single product.
+     */
+    public ?int $productId = null;
+}

--- a/src/ApiPlatform/Resources/Search/SearchIndexation.php
+++ b/src/ApiPlatform/Resources/Search/SearchIndexation.php
@@ -30,6 +30,10 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
     operations: [
         new CQRSUpdate(
             uriTemplate: '/searches/indexations',
+            // SearchIndexationCommand was introduced in 9.1.0
+            extraProperties: [
+                'minVersion' => '9.1.0',
+            ],
             output: false,
             CQRSCommand: SearchIndexationCommand::class,
             scopes: ['search_write'],

--- a/tests/Integration/ApiPlatform/SearchIndexationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SearchIndexationEndpointTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class SearchIndexationEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['search_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'search indexation endpoint' => [
+            'PUT',
+            '/searches/indexations',
+        ];
+    }
+
+    public function testSearchIndexation(): void
+    {
+        $return = $this->updateItem(
+            '/searches/indexations',
+            ['full' => false],
+            ['search_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+    }
+}

--- a/tests/Integration/ApiPlatform/SearchIndexationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SearchIndexationEndpointTest.php
@@ -27,9 +27,19 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SearchIndexationEndpointTest extends ApiTestCase
 {
+    private const MIN_VERSION = '9.1.0';
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
+
+        // SearchIndexationCommand was introduced in 9.1.0. Below that version
+        // ApiResourceScopesExtractor drops the operation, so neither its route nor the
+        // search_write scope exists and even creating the API client fails.
+        if (self::isVersionUnder(self::MIN_VERSION)) {
+            static::markTestSkipped(sprintf('The search indexation endpoint requires PrestaShop >= %s.', self::MIN_VERSION));
+        }
+
         self::createApiClient(['search_write']);
     }
 

--- a/tests/PHPStan/phpstan-9.0.3.neon
+++ b/tests/PHPStan/phpstan-9.0.3.neon
@@ -19,3 +19,9 @@ parameters:
             identifier: class.notFound
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
+        # SearchIndexationCommand was introduced in 9.1.0. The operation declares minVersion
+        # 9.1.0, so the class is expected to be absent here.
+        -
+            message: "#Class .*Search\\\\Command.* not found.#"
+            identifier: class.notFound
+            path: ../../src/ApiPlatform/Resources/Search/*


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Search indexation endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `SearchIndexationCommand` through **`PUT /searches/indexations`**, rebuilding the
products search index. Body: `full` (rebuild everything vs index only missing products)
and an optional `productId` to restrict it to a single product.

⚠️ **Draft** — the `SearchIndexation` CQRS layer only exists since PrestaShop **9.1**, so
the 9.0.3 CI jobs report the class as not found. This depends on dropping 9.0.x from the
CI matrix (#220); ready to un-draft once that lands. The URI uses the plural form imposed
by `ApiResourceUriTemplateRector` (`/searches/indexations`) — happy to adjust the naming.

Adds an integration test and the `search_write` scope.
