### PR TITLE
Add Customer transform-guest-to-customer endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Customer/TransformGuestToCustomer.php
+++ b/src/ApiPlatform/Resources/Customer/TransformGuestToCustomer.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Command\TransformGuestToCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerTransformationException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/customers/{customerId}/transform-to-customers',
+            requirements: ['customerId' => '\d+'],
+            output: false,
+            allowEmptyBody: true,
+            CQRSCommand: TransformGuestToCustomerCommand::class,
+            scopes: ['customer_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomerTransformationException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class TransformGuestToCustomer
+{
+    #[ApiProperty(identifier: true)]
+    public int $customerId;
+}

--- a/tests/Integration/ApiPlatform/CustomerTransformGuestEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerTransformGuestEndpointTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CustomerTransformGuestEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient(['customer_write', 'customer_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'customer',
+            'customer_group',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'transform endpoint' => ['PUT', '/customers/1/transform-to-customers'];
+    }
+
+    private function createGuest(): int
+    {
+        $guest = $this->createItem('/customers', [
+            'firstName' => 'Jane',
+            'lastName' => 'GUEST',
+            'email' => 'jane.transform@example.com',
+            'password' => 'INVALID',
+            'genderId' => 2,
+            'guest' => true,
+            'defaultGroupId' => 1,
+            'groupIds' => [1],
+            'enabled' => false,
+        ], ['customer_write']);
+
+        $this->assertTrue($guest['guest']);
+
+        return $guest['customerId'];
+    }
+
+    public function testTransformGuestToCustomer(): int
+    {
+        $customerId = $this->createGuest();
+
+        $this->updateItem(
+            '/customers/' . $customerId . '/transform-to-customers',
+            [],
+            ['customer_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        // The guest is now a registered customer
+        $customer = $this->getItem('/customers/' . $customerId, ['customer_read']);
+        $this->assertFalse($customer['guest']);
+
+        return $customerId;
+    }
+
+    /**
+     * @depends testTransformGuestToCustomer
+     */
+    public function testTransformAlreadyRegisteredCustomerFails(int $customerId): void
+    {
+        // Transforming a customer that is no longer a guest is rejected
+        $this->updateItem(
+            '/customers/' . $customerId . '/transform-to-customers',
+            [],
+            ['customer_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the transform-guest-to-customer endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`PUT /customers/{customerId}/transform-to-customers`** — `TransformGuestToCustomerCommand`:
turns an existing guest customer into a registered customer (empty body).

- `404` if the customer does not exist (`CustomerNotFoundException`)
- `422` if the customer is not a guest (`CustomerTransformationException`)

Added as a **standalone resource class** (`TransformGuestToCustomer`) and a separate test, so it
doesn't collide with the in-progress Customer PRs that touch `Customer.php` / `CustomerEndpointTest.php`.

Adds an integration test (create a guest, transform it, then check a second transform is rejected)
and reuses the `customer_read` / `customer_write` scopes.
