### PR TITLE
Add Meta resource (SEO)

### DIFF
--- a/src/ApiPlatform/Resources/Meta/Meta.php
+++ b/src/ApiPlatform/Resources/Meta/Meta.php
@@ -24,17 +24,27 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Meta;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Meta\Command\AddMetaCommand;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Command\EditMetaCommand;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Meta\Query\GetMetaForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
+        new CQRSCreate(
+            uriTemplate: '/metas',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddMetaCommand::class,
+            CQRSCommandMapping: self::CREATE_COMMAND_MAPPING,
+            scopes: ['meta_write'],
+        ),
         new CQRSGet(
             uriTemplate: '/metas/{metaId}',
             requirements: ['metaId' => '\d+'],
@@ -64,6 +74,7 @@ class Meta
     #[ApiProperty(identifier: true)]
     public int $metaId;
 
+    #[Assert\NotBlank(groups: ['Create'])]
     public string $pageName;
 
     #[LocalizedValue]
@@ -73,6 +84,7 @@ class Meta
     public array $metaDescriptions;
 
     #[LocalizedValue]
+    #[Assert\NotBlank(groups: ['Create'])]
     public array $urlRewrites;
 
     // EditableMeta exposes getLocalisedPageTitles / getLocalisedMetaDescriptions / getLocalisedUrlRewrites
@@ -80,6 +92,13 @@ class Meta
         '[localisedPageTitles]' => '[pageTitles]',
         '[localisedMetaDescriptions]' => '[metaDescriptions]',
         '[localisedUrlRewrites]' => '[urlRewrites]',
+    ];
+
+    // AddMetaCommand expects localisedPageTitle / localisedMetaDescription / localisedRewriteUrls (singular title/description)
+    public const CREATE_COMMAND_MAPPING = [
+        '[pageTitles]' => '[localisedPageTitle]',
+        '[metaDescriptions]' => '[localisedMetaDescription]',
+        '[urlRewrites]' => '[localisedRewriteUrls]',
     ];
 
     // EditMetaCommand expects localisedPageTitles / localisedMetaDescriptions / localisedRewriteUrls

--- a/src/ApiPlatform/Resources/Meta/Meta.php
+++ b/src/ApiPlatform/Resources/Meta/Meta.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Meta;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Meta\Command\EditMetaCommand;
+use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Meta\Exception\MetaNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Meta\Query\GetMetaForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/metas/{metaId}',
+            requirements: ['metaId' => '\d+'],
+            CQRSQuery: GetMetaForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            scopes: ['meta_read'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/metas/{metaId}',
+            requirements: ['metaId' => '\d+'],
+            read: false,
+            CQRSCommand: EditMetaCommand::class,
+            CQRSCommandMapping: self::UPDATE_COMMAND_MAPPING,
+            CQRSQuery: GetMetaForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            scopes: ['meta_write'],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        MetaNotFoundException::class => Response::HTTP_NOT_FOUND,
+        MetaConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class Meta
+{
+    #[ApiProperty(identifier: true)]
+    public int $metaId;
+
+    public string $pageName;
+
+    #[LocalizedValue]
+    public array $pageTitles;
+
+    #[LocalizedValue]
+    public array $metaDescriptions;
+
+    #[LocalizedValue]
+    public array $urlRewrites;
+
+    // EditableMeta exposes getLocalisedPageTitles / getLocalisedMetaDescriptions / getLocalisedUrlRewrites
+    public const QUERY_MAPPING = [
+        '[localisedPageTitles]' => '[pageTitles]',
+        '[localisedMetaDescriptions]' => '[metaDescriptions]',
+        '[localisedUrlRewrites]' => '[urlRewrites]',
+    ];
+
+    // EditMetaCommand expects localisedPageTitles / localisedMetaDescriptions / localisedRewriteUrls
+    public const UPDATE_COMMAND_MAPPING = [
+        '[pageTitles]' => '[localisedPageTitles]',
+        '[metaDescriptions]' => '[localisedMetaDescriptions]',
+        '[urlRewrites]' => '[localisedRewriteUrls]',
+    ];
+}

--- a/src/ApiPlatform/Resources/Meta/MetaLayoutPage.php
+++ b/src/ApiPlatform/Resources/Meta/MetaLayoutPage.php
@@ -39,7 +39,8 @@ class MetaLayoutPage
 {
     public string $page;
 
-    public string $title;
+    // Some pages have no default title/description (notably on PrestaShop 9.0.x)
+    public ?string $title = null;
 
-    public string $description;
+    public ?string $description = null;
 }

--- a/src/ApiPlatform/Resources/Meta/MetaLayoutPage.php
+++ b/src/ApiPlatform/Resources/Meta/MetaLayoutPage.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Meta;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Meta\Query\GetPagesForLayoutCustomization;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/metas/pages',
+            CQRSQuery: GetPagesForLayoutCustomization::class,
+            scopes: ['meta_read'],
+        ),
+    ],
+)]
+class MetaLayoutPage
+{
+    public string $page;
+
+    public string $title;
+
+    public string $description;
+}

