### PR TITLE
Add SqlRequest single edit & delete endpoints

### DIFF
--- a/src/ApiPlatform/Resources/SqlRequest/BulkDeleteSqlRequests.php
+++ b/src/ApiPlatform/Resources/SqlRequest/BulkDeleteSqlRequests.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SqlRequest;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\BulkDeleteSqlRequestCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/sql-requests/bulk-delete',
+            CQRSCommand: BulkDeleteSqlRequestCommand::class,
+            scopes: [
+                'sql_management_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        SqlRequestNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteSqlRequests
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $sqlRequestIds;
+}

--- a/src/ApiPlatform/Resources/SqlRequest/SqlRequest.php
+++ b/src/ApiPlatform/Resources/SqlRequest/SqlRequest.php
@@ -25,15 +25,11 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SqlRequest;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\AddSqlRequestCommand;
-use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\DeleteSqlRequestCommand;
-use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\EditSqlRequestCommand;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetSqlRequestForEditing;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
-use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
-use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -45,28 +41,11 @@ use Symfony\Component\Validator\Constraints as Assert;
             CQRSCommand: AddSqlRequestCommand::class,
             scopes: ['sql_management_write'],
         ),
-        new CQRSDelete(
-            uriTemplate: '/sql-requests/{sqlRequestId}',
-            requirements: ['sqlRequestId' => '\d+'],
-            output: false,
-            CQRSCommand: DeleteSqlRequestCommand::class,
-            scopes: ['sql_management_write'],
-        ),
         new CQRSGet(
             uriTemplate: '/sql-requests/{sqlRequestId}',
             requirements: ['sqlRequestId' => '\d+'],
             CQRSQuery: GetSqlRequestForEditing::class,
             scopes: ['sql_management_read'],
-            CQRSQueryMapping: self::QUERY_MAPPING,
-            ApiResourceMapping: self::RESOURCE_MAPPING,
-        ),
-        new CQRSPartialUpdate(
-            uriTemplate: '/sql-requests/{sqlRequestId}',
-            requirements: ['sqlRequestId' => '\d+'],
-            read: false,
-            CQRSCommand: EditSqlRequestCommand::class,
-            CQRSQuery: GetSqlRequestForEditing::class,
-            scopes: ['sql_management_write'],
             CQRSQueryMapping: self::QUERY_MAPPING,
             ApiResourceMapping: self::RESOURCE_MAPPING,
         ),

