### PR TITLE
Add OrderState resource

### DIFF
--- a/src/ApiPlatform/Resources/OrderState/BulkDeleteOrderStates.php
+++ b/src/ApiPlatform/Resources/OrderState/BulkDeleteOrderStates.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderState;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\BulkDeleteOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/order-states/bulk-delete',
+            CQRSCommand: BulkDeleteOrderStateCommand::class,
+            scopes: [
+                'order_state_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        OrderStateNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteOrderStates
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $orderStateIds;
+}

--- a/src/ApiPlatform/Resources/OrderState/OrderState.php
+++ b/src/ApiPlatform/Resources/OrderState/OrderState.php
@@ -121,9 +121,14 @@ class OrderState
     #[Assert\NotNull(groups: ['Create'])]
     public array $templates;
 
+    public bool $isDeleted;
+
     public const QUERY_MAPPING = [
         '[localizedNames]' => '[names]',
         '[localizedTemplates]' => '[templates]',
+        // EditableOrderState exposes isSendEmailEnabled() and isDeleted()
+        '[sendEmailEnabled]' => '[sendEmail]',
+        '[deleted]' => '[isDeleted]',
     ];
 
     // AddOrderStateCommand expects "localizedNames" / "localizedTemplates"

--- a/src/ApiPlatform/Resources/OrderState/OrderState.php
+++ b/src/ApiPlatform/Resources/OrderState/OrderState.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderState;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\AddOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\DeleteOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\EditOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Query\GetOrderStateForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/order-states',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddOrderStateCommand::class,
+            CQRSCommandMapping: self::CREATE_COMMAND_MAPPING,
+            scopes: ['order_state_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/order-states/{orderStateId}',
+            requirements: ['orderStateId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteOrderStateCommand::class,
+            scopes: ['order_state_write'],
+        ),
+        new CQRSGet(
+            uriTemplate: '/order-states/{orderStateId}',
+            requirements: ['orderStateId' => '\d+'],
+            CQRSQuery: GetOrderStateForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            scopes: ['order_state_read'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/order-states/{orderStateId}',
+            requirements: ['orderStateId' => '\d+'],
+            read: false,
+            CQRSCommand: EditOrderStateCommand::class,
+            CQRSCommandMapping: self::UPDATE_COMMAND_MAPPING,
+            CQRSQuery: GetOrderStateForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            scopes: ['order_state_write'],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        OrderStateNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderStateConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderState
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderStateId;
+
+    #[LocalizedValue]
+    #[Assert\NotBlank(groups: ['Create'])]
+    public array $names;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $color;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $loggable;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $invoice;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $hidden;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $sendEmail;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $pdfInvoice;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $pdfDelivery;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $shipped;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $paid;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $delivery;
+
+    #[LocalizedValue]
+    #[Assert\NotNull(groups: ['Create'])]
+    public array $templates;
+
+    public const QUERY_MAPPING = [
+        '[localizedNames]' => '[names]',
+        '[localizedTemplates]' => '[templates]',
+    ];
+
+    // AddOrderStateCommand expects "localizedNames" / "localizedTemplates"
+    public const CREATE_COMMAND_MAPPING = [
+        '[names]' => '[localizedNames]',
+        '[templates]' => '[localizedTemplates]',
+    ];
+
+    // EditOrderStateCommand expects "name" / "template"
+    public const UPDATE_COMMAND_MAPPING = [
+        '[names]' => '[name]',
+        '[templates]' => '[template]',
+    ];
+}

--- a/src/ApiPlatform/Resources/OrderState/OrderState.php
+++ b/src/ApiPlatform/Resources/OrderState/OrderState.php
@@ -121,14 +121,13 @@ class OrderState
     #[Assert\NotNull(groups: ['Create'])]
     public array $templates;
 
-    public bool $isDeleted;
+    public bool $deleted;
 
     public const QUERY_MAPPING = [
         '[localizedNames]' => '[names]',
         '[localizedTemplates]' => '[templates]',
-        // EditableOrderState exposes isSendEmailEnabled() and isDeleted()
+        // EditableOrderState exposes isSendEmailEnabled(); "deleted" maps by identity
         '[sendEmailEnabled]' => '[sendEmail]',
-        '[deleted]' => '[isDeleted]',
     ];
 
     // AddOrderStateCommand expects "localizedNames" / "localizedTemplates"

--- a/tests/Integration/ApiPlatform/OrderStateEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderStateEndpointTest.php
@@ -106,7 +106,7 @@ class OrderStateEndpointTest extends ApiTestCase
         $this->assertFalse($orderState['shipped']);
         $this->assertFalse($orderState['paid']);
         $this->assertFalse($orderState['delivery']);
-        $this->assertFalse($orderState['isDeleted']);
+        $this->assertFalse($orderState['deleted']);
         $this->assertArrayHasKey('templates', $orderState);
 
         return $orderStateId;
@@ -145,7 +145,7 @@ class OrderStateEndpointTest extends ApiTestCase
 
         // Order states are soft-deleted: the record still exists but is flagged as deleted
         $deleted = $this->getItem('/order-states/' . $orderStateId, ['order_state_read']);
-        $this->assertTrue($deleted['isDeleted']);
+        $this->assertTrue($deleted['deleted']);
     }
 
     public function testBulkDeleteOrderStates(): void
@@ -158,7 +158,7 @@ class OrderStateEndpointTest extends ApiTestCase
         ], ['order_state_write']);
 
         // Order states are soft-deleted: still readable but flagged as deleted
