### PR TITLE
Add CustomerService thread management endpoints

### DIFF
--- a/src/ApiPlatform/Resources/CustomerThread/BulkCustomerThreads.php
+++ b/src/ApiPlatform/Resources/CustomerThread/BulkCustomerThreads.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CustomerThread;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\BulkDeleteCustomerThreadCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerThreadNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/customer-threads/bulk-delete',
+            output: false,
+            CQRSCommand: BulkDeleteCustomerThreadCommand::class,
+            scopes: ['customer_service_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerThreadNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkCustomerThreads
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $customerThreadIds;
+}

--- a/src/ApiPlatform/Resources/CustomerThread/CustomerThread.php
+++ b/src/ApiPlatform/Resources/CustomerThread/CustomerThread.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CustomerThread;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\DeleteCustomerThreadCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\UpdateCustomerThreadStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerServiceException;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerThreadNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/customer-threads/{customerThreadId}/set-status',
+            requirements: ['customerThreadId' => '\d+'],
+            output: false,
+            CQRSCommand: UpdateCustomerThreadStatusCommand::class,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            scopes: ['customer_service_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/customer-threads/{customerThreadId}',
+            requirements: ['customerThreadId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteCustomerThreadCommand::class,
+            scopes: ['customer_service_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerThreadNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomerServiceException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CustomerThread
+{
+    #[ApiProperty(identifier: true)]
+    public int $customerThreadId;
+
+    /**
+     * One of open, closed, pending1, pending2.
+     */
+    public string $status;
+
+    /**
+     * UpdateCustomerThreadStatusCommand expects a $newCustomerThreadStatus constructor argument.
+     */
+    public const COMMAND_MAPPING = [
+        '[status]' => '[newCustomerThreadStatus]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CustomerThreadEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerThreadEndpointTest.php
@@ -22,10 +22,8 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
-use CustomerThread;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Resources\DatabaseDump;
-use Validate;
 
 class CustomerThreadEndpointTest extends ApiTestCase
 {
@@ -59,7 +57,7 @@ class CustomerThreadEndpointTest extends ApiTestCase
 
     private function createCustomerThread(string $status = 'open'): int
     {
-        $thread = new CustomerThread();
+        $thread = new \CustomerThread();
         $thread->id_lang = 1;
         $thread->id_contact = 1;
         $thread->id_shop = 1;
@@ -83,7 +81,7 @@ class CustomerThreadEndpointTest extends ApiTestCase
             Response::HTTP_NO_CONTENT
         );
 
-        $thread = new CustomerThread($customerThreadId);
+        $thread = new \CustomerThread($customerThreadId);
         $this->assertSame('closed', $thread->status);
     }
 
@@ -106,7 +104,7 @@ class CustomerThreadEndpointTest extends ApiTestCase
         $return = $this->deleteItem('/customer-threads/' . $customerThreadId, ['customer_service_write']);
         $this->assertNull($return);
 
-        $this->assertFalse(Validate::isLoadedObject(new CustomerThread($customerThreadId)));
+        $this->assertFalse(\Validate::isLoadedObject(new \CustomerThread($customerThreadId)));
     }
 
     public function testBulkDeleteCustomerThreads(): void
@@ -118,7 +116,7 @@ class CustomerThreadEndpointTest extends ApiTestCase
             'customerThreadIds' => [$firstId, $secondId],
         ], ['customer_service_write']);
 
-        $this->assertFalse(Validate::isLoadedObject(new CustomerThread($firstId)));
-        $this->assertFalse(Validate::isLoadedObject(new CustomerThread($secondId)));
+        $this->assertFalse(\Validate::isLoadedObject(new \CustomerThread($firstId)));
+        $this->assertFalse(\Validate::isLoadedObject(new \CustomerThread($secondId)));
     }
 }

--- a/tests/Integration/ApiPlatform/CustomerThreadEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerThreadEndpointTest.php
@@ -63,7 +63,7 @@ class CustomerThreadEndpointTest extends ApiTestCase
         $thread->id_shop = 1;
         $thread->id_customer = 0;
         $thread->email = 'thread-test@example.com';
