### PR TITLE
Add Manufacturer status (single + bulk) and delete-logo endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Manufacturer/BulkManufacturersStatus.php
+++ b/src/ApiPlatform/Resources/Manufacturer/BulkManufacturersStatus.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Manufacturer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\BulkToggleManufacturerStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/manufacturers/bulk-update-status',
+            output: false,
+            CQRSCommand: BulkToggleManufacturerStatusCommand::class,
+            CQRSCommandMapping: [
+                '[enabled]' => '[expectedStatus]',
+            ],
+            scopes: ['manufacturer_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ManufacturerNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkManufacturersStatus
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $manufacturerIds;
+
+    public bool $enabled;
+}

--- a/src/ApiPlatform/Resources/Manufacturer/ManufacturerLogo.php
+++ b/src/ApiPlatform/Resources/Manufacturer/ManufacturerLogo.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Manufacturer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\DeleteManufacturerLogoImageCommand;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/manufacturers/{manufacturerId}/logo',
+            requirements: ['manufacturerId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteManufacturerLogoImageCommand::class,
+            scopes: ['manufacturer_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ManufacturerNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ManufacturerLogo
+{
+    #[ApiProperty(identifier: true)]
+    public int $manufacturerId;
+}

--- a/src/ApiPlatform/Resources/Manufacturer/ManufacturerStatus.php
+++ b/src/ApiPlatform/Resources/Manufacturer/ManufacturerStatus.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Manufacturer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Command\ToggleManufacturerStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Manufacturer\Exception\ManufacturerNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/manufacturers/{manufacturerId}/set-status',
+            requirements: ['manufacturerId' => '\d+'],
+            output: false,
+            CQRSCommand: ToggleManufacturerStatusCommand::class,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            scopes: ['manufacturer_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ManufacturerNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ManufacturerStatus
+{
+    #[ApiProperty(identifier: true)]
+    public int $manufacturerId;
+
+    public bool $enabled;
+
+    /**
+     * ToggleManufacturerStatusCommand expects an $expectedStatus constructor argument.
+     */
+    public const COMMAND_MAPPING = [
+        '[enabled]' => '[expectedStatus]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/ManufacturerStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ManufacturerStatusEndpointTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class ManufacturerStatusEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient(['manufacturer_write', 'manufacturer_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'manufacturer',
+            'manufacturer_lang',
+            'manufacturer_shop',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set-status endpoint' => ['PUT', '/manufacturers/1/set-status'];
+        yield 'delete logo endpoint' => ['DELETE', '/manufacturers/1/logo'];
+    }
+
+    private function createManufacturer(): int
+    {
+        $manufacturer = $this->createItem('/manufacturers', [
+            'name' => 'Manufacturer status test',
+            'shortDescriptions' => ['en-US' => 'short en', 'fr-FR' => 'short fr'],
+            'descriptions' => ['en-US' => 'description en', 'fr-FR' => 'description fr'],
+            'metaTitles' => ['en-US' => 'meta title en', 'fr-FR' => 'meta title fr'],
+            'metaDescriptions' => ['en-US' => 'meta description en', 'fr-FR' => 'meta description fr'],
+            'shopIds' => [1],
+            'enabled' => true,
+        ], ['manufacturer_write']);
+
+        return $manufacturer['manufacturerId'];
+    }
+
+    public function testSetManufacturerStatus(): void
+    {
+        $manufacturerId = $this->createManufacturer();
+
+        // Disable the manufacturer
+        $this->updateItem(
+            '/manufacturers/' . $manufacturerId . '/set-status',
+            ['enabled' => false],
+            ['manufacturer_write'],
+            Response::HTTP_NO_CONTENT
+        );
+        $manufacturer = $this->getItem('/manufacturers/' . $manufacturerId, ['manufacturer_read']);
+        $this->assertFalse($manufacturer['enabled']);
+
+        // Enable it again
+        $this->updateItem(
+            '/manufacturers/' . $manufacturerId . '/set-status',
+            ['enabled' => true],
+            ['manufacturer_write'],
+            Response::HTTP_NO_CONTENT
+        );
+        $manufacturer = $this->getItem('/manufacturers/' . $manufacturerId, ['manufacturer_read']);
+        $this->assertTrue($manufacturer['enabled']);
+    }
+
+    public function testDeleteManufacturerLogo(): void
+    {
+        $manufacturerId = $this->createManufacturer();
+
+        $return = $this->deleteItem('/manufacturers/' . $manufacturerId . '/logo', ['manufacturer_write']);
+        $this->assertNull($return);
+    }
+}

--- a/tests/Integration/ApiPlatform/ManufacturerStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ManufacturerStatusEndpointTest.php
@@ -52,6 +52,7 @@ class ManufacturerStatusEndpointTest extends ApiTestCase
     public static function getProtectedEndpoints(): iterable
     {
         yield 'set-status endpoint' => ['PUT', '/manufacturers/1/set-status'];
+        yield 'bulk update status endpoint' => ['PUT', '/manufacturers/bulk-update-status'];
         yield 'delete logo endpoint' => ['DELETE', '/manufacturers/1/logo'];
     }
 
@@ -93,6 +94,25 @@ class ManufacturerStatusEndpointTest extends ApiTestCase
         );
         $manufacturer = $this->getItem('/manufacturers/' . $manufacturerId, ['manufacturer_read']);
         $this->assertTrue($manufacturer['enabled']);
+    }
+
+    public function testBulkUpdateManufacturerStatus(): void
+    {
+        $firstId = $this->createManufacturer();
+        $secondId = $this->createManufacturer();
+
+        // Disable both manufacturers at once
+        $this->updateItem(
+            '/manufacturers/bulk-update-status',
+            ['manufacturerIds' => [$firstId, $secondId], 'enabled' => false],
+            ['manufacturer_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        foreach ([$firstId, $secondId] as $id) {
+            $manufacturer = $this->getItem('/manufacturers/' . $id, ['manufacturer_read']);
+            $this->assertFalse($manufacturer['enabled']);
+        }
     }
 
     public function testDeleteManufacturerLogo(): void


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Manufacturer status (single + bulk) and delete-logo endpoints
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Mirrors the equivalent **Supplier** / **Zone** write actions, which the Manufacturer resource was missing:

- `PUT /manufacturers/{manufacturerId}/set-status` — `ToggleManufacturerStatusCommand`
- `PUT /manufacturers/bulk-update-status` — `BulkToggleManufacturerStatusCommand`
- `DELETE /manufacturers/{manufacturerId}/logo` — `DeleteManufacturerLogoImageCommand`

`ToggleManufacturerStatusCommand` / `BulkToggleManufacturerStatusCommand` take an explicit
expected status, so the status endpoints accept an `{enabled}` body mapped to `expectedStatus`
(same convention as the Zone `bulk-update-status` endpoint).

These are added as **standalone resource classes** (`ManufacturerStatus`, `BulkManufacturersStatus`,
`ManufacturerLogo`) and a separate test, so they don't collide with the in-progress
manufacturer-detail PR (#113) that touches `Manufacturer.php` / `ManufacturerEndpointTest.php`.

Adds an integration test covering all three endpoints and reuses the `manufacturer_read` /
`manufacturer_write` scopes.