### PR TITLE
Add Product status endpoints (single get + bulk update)

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductStatus.php
+++ b/src/ApiPlatform/Resources/Product/ProductStatus.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\BulkUpdateProductStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/status',
+            requirements: ['productId' => '\d+'],
+            CQRSQuery: GetProductForEditing::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/products/bulk-status',
+            CQRSCommand: BulkUpdateProductStatusCommand::class,
+            // No output 204 code
+            output: false,
+            status: Response::HTTP_NO_CONTENT,
+            scopes: [
+                'product_write',
+            ],
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ShopAssociationNotFound::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductStatus
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    public bool $enabled;
+
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $productIds;
+
+    public const QUERY_MAPPING = [
+        '[_context][shopConstraint]' => '[shopConstraint]',
+        '[_context][langId]' => '[displayLanguageId]',
+        '[active]' => '[enabled]',
+    ];
+
+    public const COMMAND_MAPPING = [
+        '[_context][shopConstraint]' => '[shopConstraint]',
+        '[enabled]' => '[newStatus]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/ProductStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductStatusEndpointTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\Resetter\ProductResetter;
+
+class ProductStatusEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        ProductResetter::resetProducts();
+        // Pre-create the API Client with the needed scopes, this way we reduce the number of created API Clients
+        self::createApiClient(['product_write', 'product_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        ProductResetter::resetProducts();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get status endpoint' => [
+            'GET',
+            '/products/1/status',
+        ];
+
+        yield 'bulk status endpoint' => [
+            'PUT',
+            '/products/bulk-status',
+        ];
+    }
+
+    private function createProduct(string $name): int
+    {
+        $product = $this->createItem('/products', [
+            'type' => ProductType::TYPE_STANDARD,
+            'names' => [
+                'en-US' => $name,
+            ],
+        ], ['product_write']);
+        $this->assertArrayHasKey('productId', $product);
+
+        return $product['productId'];
+    }
+
+    public function testGetProductStatus(): int
+    {
+        $productId = $this->createProduct('product status get');
+
+        $status = $this->getItem('/products/' . $productId . '/status', ['product_read']);
+        $this->assertArrayHasKey('productId', $status);
+        $this->assertArrayHasKey('enabled', $status);
+        $this->assertEquals($productId, $status['productId']);
+        $this->assertIsBool($status['enabled']);
+
+        return $productId;
+    }
+
+    public function testBulkUpdateProductStatus(): void
+    {
+        $firstProductId = $this->createProduct('product bulk status one');
+        $secondProductId = $this->createProduct('product bulk status two');
+
+        // Enable both products
+        $this->updateItem('/products/bulk-status', [
+            'productIds' => [$firstProductId, $secondProductId],
+            'enabled' => true,
+        ], ['product_write'], Response::HTTP_NO_CONTENT);
+
+        $this->assertTrue($this->getItem('/products/' . $firstProductId . '/status', ['product_read'])['enabled']);
+        $this->assertTrue($this->getItem('/products/' . $secondProductId . '/status', ['product_read'])['enabled']);
+
+        // Disable both products
+        $this->updateItem('/products/bulk-status', [
+            'productIds' => [$firstProductId, $secondProductId],
+            'enabled' => false,
+        ], ['product_write'], Response::HTTP_NO_CONTENT);
+
+        $this->assertFalse($this->getItem('/products/' . $firstProductId . '/status', ['product_read'])['enabled']);
+        $this->assertFalse($this->getItem('/products/' . $secondProductId . '/status', ['product_read'])['enabled']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes two missing **Product status** operations of the Admin API. <br> - `GET /products/{productId}/status` → returns the product enabled state (backed by `GetProductForEditing`), scope `product_read`. <br> - `PUT /products/bulk-status` → toggles the enabled state of several products at once (backed by `BulkUpdateProductStatusCommand`), scope `product_write`.
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `ProductStatusEndpointTest`. Create a product, `GET /products/{id}/status` returns `{ productId, enabled }`; `PUT /products/bulk-status` with `{ productIds, enabled }` returns 204 and updates each product's state.
| Sponsor company   |

Implements part of the missing Product Admin API surface tracked in PrestaShop/PrestaShop#39630, following the existing resource patterns (`Product`, `Category`, `BulkManufacturers`).