-        $thread->token = 'token-' . uniqid();
+        $thread->token = bin2hex(random_bytes(6));
         $thread->status = $status;
         $thread->add();
 

--- a/tests/Integration/ApiPlatform/CustomerThreadEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerThreadEndpointTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use CustomerThread;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+use Validate;
+
+class CustomerThreadEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient(['customer_service_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'customer_thread',
+            'customer_message',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set-status endpoint' => ['PUT', '/customer-threads/1/set-status'];
+        yield 'delete endpoint' => ['DELETE', '/customer-threads/1'];
+        yield 'bulk delete endpoint' => ['DELETE', '/customer-threads/bulk-delete'];
+    }
+
+    private function createCustomerThread(string $status = 'open'): int
+    {
+        $thread = new CustomerThread();
+        $thread->id_lang = 1;
+        $thread->id_contact = 1;
+        $thread->id_shop = 1;
+        $thread->id_customer = 0;
+        $thread->email = 'thread-test@example.com';
+        $thread->token = 'token-' . uniqid();
+        $thread->status = $status;
+        $thread->add();
+
+        return (int) $thread->id;
+    }
+
+    public function testSetCustomerThreadStatus(): void
+    {
+        $customerThreadId = $this->createCustomerThread('open');
+
+        $this->updateItem(
+            '/customer-threads/' . $customerThreadId . '/set-status',
+            ['status' => 'closed'],
+            ['customer_service_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $thread = new CustomerThread($customerThreadId);
+        $this->assertSame('closed', $thread->status);
+    }
+
+    public function testSetInvalidStatusIsRejected(): void
+    {
+        $customerThreadId = $this->createCustomerThread('open');
+
+        $this->updateItem(
+            '/customer-threads/' . $customerThreadId . '/set-status',
+            ['status' => 'not-a-status'],
+            ['customer_service_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+    }
+
+    public function testDeleteCustomerThread(): void
+    {
+        $customerThreadId = $this->createCustomerThread('open');
+
+        $return = $this->deleteItem('/customer-threads/' . $customerThreadId, ['customer_service_write']);
+        $this->assertNull($return);
+
+        $this->assertFalse(Validate::isLoadedObject(new CustomerThread($customerThreadId)));
+    }
+
+    public function testBulkDeleteCustomerThreads(): void
+    {
+        $firstId = $this->createCustomerThread('open');
+        $secondId = $this->createCustomerThread('open');
+
+        $this->bulkDeleteItems('/customer-threads/bulk-delete', [
+            'customerThreadIds' => [$firstId, $secondId],
+        ], ['customer_service_write']);
+
+        $this->assertFalse(Validate::isLoadedObject(new CustomerThread($firstId)));
+        $this->assertFalse(Validate::isLoadedObject(new CustomerThread($secondId)));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the customer service thread management endpoints
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints to manage **customer service threads**:

- `PUT /customer-threads/{customerThreadId}/set-status` — `UpdateCustomerThreadStatusCommand`
- `DELETE /customer-threads/{customerThreadId}` — `DeleteCustomerThreadCommand`
- `DELETE /customer-threads/bulk-delete` — `BulkDeleteCustomerThreadCommand`

`set-status` takes a `{status}` body (`open` / `closed` / `pending1` / `pending2`) mapped to the
command's `newCustomerThreadStatus` argument; an invalid status returns `422`.

### Notes / scope

There is no *add* command for threads (they are created from customer messages / the contact form),
so the integration test seeds threads via the `CustomerThread` model. The `reply` / `forward`
actions (which send e-mails) and the rich `GetCustomerThreadForViewing` read (a nested
timeline/messages aggregate that does not expose the status) are intentionally left out of this
first resource and can follow up separately.

Adds an integration test (set-status happy path + invalid-status 422, delete, bulk-delete) and
declares the `customer_service_write` scope.
