### PR TITLE
Add Customer required-fields endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Customer/CustomerRequiredFields.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerRequiredFields.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetRequiredFieldsForCustomerCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/customers/required-fields',
+            output: false,
+            CQRSCommand: SetRequiredFieldsForCustomerCommand::class,
+            scopes: ['customer_write'],
+        ),
+    ],
+)]
+class CustomerRequiredFields
+{
+    /**
+     * The customer fields that should be required (e.g. "company", "siret").
+     *
+     * @var string[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'string'], 'example' => ['company', 'siret']])]
+    public array $requiredFields;
+}

--- a/src/ApiPlatform/Resources/Customer/CustomerRequiredFields.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerRequiredFields.php
@@ -25,7 +25,10 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetRequiredFieldsForCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CannotSetRequiredFieldsForCustomerException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\InvalidCustomerRequiredFieldsException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
 
 #[ApiResource(
     operations: [
@@ -36,6 +39,10 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
             scopes: ['customer_write'],
         ),
     ],
+    exceptionToStatus: [
+        InvalidCustomerRequiredFieldsException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CannotSetRequiredFieldsForCustomerException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
 )]
 class CustomerRequiredFields
 {
@@ -45,5 +52,5 @@ class CustomerRequiredFields
      * @var string[]
      */
     #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'string'], 'example' => ['company', 'siret']])]
-    public array $requiredFields;
+    public array $requiredFields = [];
 }

--- a/src/ApiPlatform/Resources/Customer/CustomerRequiredFields.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerRequiredFields.php
@@ -47,10 +47,10 @@ use Symfony\Component\HttpFoundation\Response;
 class CustomerRequiredFields
 {
     /**
-     * The customer fields that should be required (e.g. "company", "siret").
+     * The customer fields that should be required (e.g. "optin", "newsletter").
      *
      * @var string[]
      */
-    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'string'], 'example' => ['company', 'siret']])]
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'string'], 'example' => ['optin', 'newsletter']])]
     public array $requiredFields = [];
 }

--- a/tests/Integration/ApiPlatform/CustomerRequiredFieldsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerRequiredFieldsEndpointTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CustomerRequiredFieldsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['required_field']);
+        self::createApiClient(['customer_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['required_field']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set required fields endpoint' => [
+            'PUT',
+            '/customers/required-fields',
+        ];
+    }
+
+    public function testSetCustomerRequiredFields(): void
+    {
+        // Setting an empty list clears the required fields - a valid, side-effect-safe value
+        $return = $this->updateItem(
+            '/customers/required-fields',
+            ['requiredFields' => []],
+            ['customer_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $this->assertNull($return);
+    }
+}

--- a/tests/Integration/ApiPlatform/CustomerRequiredFieldsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerRequiredFieldsEndpointTest.php
@@ -51,14 +51,28 @@ class CustomerRequiredFieldsEndpointTest extends ApiTestCase
 
     public function testSetCustomerRequiredFields(): void
     {
-        // Setting an empty list clears the required fields - a valid, side-effect-safe value
-        $return = $this->updateItem(
+        $this->updateItem(
             '/customers/required-fields',
-            ['requiredFields' => []],
+            ['requiredFields' => ['company']],
             ['customer_write'],
             Response::HTTP_NO_CONTENT
         );
 
-        $this->assertNull($return);
+        $storedFields = \Db::getInstance()->executeS(
+            'SELECT `field_name` FROM `' . _DB_PREFIX_ . "required_field` WHERE `object_name` = 'Customer'"
+        );
+        $fieldNames = array_column($storedFields ?: [], 'field_name');
+
+        $this->assertContains('company', $fieldNames);
+    }
+
+    public function testSetInvalidCustomerRequiredFieldIsRejected(): void
+    {
+        $this->updateItem(
+            '/customers/required-fields',
+            ['requiredFields' => ['not_a_valid_field']],
+            ['customer_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
     }
 }

--- a/tests/Integration/ApiPlatform/CustomerRequiredFieldsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerRequiredFieldsEndpointTest.php
@@ -53,7 +53,7 @@ class CustomerRequiredFieldsEndpointTest extends ApiTestCase
     {
         $this->updateItem(
             '/customers/required-fields',
-            ['requiredFields' => ['company']],
+            ['requiredFields' => ['newsletter']],
             ['customer_write'],
             Response::HTTP_NO_CONTENT
         );
@@ -63,7 +63,7 @@ class CustomerRequiredFieldsEndpointTest extends ApiTestCase
         );
         $fieldNames = array_column($storedFields ?: [], 'field_name');
 
-        $this->assertContains('company', $fieldNames);
+        $this->assertContains('newsletter', $fieldNames);
     }
 
     public function testSetInvalidCustomerRequiredFieldIsRejected(): void


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Customer required-fields endpoint to the Admin API
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Exposes `SetRequiredFieldsForCustomerCommand` through **`PUT /customers/required-fields`**,
which sets the list of customer fields that must be required (body: `requiredFields`). An
empty array clears them.

Adds an integration test (in its own class to isolate the global config change) and reuses
the `customer_write` scope.