-        $this->assertTrue($this->getItem('/order-states/' . $firstId, ['order_state_read'])['isDeleted']);
-        $this->assertTrue($this->getItem('/order-states/' . $secondId, ['order_state_read'])['isDeleted']);
+        $this->assertTrue($this->getItem('/order-states/' . $firstId, ['order_state_read'])['deleted']);
+        $this->assertTrue($this->getItem('/order-states/' . $secondId, ['order_state_read'])['deleted']);
     }
 }

--- a/tests/Integration/ApiPlatform/OrderStateEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderStateEndpointTest.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
-use Symfony\Component\HttpFoundation\Response;
 use Tests\Resources\DatabaseDump;
 
 class OrderStateEndpointTest extends ApiTestCase
@@ -107,6 +106,7 @@ class OrderStateEndpointTest extends ApiTestCase
         $this->assertFalse($orderState['shipped']);
         $this->assertFalse($orderState['paid']);
         $this->assertFalse($orderState['delivery']);
+        $this->assertFalse($orderState['isDeleted']);
         $this->assertArrayHasKey('templates', $orderState);
 
         return $orderStateId;
@@ -143,7 +143,9 @@ class OrderStateEndpointTest extends ApiTestCase
         // This endpoint returns an empty response and a 204 HTTP code
         $this->assertNull($return);
 
-        $this->getItem('/order-states/' . $orderStateId, ['order_state_read'], Response::HTTP_NOT_FOUND);
+        // Order states are soft-deleted: the record still exists but is flagged as deleted
+        $deleted = $this->getItem('/order-states/' . $orderStateId, ['order_state_read']);
+        $this->assertTrue($deleted['isDeleted']);
     }
 
     public function testBulkDeleteOrderStates(): void
@@ -155,7 +157,8 @@ class OrderStateEndpointTest extends ApiTestCase
             'orderStateIds' => [$firstId, $secondId],
         ], ['order_state_write']);
 
-        $this->getItem('/order-states/' . $firstId, ['order_state_read'], Response::HTTP_NOT_FOUND);
-        $this->getItem('/order-states/' . $secondId, ['order_state_read'], Response::HTTP_NOT_FOUND);
+        // Order states are soft-deleted: still readable but flagged as deleted
+        $this->assertTrue($this->getItem('/order-states/' . $firstId, ['order_state_read'])['isDeleted']);
+        $this->assertTrue($this->getItem('/order-states/' . $secondId, ['order_state_read'])['isDeleted']);
     }
 }

