### PR TITLE
Add Shop search endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Shop/FoundShop.php
+++ b/src/ApiPlatform/Resources/Shop/FoundShop.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Shop;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Query\SearchShops;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/shops/search',
+            CQRSQuery: SearchShops::class,
+            scopes: ['shop_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'searchTerm',
+                    required: true,
+                    description: 'Search term to find shops and shop groups by name'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    [
+                        'name' => 'searchTerm',
+                        'in' => 'query',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                        'description' => 'Search term to find shops and shop groups by name',
+                    ],
+                ],
+            ],
+        ),
+    ],
+)]
+class FoundShop
+{
+    #[ApiProperty(identifier: true)]
+    public int $id;
+
+    public string $color;
+
+    public string $name;
+
+    // Only present for shop rows (shop-group rows omit these)
+    public ?int $groupId = null;
+
+    public ?string $groupName = null;
+
+    public ?string $groupColor = null;
+
+    public const QUERY_MAPPING = [
+        '[searchTerm]' => '[searchTerm]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/ShopEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ShopEndpointTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ShopEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['shop_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'search endpoint' => [
+            'GET',
+            '/shops/search?searchTerm=shop',
+        ];
+    }
+
+    public function testSearchShops(): void
+    {
+        $results = $this->getItem('/shops/search?searchTerm=shop', ['shop_read']);
+
+        $this->assertIsArray($results);
+        // The result mixes shop-group rows and shop rows; every row exposes id/color/name
+        foreach ($results as $result) {
+            $this->assertArrayHasKey('id', $result);
+            $this->assertArrayHasKey('color', $result);
+            $this->assertArrayHasKey('name', $result);
+        }
+    }
+
+    public function testSearchShopsWithNoResults(): void
+    {
+        $results = $this->getItem('/shops/search?searchTerm=nonexistentshop999', ['shop_read']);
+
+        $this->assertIsArray($results);
+        $this->assertEmpty($results);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Shop search endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `SearchShops` through **`GET /shops/search?searchTerm=...`**, returning the shop
groups and shops matching the term (the same data used by the back-office shop selector).
Implemented as a `CQRSGetCollection`, like the cart-rules search.

The query result mixes shop-group rows (`{id, color, name}`) and shop rows (which also carry
`groupId` / `groupName` / `groupColor`), represented by a single resource whose `group*`
fields are nullable.

Adds an integration test and the `shop_read` scope.
