### PR TITLE
Add ImageType resource

### DIFF
--- a/src/ApiPlatform/Resources/ImageType/BulkDeleteImageTypes.php
+++ b/src/ApiPlatform/Resources/ImageType/BulkDeleteImageTypes.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\ImageType;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\BulkDeleteImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/image-types/bulk-delete',
+            CQRSCommand: BulkDeleteImageTypeCommand::class,
+            scopes: [
+                'image_type_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        ImageTypeNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteImageTypes
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $imageTypeIds;
+}

--- a/src/ApiPlatform/Resources/ImageType/ImageType.php
+++ b/src/ApiPlatform/Resources/ImageType/ImageType.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\ImageType;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\AddImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\EditImageTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageTypeForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/image-types',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddImageTypeCommand::class,
+            scopes: ['image_type_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/image-types/{imageTypeId}',
+            requirements: ['imageTypeId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteImageTypeCommand::class,
+            scopes: ['image_type_write'],
+        ),
+        new CQRSGet(
+            uriTemplate: '/image-types/{imageTypeId}',
+            requirements: ['imageTypeId' => '\d+'],
+            CQRSQuery: GetImageTypeForEditing::class,
+            scopes: ['image_type_read'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/image-types/{imageTypeId}',
+            requirements: ['imageTypeId' => '\d+'],
+            read: false,
+            CQRSCommand: EditImageTypeCommand::class,
+            CQRSQuery: GetImageTypeForEditing::class,
+            scopes: ['image_type_write'],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        ImageTypeNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ImageTypeException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ImageType
+{
+    #[ApiProperty(identifier: true)]
+    public int $imageTypeId;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $name;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    #[Assert\Positive(groups: ['Create'])]
+    public int $width;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    #[Assert\Positive(groups: ['Create'])]
+    public int $height;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $products;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $categories;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $manufacturers;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $suppliers;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $stores;
+}

--- a/tests/Integration/ApiPlatform/ImageTypeEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ImageTypeEndpointTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class ImageTypeEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['image_type']);
+        self::createApiClient(['image_type_write', 'image_type_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['image_type']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => ['POST', '/image-types'];
+        yield 'get endpoint' => ['GET', '/image-types/1'];
+        yield 'update endpoint' => ['PATCH', '/image-types/1'];
+        yield 'delete endpoint' => ['DELETE', '/image-types/1'];
+        yield 'bulk delete endpoint' => ['DELETE', '/image-types/bulk-delete'];
+    }
+
+    private function createPayload(string $name): array
+    {
+        return [
+            'name' => $name,
+            'width' => 120,
+            'height' => 90,
+            'products' => true,
+            'categories' => false,
+            'manufacturers' => false,
+            'suppliers' => false,
+            'stores' => false,
+        ];
+    }
+
+    public function testAddImageType(): int
+    {
+        $imageType = $this->createItem('/image-types', $this->createPayload('my_custom_type'), ['image_type_write']);
+
+        $this->assertArrayHasKey('imageTypeId', $imageType);
+        $imageTypeId = $imageType['imageTypeId'];
+        $this->assertEquals(['imageTypeId' => $imageTypeId], $imageType);
+
+        return $imageTypeId;
+    }
+
+    /**
+     * @depends testAddImageType
+     */
+    public function testGetImageType(int $imageTypeId): int
+    {
+        $imageType = $this->getItem('/image-types/' . $imageTypeId, ['image_type_read']);
+        $this->assertEquals(
+            [
+                'imageTypeId' => $imageTypeId,
+                'name' => 'my_custom_type',
+                'width' => 120,
+                'height' => 90,
+                'products' => true,
+                'categories' => false,
+                'manufacturers' => false,
+                'suppliers' => false,
+                'stores' => false,
+            ],
+            $imageType
+        );
+
+        return $imageTypeId;
+    }
+
+    /**
+     * @depends testGetImageType
+     */
+    public function testEditImageType(int $imageTypeId): int
+    {
+        $updated = $this->partialUpdateItem('/image-types/' . $imageTypeId, [
+            'width' => 200,
+            'categories' => true,
+        ], ['image_type_write']);
+
+        $this->assertSame(200, $updated['width']);
+        $this->assertTrue($updated['categories']);
+        $this->assertSame(90, $updated['height']);
+
+        return $imageTypeId;
+    }
+
+    /**
+     * @depends testEditImageType
+     */
+    public function testDeleteImageType(int $imageTypeId): void
+    {
+        $return = $this->deleteItem('/image-types/' . $imageTypeId, ['image_type_write']);
+        $this->assertNull($return);
+
+        $this->getItem('/image-types/' . $imageTypeId, ['image_type_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testBulkDeleteImageTypes(): void
+    {
+        $firstId = $this->createItem('/image-types', $this->createPayload('bulk_type_1'), ['image_type_write'])['imageTypeId'];
+        $secondId = $this->createItem('/image-types', $this->createPayload('bulk_type_2'), ['image_type_write'])['imageTypeId'];
+
+        $this->bulkDeleteItems('/image-types/bulk-delete', [
+            'imageTypeIds' => [$firstId, $secondId],
+        ], ['image_type_write']);
+
+        $this->getItem('/image-types/' . $firstId, ['image_type_read'], Response::HTTP_NOT_FOUND);
+        $this->getItem('/image-types/' . $secondId, ['image_type_read'], Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the ImageType resource (CRUD) to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints for **image types** (Image Settings):

- `POST /image-types` — `AddImageTypeCommand`
- `GET /image-types/{imageTypeId}` — `GetImageTypeForEditing`
- `PATCH /image-types/{imageTypeId}` — `EditImageTypeCommand`
- `DELETE /image-types/{imageTypeId}` — `DeleteImageTypeCommand`
- `DELETE /image-types/bulk-delete` — `BulkDeleteImageTypeCommand`

An image type has a `name`, `width`/`height` and the entity flags it applies to
(`products`, `categories`, `manufacturers`, `suppliers`, `stores`). All fields are scalar
and match the CQRS command/query names, so no mapping is needed.

Adds an integration test covering the full CRUD + bulk delete, and the
`image_type_read` / `image_type_write` scopes.