--- a/src/ApiPlatform/Resources/SqlRequest/SqlRequest.php
+++ b/src/ApiPlatform/Resources/SqlRequest/SqlRequest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SqlRequest;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\AddSqlRequestCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\DeleteSqlRequestCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\EditSqlRequestCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetSqlRequestForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/sql-requests',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddSqlRequestCommand::class,
+            scopes: ['sql_management_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/sql-requests/{sqlRequestId}',
+            requirements: ['sqlRequestId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteSqlRequestCommand::class,
+            scopes: ['sql_management_write'],
+        ),
+        new CQRSGet(
+            uriTemplate: '/sql-requests/{sqlRequestId}',
+            requirements: ['sqlRequestId' => '\d+'],
+            CQRSQuery: GetSqlRequestForEditing::class,
+            scopes: ['sql_management_read'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/sql-requests/{sqlRequestId}',
+            requirements: ['sqlRequestId' => '\d+'],
+            read: false,
+            CQRSCommand: EditSqlRequestCommand::class,
+            CQRSQuery: GetSqlRequestForEditing::class,
+            scopes: ['sql_management_write'],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        SqlRequestNotFoundException::class => Response::HTTP_NOT_FOUND,
+        SqlRequestConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class SqlRequest
+{
+    #[ApiProperty(identifier: true)]
+    public int $sqlRequestId;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $name;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $sql;
+}

--- a/src/ApiPlatform/Resources/SqlRequest/SqlRequest.php
+++ b/src/ApiPlatform/Resources/SqlRequest/SqlRequest.php
@@ -57,6 +57,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             requirements: ['sqlRequestId' => '\d+'],
             CQRSQuery: GetSqlRequestForEditing::class,
             scopes: ['sql_management_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            ApiResourceMapping: self::RESOURCE_MAPPING,
         ),
         new CQRSPartialUpdate(
             uriTemplate: '/sql-requests/{sqlRequestId}',
@@ -65,6 +67,8 @@ use Symfony\Component\Validator\Constraints as Assert;
             CQRSCommand: EditSqlRequestCommand::class,
             CQRSQuery: GetSqlRequestForEditing::class,
             scopes: ['sql_management_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            ApiResourceMapping: self::RESOURCE_MAPPING,
         ),
     ],
     normalizationContext: ['skip_null_values' => false],
@@ -83,4 +87,20 @@ class SqlRequest
 
     #[Assert\NotBlank(groups: ['Create'])]
     public string $sql;
+
+    /**
+     * GetSqlRequestForEditing expects a $requestSqlId constructor argument (legacy naming),
+     * so the sqlRequestId URI variable must be renamed when the query is built.
+     */
+    public const QUERY_MAPPING = [
+        '[sqlRequestId]' => '[requestSqlId]',
+    ];
+
+    /**
+     * The query mapping above also renames the query result key, so map it back to the
+     * sqlRequestId resource identifier when denormalizing the response.
+     */
+    public const RESOURCE_MAPPING = [
+        '[requestSqlId]' => '[sqlRequestId]',
+    ];
 }

--- a/src/ApiPlatform/Resources/SqlRequest/SqlRequest.php
+++ b/src/ApiPlatform/Resources/SqlRequest/SqlRequest.php
@@ -25,11 +25,15 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SqlRequest;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\AddSqlRequestCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\DeleteSqlRequestCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\EditSqlRequestCommand;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetSqlRequestForEditing;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -48,6 +52,23 @@ use Symfony\Component\Validator\Constraints as Assert;
             scopes: ['sql_management_read'],
             CQRSQueryMapping: self::QUERY_MAPPING,
             ApiResourceMapping: self::RESOURCE_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/sql-requests/{sqlRequestId}',
+            requirements: ['sqlRequestId' => '\d+'],
+            read: false,
+            CQRSCommand: EditSqlRequestCommand::class,
+            CQRSQuery: GetSqlRequestForEditing::class,
+            scopes: ['sql_management_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            ApiResourceMapping: self::RESOURCE_MAPPING,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/sql-requests/{sqlRequestId}',
+            requirements: ['sqlRequestId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteSqlRequestCommand::class,
+            scopes: ['sql_management_write'],
         ),
     ],
     normalizationContext: ['skip_null_values' => false],

--- a/tests/Integration/ApiPlatform/SqlRequestEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SqlRequestEndpointTest.php
@@ -50,6 +50,8 @@ class SqlRequestEndpointTest extends ApiTestCase
     {
         yield 'create endpoint' => ['POST', '/sql-requests'];
         yield 'get endpoint' => ['GET', '/sql-requests/1'];
+        yield 'update endpoint' => ['PATCH', '/sql-requests/1'];
+        yield 'delete endpoint' => ['DELETE', '/sql-requests/1'];
         yield 'bulk delete endpoint' => ['DELETE', '/sql-requests/bulk-delete'];
     }
 
@@ -83,6 +85,32 @@ class SqlRequestEndpointTest extends ApiTestCase
         );
 
         return $sqlRequestId;
+    }
+
+    /**
+     * @depends testGetSqlRequest
+     */
+    public function testEditSqlRequest(int $sqlRequestId): int
+    {
+        $updated = $this->partialUpdateItem('/sql-requests/' . $sqlRequestId, [
+            'name' => 'My SQL Request Updated',
+        ], ['sql_management_write']);
+
+        $this->assertSame('My SQL Request Updated', $updated['name']);
+        $this->assertSame($this->validSql(), $updated['sql']);
+
+        return $sqlRequestId;
+    }
+
+    /**
+     * @depends testEditSqlRequest
+     */
+    public function testDeleteSqlRequest(int $sqlRequestId): void
+    {
+        $return = $this->deleteItem('/sql-requests/' . $sqlRequestId, ['sql_management_write']);
+        $this->assertNull($return);
+
+        $this->getItem('/sql-requests/' . $sqlRequestId, ['sql_management_read'], Response::HTTP_NOT_FOUND);
     }
 
     public function testBulkDeleteSqlRequests(): void