--- a/tests/Integration/ApiPlatform/OrderStateEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderStateEndpointTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderStateEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['order_state', 'order_state_lang']);
+        self::createApiClient(['order_state_write', 'order_state_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['order_state', 'order_state_lang']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => ['POST', '/order-states'];
+        yield 'get endpoint' => ['GET', '/order-states/1'];
+        yield 'update endpoint' => ['PATCH', '/order-states/1'];
+        yield 'delete endpoint' => ['DELETE', '/order-states/1'];
+        yield 'bulk delete endpoint' => ['DELETE', '/order-states/bulk-delete'];
+    }
+
+    private function createPayload(): array
+    {
+        return [
+            'names' => [
+                'en-US' => 'My Order State EN',
+                'fr-FR' => 'My Order State FR',
+            ],
+            'color' => '#4169E1',
+            'loggable' => true,
+            'invoice' => false,
+            'hidden' => false,
+            'sendEmail' => false,
+            'pdfInvoice' => false,
+            'pdfDelivery' => false,
+            'shipped' => false,
+            'paid' => false,
+            'delivery' => false,
+            'templates' => [
+                'en-US' => '',
+                'fr-FR' => '',
+            ],
+        ];
+    }
+
+    public function testAddOrderState(): int
+    {
+        $orderState = $this->createItem('/order-states', $this->createPayload(), ['order_state_write']);
+
+        $this->assertArrayHasKey('orderStateId', $orderState);
+        $orderStateId = $orderState['orderStateId'];
+        $this->assertEquals(['orderStateId' => $orderStateId], $orderState);
+
+        return $orderStateId;
+    }
+
+    /**
+     * @depends testAddOrderState
+     */
+    public function testGetOrderState(int $orderStateId): int
+    {
+        $orderState = $this->getItem('/order-states/' . $orderStateId, ['order_state_read']);
+
+        $this->assertSame($orderStateId, $orderState['orderStateId']);
+        $this->assertSame(
+            ['en-US' => 'My Order State EN', 'fr-FR' => 'My Order State FR'],
+            $orderState['names']
+        );
+        $this->assertSame('#4169E1', $orderState['color']);
+        $this->assertTrue($orderState['loggable']);
+        $this->assertFalse($orderState['invoice']);
+        $this->assertFalse($orderState['hidden']);
+        $this->assertFalse($orderState['sendEmail']);
+        $this->assertFalse($orderState['pdfInvoice']);
+        $this->assertFalse($orderState['pdfDelivery']);
+        $this->assertFalse($orderState['shipped']);
+        $this->assertFalse($orderState['paid']);
+        $this->assertFalse($orderState['delivery']);
+        $this->assertArrayHasKey('templates', $orderState);
+
+        return $orderStateId;
+    }
+
+    /**
+     * @depends testGetOrderState
+     */
+    public function testEditOrderState(int $orderStateId): int
+    {
+        $updated = $this->partialUpdateItem('/order-states/' . $orderStateId, [
+            'names' => [
+                'en-US' => 'My Order State EN Updated',
+                'fr-FR' => 'My Order State FR Updated',
+            ],
+            'paid' => true,
+        ], ['order_state_write']);
+
+        $this->assertSame(
+            ['en-US' => 'My Order State EN Updated', 'fr-FR' => 'My Order State FR Updated'],
+            $updated['names']
+        );
+        $this->assertTrue($updated['paid']);
+
+        return $orderStateId;
+    }
+
+    /**
+     * @depends testEditOrderState
+     */
+    public function testDeleteOrderState(int $orderStateId): void
+    {
+        $return = $this->deleteItem('/order-states/' . $orderStateId, ['order_state_write']);
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+
+        $this->getItem('/order-states/' . $orderStateId, ['order_state_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testBulkDeleteOrderStates(): void
+    {
+        $firstId = $this->createItem('/order-states', $this->createPayload(), ['order_state_write'])['orderStateId'];
+        $secondId = $this->createItem('/order-states', $this->createPayload(), ['order_state_write'])['orderStateId'];
+
+        $this->bulkDeleteItems('/order-states/bulk-delete', [
+            'orderStateIds' => [$firstId, $secondId],
+        ], ['order_state_write']);
+
+        $this->getItem('/order-states/' . $firstId, ['order_state_read'], Response::HTTP_NOT_FOUND);
+        $this->getItem('/order-states/' . $secondId, ['order_state_read'], Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the OrderState resource (CRUD) to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints for the **OrderState** domain (order statuses):

- `POST /order-states` — `AddOrderStateCommand`
- `GET /order-states/{orderStateId}` — `GetOrderStateForEditing`
- `PATCH /order-states/{orderStateId}` — `EditOrderStateCommand`
- `DELETE /order-states/{orderStateId}` — `DeleteOrderStateCommand`
- `DELETE /order-states/bulk-delete` — `BulkDeleteOrderStateCommand`

Exposes the order state data fields: localized `names` and `templates` (email template
per language), `color`, and the behaviour flags (`loggable`, `invoice`, `hidden`,
`sendEmail`, `pdfInvoice`, `pdfDelivery`, `shipped`, `paid`, `delivery`). As with
Contact / OrderReturnState, create and update commands expect different field names
(`localizedNames`/`localizedTemplates` vs `name`/`template`), handled by distinct
command mappings.

The optional state **icon upload** is intentionally left out of this first version and can
be added later as a dedicated multipart operation.

Adds an integration test covering the full CRUD + bulk delete, and the
`order_state_read` / `order_state_write` scopes.
