### PR TITLE
Add Product related-products endpoints (list, set, remove all)

### DIFF
--- a/src/ApiPlatform/Resources/Product/RelatedProductList.php
+++ b/src/ApiPlatform/Resources/Product/RelatedProductList.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetRelatedProducts;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/products/{productId}/related-products',
+            requirements: ['productId' => '\d+'],
+            CQRSQuery: GetRelatedProducts::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][langId]' => '[languageId]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class RelatedProductList
+{
+    public int $productId;
+
+    public string $name;
+
+    public string $reference;
+
+    public string $imageUrl;
+}

--- a/src/ApiPlatform/Resources/Product/RelatedProducts.php
+++ b/src/ApiPlatform/Resources/Product/RelatedProducts.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllRelatedProductsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetRelatedProductsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/products/{productId}/related-products',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: SetRelatedProductsCommand::class,
+            status: Response::HTTP_NO_CONTENT,
+            output: false,
+            scopes: [
+                'product_write',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/products/{productId}/related-products',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: RemoveAllRelatedProductsCommand::class,
+            status: Response::HTTP_NO_CONTENT,
+            output: false,
+            scopes: [
+                'product_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class RelatedProducts
+{
+    public int $productId;
+
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    public array $relatedProductIds;
+}

--- a/tests/Integration/ApiPlatform/ProductRelatedEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductRelatedEndpointTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\Resetter\ProductResetter;
+
+class ProductRelatedEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        ProductResetter::resetProducts();
+        // Pre-create the API Client with the needed scopes, this way we reduce the number of created API Clients
+        self::createApiClient(['product_write', 'product_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        ProductResetter::resetProducts();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get related-products endpoint' => [
+            'GET',
+            '/products/1/related-products',
+        ];
+
+        yield 'set related-products endpoint' => [
+            'POST',
+            '/products/1/related-products',
+        ];
+
+        yield 'delete related-products endpoint' => [
+            'DELETE',
+            '/products/1/related-products',
+        ];
+    }
+
+    private function createProduct(string $name): int
+    {
+        $product = $this->createItem('/products', [
+            'type' => ProductType::TYPE_STANDARD,
+            'names' => [
+                'en-US' => $name,
+            ],
+        ], ['product_write']);
+        $this->assertArrayHasKey('productId', $product);
+
+        return $product['productId'];
+    }
+
+    public function testSetAndGetRelatedProducts(): int
+    {
+        $productId = $this->createProduct('related main');
+        $firstRelatedId = $this->createProduct('related one');
+        $secondRelatedId = $this->createProduct('related two');
+
+        $this->createItem(
+            '/products/' . $productId . '/related-products',
+            [
+                'relatedProductIds' => [$firstRelatedId, $secondRelatedId],
+            ],
+            ['product_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $relatedProducts = $this->getItem('/products/' . $productId . '/related-products', ['product_read']);
+        $this->assertCount(2, $relatedProducts);
+        $relatedIds = array_column($relatedProducts, 'productId');
+        $this->assertContains($firstRelatedId, $relatedIds);
+        $this->assertContains($secondRelatedId, $relatedIds);
+
+        return $productId;
+    }
+
+    /**
+     * @depends testSetAndGetRelatedProducts
+     */
+    public function testRemoveAllRelatedProducts(int $productId): void
+    {
+        $this->deleteItem('/products/' . $productId . '/related-products', ['product_write']);
+
+        $relatedProducts = $this->getItem('/products/' . $productId . '/related-products', ['product_read']);
+        $this->assertCount(0, $relatedProducts);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the missing **Product related-products** operations of the Admin API. <br> - `GET /products/{productId}/related-products` → lists the associated products (backed by `GetRelatedProducts`), scope `product_read`. <br> - `POST /products/{productId}/related-products` → replaces the related products set (backed by `SetRelatedProductsCommand`), scope `product_write`. <br> - `DELETE /products/{productId}/related-products` → removes all related products (backed by `RemoveAllRelatedProductsCommand`), scope `product_write`.
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `ProductRelatedEndpointTest`. Set related products via `POST` (204), list them via `GET`, then remove all via `DELETE` (204).
| Sponsor company   |

Implements part of the missing Product Admin API surface tracked in PrestaShop/PrestaShop#39630, following the existing resource patterns (`ProductCategory`, `ProductImageList`).
