### PR TITLE
Allow product images to be uploaded via the Swagger documentation

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductImage.php
+++ b/src/ApiPlatform/Resources/Product/ProductImage.php
@@ -32,6 +32,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 
@@ -39,6 +40,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
     operations: [
         new CQRSGet(
             uriTemplate: '/products/images/{imageId}',
+            requirements: ['imageId' => '\d+'],
             CQRSQuery: GetProductImage::class,
             scopes: [
                 'product_read',
@@ -49,6 +51,7 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
             // We have to force POST request, because we cannot use PUT with files AND data
             method: CQRSUpdate::METHOD_POST,
             uriTemplate: '/products/images/{imageId}',
+            requirements: ['imageId' => '\d+'],
             inputFormats: ['multipart' => ['multipart/form-data']],
             status: Response::HTTP_OK,
             // Form data value are all string so we disable type enforcement
@@ -59,15 +62,11 @@ use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
                 'product_write',
             ],
             CQRSQueryMapping: ProductImage::QUERY_MAPPING,
-            CQRSCommandMapping: [
-                '[_context][shopConstraint]' => '[shopConstraint]',
-                '[image].pathName' => '[filePath]',
-                '[legends]' => '[localizedLegends]',
-                '[cover]' => '[isCover]',
-            ]
+            CQRSCommandMapping: ProductImage::COMMAND_MAPPING,
         ),
         new CQRSDelete(
             uriTemplate: '/products/images/{imageId}',
+            requirements: ['imageId' => '\d+'],
             CQRSCommand: DeleteProductImageCommand::class,
         ),
     ],
@@ -93,8 +92,17 @@ class ProductImage
 
     public array $shopIds;
 
+    public File $image;
+
     public const QUERY_MAPPING = [
         '[_context][shopConstraint]' => '[shopConstraint]',
         '[localizedLegends]' => '[legends]',
+    ];
+
+    public const COMMAND_MAPPING = [
+        '[_context][shopConstraint]' => '[shopConstraint]',
+        '[image].pathName' => '[filePath]',
+        '[legends]' => '[localizedLegends]',
+        '[cover]' => '[isCover]',
     ];
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When looking at the input that updates an existing product image, no file input was shown on the Swagger documentation page, even though it is already covered by the unit tests. This PR adds it.
| Type?             |improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | /
| Sponsor company   | @PrestaShopCorp
| How to test?      | You need to test with this PR applied on the Core: https://github.com/PrestaShop/PrestaShop/pull/41701. Open the Swagger API and upload a new image for an existing image. The image must be successfully replaced by checking the product page on the backoffice.

<img width="1140" height="925" alt="image" src="https://github.com/user-attachments/assets/b51b623b-6d4a-430f-a811-d1d0ad972f9f" />
