### PR TITLE
Add API client force-secret endpoint

### DIFF
--- a/src/ApiPlatform/Resources/ApiClient/ApiClient.php
+++ b/src/ApiPlatform/Resources/ApiClient/ApiClient.php
@@ -73,6 +73,7 @@ use Symfony\Component\Validator\Constraints as Assert;
         new CQRSUpdate(
             uriTemplate: '/api-clients/{apiClientId}/secrets',
             requirements: ['apiClientId' => '\d+'],
+            allowEmptyBody: true,
             CQRSCommand: GenerateApiClientSecretCommand::class,
             CQRSQueryMapping: [
                 '[_queryResult]' => '[secret]',

--- a/src/ApiPlatform/Resources/ApiClient/ApiClient.php
+++ b/src/ApiPlatform/Resources/ApiClient/ApiClient.php
@@ -28,6 +28,8 @@ use PrestaShop\PrestaShop\Core\Domain\ApiClient\ApiClientSettings;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\AddApiClientCommand;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\DeleteApiClientCommand;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\EditApiClientCommand;
+use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\ForceApiClientSecretCommand;
+use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\GenerateApiClientSecretCommand;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Exception\ApiClientConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Exception\ApiClientNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Query\GetApiClientForEditing;
@@ -35,6 +37,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -65,6 +68,25 @@ use Symfony\Component\Validator\Constraints as Assert;
             CQRSCommand: EditApiClientCommand::class,
             CQRSQuery: GetApiClientForEditing::class,
             scopes: ['api_client_write']
+        ),
+        // Regenerate the secret: returns the newly generated secret
+        new CQRSUpdate(
+            uriTemplate: '/api-clients/{apiClientId}/secrets',
+            requirements: ['apiClientId' => '\d+'],
+            CQRSCommand: GenerateApiClientSecretCommand::class,
+            CQRSQueryMapping: [
+                '[_queryResult]' => '[secret]',
+            ],
+            scopes: ['api_client_write'],
+        ),
+        // Force a specific secret value (no content returned)
+        new CQRSPartialUpdate(
+            uriTemplate: '/api-clients/{apiClientId}/secrets',
+            requirements: ['apiClientId' => '\d+'],
+            read: false,
+            output: false,
+            CQRSCommand: ForceApiClientSecretCommand::class,
+            scopes: ['api_client_write'],
         ),
     ],
     normalizationContext: ['skip_null_values' => false],

--- a/src/ApiPlatform/Resources/ApiClient/ApiClient.php
+++ b/src/ApiPlatform/Resources/ApiClient/ApiClient.php
@@ -29,7 +29,6 @@ use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\AddApiClientCommand;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\DeleteApiClientCommand;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\EditApiClientCommand;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\ForceApiClientSecretCommand;
-use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\GenerateApiClientSecretCommand;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Exception\ApiClientConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Exception\ApiClientNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\ApiClient\Query\GetApiClientForEditing;
@@ -37,7 +36,6 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
-use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -69,18 +67,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             CQRSQuery: GetApiClientForEditing::class,
             scopes: ['api_client_write']
         ),
-        // Regenerate the secret: returns the newly generated secret
-        new CQRSUpdate(
-            uriTemplate: '/api-clients/{apiClientId}/secrets',
-            requirements: ['apiClientId' => '\d+'],
-            allowEmptyBody: true,
-            CQRSCommand: GenerateApiClientSecretCommand::class,
-            CQRSQueryMapping: [
-                '[_queryResult]' => '[secret]',
-            ],
-            scopes: ['api_client_write'],
-        ),
-        // Force a specific secret value (no content returned)
+        // Set a specific secret value (no content returned)
         new CQRSPartialUpdate(
             uriTemplate: '/api-clients/{apiClientId}/secrets',
             requirements: ['apiClientId' => '\d+'],

--- a/tests/Integration/ApiPlatform/ApiClientEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ApiClientEndpointTest.php
@@ -62,11 +62,6 @@ class ApiClientEndpointTest extends ApiTestCase
             '/api-clients',
         ];
 
-        yield 'generate secret endpoint' => [
-            'PUT',
-            '/api-clients/1/secrets',
-        ];
-
         yield 'force secret endpoint' => [
             'PATCH',
             '/api-clients/1/secrets',
@@ -110,24 +105,9 @@ class ApiClientEndpointTest extends ApiTestCase
     /**
      * @depends testAddApiClient
      */
-    public function testGenerateApiClientSecret(int $apiClientId): int
-    {
-        $response = $this->updateItem('/api-clients/' . $apiClientId . '/secrets', [], ['api_client_write']);
-
-        // Regenerating returns the new secret
-        $this->assertArrayHasKey('secret', $response);
-        $this->assertIsString($response['secret']);
-        $this->assertNotEmpty($response['secret']);
-
-        return $apiClientId;
-    }
-
-    /**
-     * @depends testGenerateApiClientSecret
-     */
     public function testForceApiClientSecret(int $apiClientId): void
     {
-        // Forcing a specific secret returns an empty 204 response
+        // Setting a specific secret returns an empty 204 response
         $return = $this->partialUpdateItem(
             '/api-clients/' . $apiClientId . '/secrets',
             ['secret' => 'ForcedSecretValue1234567890abcdef'],

--- a/tests/Integration/ApiPlatform/ApiClientEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ApiClientEndpointTest.php
@@ -61,6 +61,16 @@ class ApiClientEndpointTest extends ApiTestCase
             'GET',
             '/api-clients',
         ];
+
+        yield 'generate secret endpoint' => [
+            'PUT',
+            '/api-clients/1/secrets',
+        ];
+
+        yield 'force secret endpoint' => [
+            'PATCH',
+            '/api-clients/1/secrets',
+        ];
     }
 
     public function testAddApiClient(): int
@@ -95,6 +105,36 @@ class ApiClientEndpointTest extends ApiTestCase
         $this->assertEquals($itemsCount + 1, $newItemsCount);
 
         return $apiClientId;
+    }
+
+    /**
+     * @depends testAddApiClient
+     */
+    public function testGenerateApiClientSecret(int $apiClientId): int
+    {
+        $response = $this->updateItem('/api-clients/' . $apiClientId . '/secrets', [], ['api_client_write']);
+
+        // Regenerating returns the new secret
+        $this->assertArrayHasKey('secret', $response);
+        $this->assertIsString($response['secret']);
+        $this->assertNotEmpty($response['secret']);
+
+        return $apiClientId;
+    }
+
+    /**
+     * @depends testGenerateApiClientSecret
+     */
+    public function testForceApiClientSecret(int $apiClientId): void
+    {
+        // Forcing a specific secret returns an empty 204 response
+        $return = $this->partialUpdateItem(
+            '/api-clients/' . $apiClientId . '/secrets',
+            ['secret' => 'ForcedSecretValue1234567890abcdef'],
+            ['api_client_write'],
+            Response::HTTP_NO_CONTENT
+        );
+        $this->assertNull($return);
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the API client force-secret endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`PATCH /api-clients/{apiClientId}/secrets`** — `ForceApiClientSecretCommand`: sets a
specific secret value for an API client (`204`, no content).

Note: the *regenerate* secret operation (`GenerateApiClientSecretCommand`) is intentionally
left out — that command returns a scalar string, which the CQRS `CommandProcessor` cannot
map back into the response (it `array_merge`s the normalized command result, which fails on
a scalar). Returning the regenerated secret would require the core command to return an
object; happy to follow up on that separately.

Adds an integration test and reuses the `api_client_write` scope.