### PR TITLE
Add Order set-internal-note endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderInternalNote.php
+++ b/src/ApiPlatform/Resources/Order/OrderInternalNote.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\SetInternalOrderNoteCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/internal-notes',
+            requirements: ['orderId' => '\d+'],
+            output: false,
+            CQRSCommand: SetInternalOrderNoteCommand::class,
+            scopes: ['order_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderInternalNote
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    public string $internalNote;
+}

--- a/tests/Integration/ApiPlatform/OrderInternalNoteEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderInternalNoteEndpointTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderInternalNoteEndpointTest extends ApiTestCase
+{
+    private static int $orderId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+        self::$orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` ASC'
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['orders']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set internal note endpoint' => ['PUT', '/orders/1/internal-notes'];
+    }
+
+    public function testSetInternalOrderNote(): void
+    {
+        $note = 'Internal note set through the Admin API';
+
+        $this->updateItem(
+            '/orders/' . self::$orderId . '/internal-notes',
+            ['internalNote' => $note],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $order = new \Order(self::$orderId);
+        $this->assertSame($note, $order->note);
+    }
+
+    public function testSetInternalNoteOnMissingOrderReturnsNotFound(): void
+    {
+        $this->updateItem(
+            '/orders/999999/internal-notes',
+            ['internalNote' => 'whatever'],
+            ['order_write'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Order set-internal-note endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

First **Order** resource for the Admin API:

- `PUT /orders/{orderId}/internal-notes` — `SetInternalOrderNoteCommand`: sets the back-office
  internal note on an order (`204`, no content).

- `404` if the order does not exist (`OrderNotFoundException`)
- `422` for an invalid note (`OrderConstraintException`)

This is intentionally a small, side-effect-free first step into the (large) Order domain. Orders
are not created through a simple command, so the integration test reuses an existing fixture order
and verifies the stored note through the `Order` model. Declares the `order_write` scope.

Other Order write actions (status change, refunds, cart-rules, addresses, …) and the
`GetOrderForViewing` read can follow up in dedicated PRs.
