### PR TITLE
Add Product duplicate endpoints (single + bulk)

### DIFF
--- a/src/ApiPlatform/Resources/Product/BulkDuplicateProducts.php
+++ b/src/ApiPlatform/Resources/Product/BulkDuplicateProducts.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\BulkDuplicateProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/bulk-duplicate',
+            CQRSCommand: BulkDuplicateProductCommand::class,
+            // No output 204 code
+            output: false,
+            status: Response::HTTP_NO_CONTENT,
+            scopes: [
+                'product_write',
+            ],
+            CQRSCommandMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ShopAssociationNotFound::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDuplicateProducts
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $productIds;
+}

--- a/src/ApiPlatform/Resources/Product/DuplicateProduct.php
+++ b/src/ApiPlatform/Resources/Product/DuplicateProduct.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\DuplicateProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductForEditing;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/products/{productId}/duplicate',
+            requirements: ['productId' => '\d+'],
+            // The product to duplicate is identified by the URI, no request body is expected
+            allowEmptyBody: true,
+            CQRSCommand: DuplicateProductCommand::class,
+            CQRSQuery: GetProductForEditing::class,
+            scopes: [
+                'product_write',
+            ],
+            CQRSQueryMapping: Product::QUERY_MAPPING,
+            CQRSCommandMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ShopAssociationNotFound::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class DuplicateProduct extends Product
+{
+}

--- a/tests/Integration/ApiPlatform/ProductDuplicateEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductDuplicateEndpointTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\Resetter\ProductResetter;
+
+class ProductDuplicateEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        ProductResetter::resetProducts();
+        // Pre-create the API Client with the needed scopes, this way we reduce the number of created API Clients
+        self::createApiClient(['product_write', 'product_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        ProductResetter::resetProducts();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'duplicate endpoint' => [
+            'POST',
+            '/products/1/duplicate',
+        ];
+
+        yield 'bulk duplicate endpoint' => [
+            'PUT',
+            '/products/bulk-duplicate',
+        ];
+    }
+
+    private function createProduct(string $name): int
+    {
+        $product = $this->createItem('/products', [
+            'type' => ProductType::TYPE_STANDARD,
+            'names' => [
+                'en-US' => $name,
+            ],
+        ], ['product_write']);
+        $this->assertArrayHasKey('productId', $product);
+
+        return $product['productId'];
+    }
+
+    public function testDuplicateProduct(): void
+    {
+        $productId = $this->createProduct('product to duplicate');
+        $productsNumber = $this->countItems('/products', ['product_read']);
+
+        $duplicatedProduct = $this->createItem(
+            '/products/' . $productId . '/duplicate',
+            [],
+            ['product_write']
+        );
+
+        $this->assertArrayHasKey('productId', $duplicatedProduct);
+        // The duplicate is a brand new product, not the source one
+        $this->assertNotEquals($productId, $duplicatedProduct['productId']);
+        $this->assertEquals($productsNumber + 1, $this->countItems('/products', ['product_read']));
+    }
+
+    public function testBulkDuplicateProducts(): void
+    {
+        $firstProductId = $this->createProduct('bulk duplicate one');
+        $secondProductId = $this->createProduct('bulk duplicate two');
+        $productsNumber = $this->countItems('/products', ['product_read']);
+
+        $this->updateItem('/products/bulk-duplicate', [
+            'productIds' => [$firstProductId, $secondProductId],
+        ], ['product_write'], Response::HTTP_NO_CONTENT);
+
+        $this->assertEquals($productsNumber + 2, $this->countItems('/products', ['product_read']));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the missing **Product duplication** operations of the Admin API. <br> - `POST /products/{productId}/duplicate` → duplicates a product and returns the newly created product (backed by `DuplicateProductCommand`, then `GetProductForEditing` on the returned new id), scope `product_write`. <br> - `PUT /products/bulk-duplicate` → duplicates several products at once (backed by `BulkDuplicateProductCommand`), returns 204 like the other bulk endpoints, scope `product_write`.
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `ProductDuplicateEndpointTest`. `POST /products/{id}/duplicate` returns a product with a new `productId` and increases the product count by 1; `PUT /products/bulk-duplicate` with `{ productIds }` returns 204 and increases the count accordingly.
| Sponsor company   |

Implements part of the missing Product Admin API surface tracked in PrestaShop/PrestaShop#39630, following existing resource patterns (`Product` create→query, `BulkManufacturers`). The bulk operation returns 204 for consistency with the other bulk endpoints; returning the new product ids could be a follow-up.
