### PR TITLE
Add Order change-invoice-address endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderInvoiceAddress.php
+++ b/src/ApiPlatform/Resources/Order/OrderInvoiceAddress.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderInvoiceAddressCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/invoice-addresses',
+            requirements: ['orderId' => '\d+'],
+            output: false,
+            CQRSCommand: ChangeOrderInvoiceAddressCommand::class,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            scopes: ['order_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderInvoiceAddress
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    public int $addressId;
+
+    /**
+     * ChangeOrderInvoiceAddressCommand expects a $newInvoiceAddressId constructor argument.
+     */
+    public const COMMAND_MAPPING = [
+        '[addressId]' => '[newInvoiceAddressId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/OrderInvoiceAddressEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderInvoiceAddressEndpointTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderInvoiceAddressEndpointTest extends ApiTestCase
+{
+    private static int $orderId;
+    private static int $deliveryAddressId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+
+        $row = \Db::getInstance()->getRow(
+            'SELECT `id_order`, `id_address_delivery` FROM `' . _DB_PREFIX_ . 'orders`
+             WHERE `id_address_delivery` > 0 AND `id_address_invoice` > 0
+             ORDER BY `id_order` ASC'
+        );
+        self::$orderId = (int) $row['id_order'];
+        self::$deliveryAddressId = (int) $row['id_address_delivery'];
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['orders', 'order_detail', 'order_invoice', 'cart']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'change invoice address endpoint' => ['PUT', '/orders/1/invoice-addresses'];
+    }
+
+    public function testChangeOrderInvoiceAddress(): void
+    {
+        // Reuse a valid customer address already attached to the order
+        $this->updateItem(
+            '/orders/' . self::$orderId . '/invoice-addresses',
+            ['addressId' => self::$deliveryAddressId],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $order = new \Order(self::$orderId);
+        $this->assertSame(self::$deliveryAddressId, (int) $order->id_address_invoice);
+    }
+
+    public function testChangeInvoiceAddressOnMissingOrderReturnsNotFound(): void
+    {
+        $this->updateItem(
+            '/orders/999999/invoice-addresses',
+            ['addressId' => self::$deliveryAddressId],
+            ['order_write'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Order change-invoice-address endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`PUT /orders/{orderId}/invoice-addresses`** — `ChangeOrderInvoiceAddressCommand`: reassigns
the invoice address of an order to another address (`204`, no content).

- `404` if the order does not exist (`OrderNotFoundException`)
- `422` if the address is not valid (`OrderException`)

Second small, focused step into the Order domain (after the internal-note endpoint). The
integration test reuses an existing fixture order and one of its already-attached customer
addresses, then verifies the change through the `Order` model. Reuses the `order_write` scope.
