### PR TITLE
Add GET /countries collection listing endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Country/CountryList.php
+++ b/src/ApiPlatform/Resources/Country/CountryList.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Country;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
+use PrestaShop\PrestaShop\Core\Search\Filters\CountryFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+use PrestaShopBundle\ApiPlatform\Provider\QueryListProvider;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/countries',
+            provider: QueryListProvider::class,
+            scopes: ['country_read'],
+            ApiResourceMapping: self::MAPPING,
+            gridDataFactory: 'prestashop.core.grid.data.factory.country',
+            filtersClass: CountryFilters::class,
+            filtersMapping: self::FILTERS_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        CountryNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CountryList
+{
+    #[ApiProperty(identifier: true)]
+    public int $countryId;
+
+    public string $name;
+
+    public string $isoCode;
+
+    public int $callPrefix;
+
+    public string $zoneName;
+
+    public bool $enabled;
+
+    /**
+     * Maps the columns returned by CountryQueryBuilder to the API field names.
+     */
+    public const MAPPING = [
+        '[id_country]' => '[countryId]',
+        '[name]' => '[name]',
+        '[iso_code]' => '[isoCode]',
+        '[call_prefix]' => '[callPrefix]',
+        '[zone_name]' => '[zoneName]',
+        '[active]' => '[enabled]',
+    ];
+
+    /**
+     * Maps the API field names used in filters and orderBy back to the grid filter names.
+     */
+    public const FILTERS_MAPPING = [
+        '[countryId]' => '[id_country]',
+        '[isoCode]' => '[iso_code]',
+        '[callPrefix]' => '[call_prefix]',
+        '[zoneName]' => '[zone_name]',
+        '[enabled]' => '[active]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CountryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CountryEndpointTest.php
@@ -58,6 +58,7 @@ class CountryEndpointTest extends ApiTestCase
         yield 'get endpoint' => ['GET', '/countries/1'];
         yield 'update endpoint' => ['PATCH', '/countries/1'];
         yield 'delete endpoint' => ['DELETE', '/countries/1'];
+        yield 'list endpoint' => ['GET', '/countries'];
     }
 
     public function testAddCountry(): int
@@ -133,12 +134,65 @@ class CountryEndpointTest extends ApiTestCase
     }
 
     /**
+     * @depends testEditCountry
+     */
+    public function testListCountries(int $countryId): int
+    {
+        // Plain listing returns a paginated, structured collection.
+        $countries = $this->listItems('/countries', ['country_read']);
+        $this->assertGreaterThanOrEqual(1, $countries['totalItems']);
+        $this->assertNotEmpty($countries['items']);
+
+        // Filtering by isoCode isolates the country created earlier in this test class.
+        $filtered = $this->listItems('/countries', ['country_read'], ['isoCode' => 'ZZ']);
+        $this->assertEquals(1, $filtered['totalItems']);
+        $this->assertEquals(['isoCode' => 'ZZ'], $filtered['filters']);
+
+        $testCountry = $filtered['items'][0];
+        // testEditCountry left the record with these values (default lang name = en-US).
+        $this->assertEquals($countryId, $testCountry['countryId']);
+        $this->assertEquals('Updated Country EN', $testCountry['name']);
+        $this->assertEquals('ZZ', $testCountry['isoCode']);
+        $this->assertEquals(999, $testCountry['callPrefix']);
+        $this->assertFalse($testCountry['enabled']);
+        // zoneName comes from the zone grid join (z.name); zone 1 always has a name.
+        $this->assertIsString($testCountry['zoneName']);
+        $this->assertNotEmpty($testCountry['zoneName']);
+
+        // Filtering by the boolean status also matches the (disabled) created country.
+        $disabled = $this->listItems('/countries', ['country_read'], ['enabled' => false]);
+        $disabledIds = array_column($disabled['items'], 'countryId');
+        $this->assertContains($countryId, $disabledIds);
+
+        // Sorting parameters are honoured and echoed back in the response.
+        $sorted = $this->listItems('/countries?orderBy=countryId&sortOrder=desc', ['country_read']);
+        $this->assertEquals('countryId', $sorted['orderBy']);
+        $this->assertEquals('desc', $sorted['sortOrder']);
+
+        // Pagination: a single-item first page, then the second page returns a different country.
+        $firstPage = $this->listItems('/countries?limit=1&offset=0&orderBy=countryId&sortOrder=asc', ['country_read']);
+        $this->assertCount(1, $firstPage['items']);
+        $this->assertEquals(1, $firstPage['limit']);
+        $this->assertEquals($countries['totalItems'], $firstPage['totalItems']);
+
+        $secondPage = $this->listItems('/countries?limit=1&offset=1&orderBy=countryId&sortOrder=asc', ['country_read']);
+        $this->assertCount(1, $secondPage['items']);
+        $this->assertNotEquals(
+            $firstPage['items'][0]['countryId'],
+            $secondPage['items'][0]['countryId']
+        );
+
+        return $countryId;
+    }
+
+    /**
      * Order-critical: must run after every other test that needs the created
      * country alive. The validation tests below also chain off testGetCountry
      * and PATCH the same record, so listing them here forces PHPUnit to
      * schedule the delete last.
      *
      * @depends testEditCountry
+     * @depends testListCountries
      * @depends testAddCountryWithInvalidAddressFormat
      * @depends testEditCountryWithInvalidAddressFormat
      */