--- a/tests/Integration/ApiPlatform/SqlRequestEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SqlRequestEndpointTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class SqlRequestEndpointTest extends ApiTestCase
+{
+    private function validSql(): string
+    {
+        return 'SELECT id_shop FROM ' . _DB_PREFIX_ . 'shop';
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['request_sql']);
+        self::createApiClient(['sql_management_write', 'sql_management_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['request_sql']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => ['POST', '/sql-requests'];
+        yield 'get endpoint' => ['GET', '/sql-requests/1'];
+        yield 'update endpoint' => ['PATCH', '/sql-requests/1'];
+        yield 'delete endpoint' => ['DELETE', '/sql-requests/1'];
+        yield 'bulk delete endpoint' => ['DELETE', '/sql-requests/bulk-delete'];
+    }
+
+    public function testAddSqlRequest(): int
+    {
+        $sqlRequest = $this->createItem('/sql-requests', [
+            'name' => 'My SQL Request',
+            'sql' => $this->validSql(),
+        ], ['sql_management_write']);
+
+        $this->assertArrayHasKey('sqlRequestId', $sqlRequest);
+        $sqlRequestId = $sqlRequest['sqlRequestId'];
+        $this->assertEquals(['sqlRequestId' => $sqlRequestId], $sqlRequest);
+
+        return $sqlRequestId;
+    }
+
+    /**
+     * @depends testAddSqlRequest
+     */
+    public function testGetSqlRequest(int $sqlRequestId): int
+    {
+        $sqlRequest = $this->getItem('/sql-requests/' . $sqlRequestId, ['sql_management_read']);
+        $this->assertEquals(
+            [
+                'sqlRequestId' => $sqlRequestId,
+                'name' => 'My SQL Request',
+                'sql' => $this->validSql(),
+            ],
+            $sqlRequest
+        );
+
+        return $sqlRequestId;
+    }
+
+    /**
+     * @depends testGetSqlRequest
+     */
+    public function testEditSqlRequest(int $sqlRequestId): int
+    {
+        $updated = $this->partialUpdateItem('/sql-requests/' . $sqlRequestId, [
+            'name' => 'My SQL Request Updated',
+        ], ['sql_management_write']);
+
+        $this->assertSame('My SQL Request Updated', $updated['name']);
+        $this->assertSame($this->validSql(), $updated['sql']);
+
+        return $sqlRequestId;
+    }
+
+    /**
+     * @depends testEditSqlRequest
+     */
+    public function testDeleteSqlRequest(int $sqlRequestId): void
+    {
+        $return = $this->deleteItem('/sql-requests/' . $sqlRequestId, ['sql_management_write']);
+        $this->assertNull($return);
+
+        $this->getItem('/sql-requests/' . $sqlRequestId, ['sql_management_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testBulkDeleteSqlRequests(): void
+    {
+        $firstId = $this->createItem('/sql-requests', [
+            'name' => 'Bulk SQL 1',
+            'sql' => $this->validSql(),
+        ], ['sql_management_write'])['sqlRequestId'];
+        $secondId = $this->createItem('/sql-requests', [
+            'name' => 'Bulk SQL 2',
+            'sql' => $this->validSql(),
+        ], ['sql_management_write'])['sqlRequestId'];
+
+        $this->bulkDeleteItems('/sql-requests/bulk-delete', [
+            'sqlRequestIds' => [$firstId, $secondId],
+        ], ['sql_management_write']);
+
+        $this->getItem('/sql-requests/' . $firstId, ['sql_management_read'], Response::HTTP_NOT_FOUND);
+        $this->getItem('/sql-requests/' . $secondId, ['sql_management_read'], Response::HTTP_NOT_FOUND);
+    }
+}

--- a/tests/Integration/ApiPlatform/SqlRequestEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SqlRequestEndpointTest.php
@@ -50,8 +50,6 @@ class SqlRequestEndpointTest extends ApiTestCase
     {
         yield 'create endpoint' => ['POST', '/sql-requests'];
         yield 'get endpoint' => ['GET', '/sql-requests/1'];
-        yield 'update endpoint' => ['PATCH', '/sql-requests/1'];
-        yield 'delete endpoint' => ['DELETE', '/sql-requests/1'];
         yield 'bulk delete endpoint' => ['DELETE', '/sql-requests/bulk-delete'];
     }
 
@@ -85,32 +83,6 @@ class SqlRequestEndpointTest extends ApiTestCase
         );
 
         return $sqlRequestId;
-    }
-
-    /**
-     * @depends testGetSqlRequest
-     */
-    public function testEditSqlRequest(int $sqlRequestId): int
-    {
-        $updated = $this->partialUpdateItem('/sql-requests/' . $sqlRequestId, [
-            'name' => 'My SQL Request Updated',
-        ], ['sql_management_write']);
-
-        $this->assertSame('My SQL Request Updated', $updated['name']);
-        $this->assertSame($this->validSql(), $updated['sql']);
-
-        return $sqlRequestId;
-    }
-
-    /**
-     * @depends testEditSqlRequest
-     */
-    public function testDeleteSqlRequest(int $sqlRequestId): void
-    {
-        $return = $this->deleteItem('/sql-requests/' . $sqlRequestId, ['sql_management_write']);
-        $this->assertNull($return);
-
-        $this->getItem('/sql-requests/' . $sqlRequestId, ['sql_management_read'], Response::HTTP_NOT_FOUND);
     }
 
     public function testBulkDeleteSqlRequests(): void


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the single edit (`PATCH`) and delete (`DELETE`) SqlRequest endpoints
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Completes the SqlRequest resource with the two remaining operations:

- `PATCH /sql-requests/{sqlRequestId}` — `EditSqlRequestCommand`
- `DELETE /sql-requests/{sqlRequestId}` — `DeleteSqlRequestCommand`

### ⚠️ Depends on a core change — kept as a draft

`EditSqlRequestCommand` and `DeleteSqlRequestCommand` take a `SqlRequestId` **value object** as their
constructor argument, while the `CQRSApiNormalizer` always passes scalar values to command constructors,
which raises a `TypeError`. The core PR **PrestaShop/PrestaShop#41742** widens those constructors to
`int|SqlRequestId` (BC-safe). This PR will stay a draft and red on the released-core matrices
(`9.0.x` / `9.1.x`) until that change is merged and shipped.

### Stacked on #239

This branch is based on #239 (create / get / bulk-delete), so its diff includes those commits until #239
is merged; it will be rebased on `dev` afterwards.
