### PR TITLE
Add Attribute delete-texture-image endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Attribute/Attribute.php
+++ b/src/ApiPlatform/Resources/Attribute/Attribute.php
@@ -30,6 +30,7 @@ use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Command\EditAttri
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Exception\AttributeConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Exception\AttributeNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Attribute\Query\GetAttributeForEditing;
+use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\Command\DeleteAttributeTextureImageCommand;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
@@ -74,6 +75,15 @@ use Symfony\Component\Validator\Constraints as Assert;
             uriTemplate: '/attributes/attributes/{attributeId}',
             requirements: ['attributeId' => '\d+'],
             CQRSCommand: DeleteAttributeCommand::class,
+            scopes: [
+                'attribute_write',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/attributes/attributes/{attributeId}/textures',
+            requirements: ['attributeId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteAttributeTextureImageCommand::class,
             scopes: [
                 'attribute_write',
             ],

--- a/tests/Integration/ApiPlatform/AttributeEndpointTest.php
+++ b/tests/Integration/ApiPlatform/AttributeEndpointTest.php
@@ -70,6 +70,11 @@ class AttributeEndpointTest extends ApiTestCase
             '/attributes/attributes/1',
         ];
 
+        yield 'delete texture endpoint' => [
+            'DELETE',
+            '/attributes/attributes/1/textures',
+        ];
+
         yield 'list endpoint' => [
             'GET',
             '/attributes/groups/1/attributes',
@@ -139,6 +144,18 @@ class AttributeEndpointTest extends ApiTestCase
         ], $attribute);
 
         return $attributeId;
+    }
+
+    /**
+     * @depends testAddAttribute
+     *
+     * @param int $attributeId
+     */
+    public function testDeleteAttributeTextureImage(int $attributeId): void
+    {
+        // The created attribute has no texture image; deleting it is a safe no-op (204)
+        $return = $this->deleteItem('/attributes/attributes/' . $attributeId . '/textures', ['attribute_write']);
+        $this->assertNull($return);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add an Attribute delete-texture-image endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `DeleteAttributeTextureImageCommand` through
**`DELETE /attributes/attributes/{attributeId}/textures`**, removing the texture image of a
texture/colour attribute. Id-only command, empty `204` response. (The plural `textures`
segment follows the module's `ApiResourceUriTemplateRector` convention.)

Adds an integration test and reuses the `attribute_write` scope.