--- a/tests/Integration/ApiPlatform/MetaEndpointTest.php
+++ b/tests/Integration/ApiPlatform/MetaEndpointTest.php
@@ -76,13 +76,10 @@ class MetaEndpointTest extends ApiTestCase
 
     public function testAddMeta(): int
     {
-        // Pick a valid page name from the same source AddMeta validates against
-        $pages = $this->getItem('/metas/pages', ['meta_read']);
-        $this->assertNotEmpty($pages);
-        $pageName = $pages[0]['page'];
-
+        // AddMeta only accepts a page that does NOT yet have a meta record.
+        // "newproducts" is a standard controller with no default meta in the fixtures.
         $meta = $this->createItem('/metas', [
-            'pageName' => $pageName,
+            'pageName' => 'newproducts',
             'urlRewrites' => [
                 'en-US' => 'my-custom-meta-page',
                 'fr-FR' => 'ma-page-meta-perso',

--- a/tests/Integration/ApiPlatform/MetaEndpointTest.php
+++ b/tests/Integration/ApiPlatform/MetaEndpointTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Tests\Resources\DatabaseDump;
+
+class MetaEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['meta', 'meta_lang']);
+        self::createApiClient(['meta_write', 'meta_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['meta', 'meta_lang']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get endpoint' => [
+            'GET',
+            '/metas/1',
+        ];
+
+        yield 'update endpoint' => [
+            'PATCH',
+            '/metas/1',
+        ];
+    }
+
+    public function testGetMeta(): void
+    {
+        // Meta id 1 exists in the default fixtures
+        $meta = $this->getItem('/metas/1', ['meta_read']);
+
+        $this->assertSame(1, $meta['metaId']);
+        $this->assertIsString($meta['pageName']);
+        $this->assertIsArray($meta['pageTitles']);
+        $this->assertIsArray($meta['metaDescriptions']);
+        $this->assertIsArray($meta['urlRewrites']);
+    }
+
+    public function testEditMeta(): void
+    {
+        $updated = $this->partialUpdateItem('/metas/1', [
+            'pageTitles' => [
+                'en-US' => 'My Updated Page Title',
+                'fr-FR' => 'Mon titre de page',
+            ],
+        ], ['meta_write']);
+
+        $this->assertSame(
+            [
+                'en-US' => 'My Updated Page Title',
+                'fr-FR' => 'Mon titre de page',
+            ],
+            $updated['pageTitles']
+        );
+        $this->assertSame(1, $updated['metaId']);
+    }
+}

--- a/tests/Integration/ApiPlatform/MetaEndpointTest.php
+++ b/tests/Integration/ApiPlatform/MetaEndpointTest.php
@@ -51,6 +51,48 @@ class MetaEndpointTest extends ApiTestCase
             'PATCH',
             '/metas/1',
         ];
+
+        yield 'create endpoint' => [
+            'POST',
+            '/metas',
+        ];
+
+        yield 'get pages endpoint' => [
+            'GET',
+            '/metas/pages',
+        ];
+    }
+
+    public function testGetPagesForLayout(): void
+    {
+        $pages = $this->getItem('/metas/pages', ['meta_read']);
+
+        $this->assertIsArray($pages);
+        $this->assertNotEmpty($pages);
+        $this->assertArrayHasKey('page', $pages[0]);
+        $this->assertArrayHasKey('title', $pages[0]);
+        $this->assertArrayHasKey('description', $pages[0]);
+    }
+
+    public function testAddMeta(): int
+    {
+        // Pick a valid page name from the same source AddMeta validates against
+        $pages = $this->getItem('/metas/pages', ['meta_read']);
+        $this->assertNotEmpty($pages);
+        $pageName = $pages[0]['page'];
+
+        $meta = $this->createItem('/metas', [
+            'pageName' => $pageName,
+            'urlRewrites' => [
+                'en-US' => 'my-custom-meta-page',
+                'fr-FR' => 'ma-page-meta-perso',
+            ],
+        ], ['meta_write']);
+
+        $this->assertArrayHasKey('metaId', $meta);
+        $this->assertEquals(['metaId' => $meta['metaId']], $meta);
+
+        return $meta['metaId'];
     }
 
     public function testGetMeta(): void

--- a/tests/Integration/ApiPlatform/MetaEndpointTest.php
+++ b/tests/Integration/ApiPlatform/MetaEndpointTest.php
@@ -69,9 +69,9 @@ class MetaEndpointTest extends ApiTestCase
 
         $this->assertIsArray($pages);
         $this->assertNotEmpty($pages);
+        // "page" is always present; title/description may be omitted when null
         $this->assertArrayHasKey('page', $pages[0]);
-        $this->assertArrayHasKey('title', $pages[0]);
-        $this->assertArrayHasKey('description', $pages[0]);
+        $this->assertIsString($pages[0]['page']);
     }
 
     public function testAddMeta(): int


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Meta (SEO) resource to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints for the **Meta** (SEO) domain:

- `POST /metas` — `AddMetaCommand`
- `GET /metas/{metaId}` — `GetMetaForEditing`
- `PATCH /metas/{metaId}` — `EditMetaCommand`
- `GET /metas/pages` — `GetPagesForLayoutCustomization` → pages available for SEO customization

The Meta domain uses several localized field naming conventions across the query result and
the add/edit commands (e.g. `localisedPageTitle` vs `localisedPageTitles`); they are
reconciled behind clean resource fields `pageTitles` / `metaDescriptions` / `urlRewrites`.
Creating a meta requires a `pageName` returned by `GET /metas/pages` and a default-language
url rewrite.

Adds integration tests and the `meta_read` / `meta_write` scopes.