--- a/tests/Integration/ApiPlatform/CountryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CountryEndpointTest.php
@@ -159,10 +159,15 @@ class CountryEndpointTest extends ApiTestCase
         $this->assertIsString($testCountry['zoneName']);
         $this->assertNotEmpty($testCountry['zoneName']);
 
-        // Filtering by the boolean status also matches the (disabled) created country.
-        $disabled = $this->listItems('/countries', ['country_read'], ['enabled' => false]);
+        // Filtering by the boolean status (combined with isoCode to avoid relying
+        // on the default pagination window) matches the disabled created country.
+        $disabled = $this->listItems('/countries', ['country_read'], ['isoCode' => 'ZZ', 'enabled' => false]);
+        $this->assertNotEmpty($disabled['items']);
         $disabledIds = array_column($disabled['items'], 'countryId');
         $this->assertContains($countryId, $disabledIds);
+        foreach ($disabled['items'] as $disabledCountry) {
+            $this->assertFalse($disabledCountry['enabled']);
+        }
 
         // Sorting parameters are honoured and echoed back in the response.
         $sorted = $this->listItems('/countries?orderBy=countryId&sortOrder=desc', ['country_read']);


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds the `GET /countries` collection listing endpoint to complete the Country CRUD + listing surface in the Admin API. A new `CountryList` API resource exposes a paginated, filterable and sortable list of countries, backed by the existing `CountryGridDataFactory` (`prestashop.core.grid.data.factory.country`) and the existing `country_read` scope. Exposed fields mirror the columns returned by `CountryQueryBuilder`: `countryId`, `name`, `isoCode`, `callPrefix`, `zoneName`, `enabled`.
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes PrestaShop/PrestaShop#41676
| Sponsor company   | PrestaShop
| How to test?      | See below.

### How to test

1. On your `admin-api` Swagger UI, authenticate with a client holding the `country_read` scope.
2. Call `GET /countries` — it returns a paginated collection (`totalItems`, `items`, `limit`, `offset`, `orderBy`, `sortOrder`, `filters`) of countries with the fields `countryId`, `name`, `isoCode`, `callPrefix`, `zoneName`, `enabled`.
3. Filtering: `filters[isoCode]=FR`, `filters[name]=...`, `filters[enabled]=0` — results match the BO Countries grid.
4. Sorting: `orderBy=countryId&sortOrder=desc` — the response echoes `orderBy`/`sortOrder` and the order is applied.
5. Pagination: `limit=1&offset=1` returns the second page.
6. A client **without** `country_read` receives `403`.

Automated coverage lives in `tests/Integration/ApiPlatform/CountryEndpointTest.php` (`testListCountries` + the `list endpoint` protected-route case):

```bash
composer run-module-tests -- --filter CountryEndpointTest
```

### Notes

- Follows the existing `PaginatedList` pattern used by every list resource in this module (e.g. `ZoneList`), which uses `QueryListProvider` under the hood — equivalent to the `CQRSGetCollection` described in the issue. No custom processor.
- The issue proposed a `zoneId` field, but `CountryQueryBuilder` selects `z.name as zone_name` (the zone *name*, not its id). The resource therefore exposes `zoneName`, in line with the "field names must match the query columns" rule.
- The boolean status field is named `enabled` for consistency with the existing `Country` resource and the module's naming convention.

Refs tracking issue PrestaShop/PrestaShop#39630 (Domain: Country).

🤖 Generated with [Claude Code](https://claude.com/claude-code)