### PR TITLE
Add Employee status & bulk action endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Employee/BulkEmployees.php
+++ b/src/ApiPlatform/Resources/Employee/BulkEmployees.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Employee;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Command\BulkDeleteEmployeeCommand;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\AdminEmployeeException;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeCannotChangeItselfException;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/employees/bulk-delete',
+            // No output, 204 code
+            output: false,
+            CQRSCommand: BulkDeleteEmployeeCommand::class,
+            scopes: ['employee_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        EmployeeNotFoundException::class => Response::HTTP_NOT_FOUND,
+        EmployeeCannotChangeItselfException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        AdminEmployeeException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkEmployees
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $employeeIds;
+}

--- a/src/ApiPlatform/Resources/Employee/BulkEmployees.php
+++ b/src/ApiPlatform/Resources/Employee/BulkEmployees.php
@@ -29,18 +29,17 @@ use PrestaShop\PrestaShop\Core\Domain\Employee\Command\BulkDeleteEmployeeCommand
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\AdminEmployeeException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeCannotChangeItselfException;
 use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeNotFoundException;
-use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
-        new CQRSUpdate(
+        new CQRSDelete(
             uriTemplate: '/employees/bulk-delete',
-            // No output, 204 code
-            output: false,
             CQRSCommand: BulkDeleteEmployeeCommand::class,
             scopes: ['employee_write'],
+            allowEmptyBody: false,
         ),
     ],
     exceptionToStatus: [

--- a/src/ApiPlatform/Resources/Employee/BulkUpdateStatusEmployees.php
+++ b/src/ApiPlatform/Resources/Employee/BulkUpdateStatusEmployees.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Employee;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Command\BulkUpdateEmployeeStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\AdminEmployeeException;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeCannotChangeItselfException;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/employees/bulk-update-status',
+            // No output, 204 code
+            output: false,
+            CQRSCommand: BulkUpdateEmployeeStatusCommand::class,
+            CQRSCommandMapping: [
+                '[enabled]' => '[status]',
+            ],
+            scopes: ['employee_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        EmployeeNotFoundException::class => Response::HTTP_NOT_FOUND,
+        EmployeeCannotChangeItselfException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        AdminEmployeeException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkUpdateStatusEmployees
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $employeeIds;
+
+    public bool $enabled;
+}

--- a/src/ApiPlatform/Resources/Employee/EmployeeStatus.php
+++ b/src/ApiPlatform/Resources/Employee/EmployeeStatus.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Employee;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Command\ToggleEmployeeStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\AdminEmployeeException;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeCannotChangeItselfException;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/employees/{employeeId}/toggle-status',
+            requirements: ['employeeId' => '\d+'],
+            // No output, 204 code
+            output: false,
+            allowEmptyBody: true,
+            CQRSCommand: ToggleEmployeeStatusCommand::class,
+            scopes: ['employee_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        EmployeeNotFoundException::class => Response::HTTP_NOT_FOUND,
+        EmployeeCannotChangeItselfException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        AdminEmployeeException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class EmployeeStatus
+{
+    #[ApiProperty(identifier: true)]
+    public int $employeeId;
+}

--- a/tests/Integration/ApiPlatform/EmployeeActionsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/EmployeeActionsEndpointTest.php
@@ -23,16 +23,27 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
-use PrestaShop\PrestaShop\Core\Domain\Employee\Command\AddEmployeeCommand;
+use PrestaShop\PrestaShop\Core\Crypto\Hashing;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Resources\DatabaseDump;
 
 class EmployeeActionsEndpointTest extends ApiTestCase
 {
+    private static int $profileId;
+
+    private static int $langId;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::createApiClient(['employee_write']);
+
+        // A non SuperAdmin profile so the seeded employees are never considered the "last admin",
+        // which would block the toggle/bulk status and bulk delete operations.
+        self::$profileId = (int) \Db::getInstance()->getValue(
+            'SELECT id_profile FROM `' . _DB_PREFIX_ . 'profile` WHERE id_profile <> 1 ORDER BY id_profile ASC'
+        );
+        self::$langId = (int) \Configuration::get('PS_LANG_DEFAULT');
     }
 
     public static function tearDownAfterClass(): void
@@ -114,32 +125,23 @@ class EmployeeActionsEndpointTest extends ApiTestCase
     }
 
     /**
-     * Seeds an employee through the CQRS command bus. The SUPER_ADMIN profile is used on
-     * purpose: the install super admin always remains, so the seeded employees are never the
-     * "only admin in shop" (which would block toggle/bulk operations), and the homepage
-     * accessibility check is skipped for the super admin profile.
+     * Seeds an employee directly through the legacy object model. AddEmployeeCommand cannot be
+     * used here because it checks that the context employee can grant the profile, and there is
+     * no authenticated employee in the API/test context.
      */
     private function createEmployee(string $email, bool $active): int
     {
-        $command = new AddEmployeeCommand(
-            'John',
-            'Doe',
-            $email,
-            'Pr3st@Sh0p!Test',
-            1,
-            (int) \Configuration::get('PS_LANG_DEFAULT'),
-            $active,
-            1,
-            [1],
-            false,
-            8,
-            72,
-            0
-        );
+        $employee = new \Employee();
+        $employee->id_profile = self::$profileId;
+        $employee->id_lang = self::$langId;
+        $employee->firstname = 'John';
+        $employee->lastname = 'Doe';
+        $employee->email = $email;
+        $employee->passwd = (new Hashing())->hash('Pr3st@Sh0p!Test');
+        $employee->active = $active;
+        $employee->add();
 
-        $commandBus = static::createClient()->getContainer()->get('prestashop.core.command_bus');
-
-        return $commandBus->handle($command)->getValue();
+        return (int) $employee->id;
     }
 
     private function getEmployeeActiveStatus(int $employeeId): bool

--- a/tests/Integration/ApiPlatform/EmployeeActionsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/EmployeeActionsEndpointTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\Domain\Employee\Command\AddEmployeeCommand;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class EmployeeActionsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['employee_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['employee', 'employee_shop']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'toggle status endpoint' => [
+            'PUT',
+            '/employees/1/toggle-status',
+        ];
+
+        yield 'bulk update status endpoint' => [
+            'PUT',
+            '/employees/bulk-update-status',
+        ];
+
+        yield 'bulk delete endpoint' => [
+            'DELETE',
+            '/employees/bulk-delete',
+        ];
+    }
+
+    public function testToggleStatus(): void
+    {
+        $employeeId = $this->createEmployee('toggle.actions@prestashop.com', true);
+        $this->assertTrue($this->getEmployeeActiveStatus($employeeId));
+
+        // Blind toggle: enabled -> disabled
+        $this->updateItem('/employees/' . $employeeId . '/toggle-status', [], ['employee_write'], Response::HTTP_NO_CONTENT);
+        $this->assertFalse($this->getEmployeeActiveStatus($employeeId));
+
+        // Blind toggle again: disabled -> enabled
+        $this->updateItem('/employees/' . $employeeId . '/toggle-status', [], ['employee_write'], Response::HTTP_NO_CONTENT);
+        $this->assertTrue($this->getEmployeeActiveStatus($employeeId));
+    }
+
+    public function testToggleStatusNotFound(): void
+    {
+        $this->updateItem('/employees/999999/toggle-status', [], ['employee_write'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testBulkUpdateStatus(): void
+    {
+        $employeeId1 = $this->createEmployee('bulk1.actions@prestashop.com', true);
+        $employeeId2 = $this->createEmployee('bulk2.actions@prestashop.com', true);
+
+        $this->updateItem('/employees/bulk-update-status', [
+            'employeeIds' => [$employeeId1, $employeeId2],
+            'enabled' => false,
+        ], ['employee_write'], Response::HTTP_NO_CONTENT);
+
+        $this->assertFalse($this->getEmployeeActiveStatus($employeeId1));
+        $this->assertFalse($this->getEmployeeActiveStatus($employeeId2));
+
+        $this->updateItem('/employees/bulk-update-status', [
+            'employeeIds' => [$employeeId1, $employeeId2],
+            'enabled' => true,
+        ], ['employee_write'], Response::HTTP_NO_CONTENT);
+
+        $this->assertTrue($this->getEmployeeActiveStatus($employeeId1));
+        $this->assertTrue($this->getEmployeeActiveStatus($employeeId2));
+    }
+
+    public function testBulkDelete(): void
+    {
+        $employeeId1 = $this->createEmployee('bulkdelete1.actions@prestashop.com', true);
+        $employeeId2 = $this->createEmployee('bulkdelete2.actions@prestashop.com', true);
+
+        $this->bulkDeleteItems('/employees/bulk-delete', [
+            'employeeIds' => [$employeeId1, $employeeId2],
+        ], ['employee_write']);
+
+        $this->assertFalse(\Validate::isLoadedObject(new \Employee($employeeId1)));
+        $this->assertFalse(\Validate::isLoadedObject(new \Employee($employeeId2)));
+    }
+
+    /**
+     * Seeds an employee through the CQRS command bus. The SUPER_ADMIN profile is used on
+     * purpose: the install super admin always remains, so the seeded employees are never the
+     * "only admin in shop" (which would block toggle/bulk operations), and the homepage
+     * accessibility check is skipped for the super admin profile.
+     */
+    private function createEmployee(string $email, bool $active): int
+    {
+        $command = new AddEmployeeCommand(
+            'John',
+            'Doe',
+            $email,
+            'Pr3st@Sh0p!Test',
+            1,
+            (int) \Configuration::get('PS_LANG_DEFAULT'),
+            $active,
+            1,
+            [1],
+            false,
+            8,
+            72,
+            0
+        );
+
+        $commandBus = static::createClient()->getContainer()->get('prestashop.core.command_bus');
+
+        return $commandBus->handle($command)->getValue();
+    }
+
+    private function getEmployeeActiveStatus(int $employeeId): bool
+    {
+        return (bool) (new \Employee($employeeId))->active;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                       |
|-------------------|---------------------------------------------------------------|
| Description?      | Adds the Employee CQRS action endpoints that are not covered by the in-progress employee resource (#155): blind status toggle, bulk status update and bulk delete. |
| Type?             | new feature                                                   |
| BC breaks?        | no                                                            |
| Deprecations?     | no                                                            |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                         |
| Sponsor company   |                                                               |
| How to test?      | Run `tests/Integration/ApiPlatform/EmployeeActionsEndpointTest.php`, or call the new endpoints with an `employee_write` scoped API client. |

### Endpoints added

- `PUT /employees/{employeeId}/toggle-status` — blind status toggle (`ToggleEmployeeStatusCommand`, empty body, 204)
- `PUT /employees/bulk-update-status` — `{ employeeIds, enabled }` (`BulkUpdateEmployeeStatusCommand`, 204)
- `DELETE /employees/bulk-delete` — `{ employeeIds }` (`BulkDeleteEmployeeCommand`, 204)

All three use the `employee_write` scope. Resources live in standalone files (`EmployeeStatus`, `BulkUpdateStatusEmployees`, `BulkEmployees`) and a separately-named test (`EmployeeActionsEndpointTest`) so they do not collide with the employee CRUD resource being added in #155.
