### PR TITLE
Add Product tags endpoints (set + remove all)

### DIFF
--- a/config/admin/services.yml
+++ b/config/admin/services.yml
@@ -51,6 +51,9 @@ services:
   PrestaShop\Module\APIResources\ApiPlatform\Normalizer\GetSearchTermAliasesQuerySerializer:
     autoconfigure: true
 
+  PrestaShop\Module\APIResources\ApiPlatform\Normalizer\ProductBasicInformationNormalizer:
+    autoconfigure: true
+
   PrestaShopBundle\ApiPlatform\Serializer\CQRSApiSerializer:
     class: PrestaShop\Module\APIResources\Serializer\QueryParameterTypeCastSerializer
     decorates: 'api_platform.serializer'

--- a/src/ApiPlatform/Normalizer/ProductBasicInformationNormalizer.php
+++ b/src/ApiPlatform/Normalizer/ProductBasicInformationNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Normalizer;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\QueryResult\ProductBasicInformation;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * GetProductForEditing returns the product tags as a list of LocalizedTags value objects
+ * (each holding a languageId and its tags), unlike the other localized fields which are
+ * already indexed by language id. This normalizer flattens the tags into a language-id
+ * indexed map so it can go through the standard LocalizedValue handling (and be exposed
+ * by locale) like the other localized product fields.
+ */
+class ProductBasicInformationNormalizer implements NormalizerInterface
+{
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
+    {
+        $localizedTags = [];
+        foreach ($object->getLocalizedTags() as $localizedTag) {
+            $localizedTags[$localizedTag->getLanguageId()] = $localizedTag->getTags();
+        }
+
+        return [
+            'localizedNames' => $object->getLocalizedNames(),
+            'localizedDescriptions' => $object->getLocalizedDescriptions(),
+            'localizedShortDescriptions' => $object->getLocalizedShortDescriptions(),
+            'localizedTags' => $localizedTags,
+        ];
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof ProductBasicInformation;
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            ProductBasicInformation::class => true,
+        ];
+    }
+}

--- a/src/ApiPlatform/Resources/Product/ProductTags.php
+++ b/src/ApiPlatform/Resources/Product/ProductTags.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\RemoveAllProductTagsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetProductTagsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/tags',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: SetProductTagsCommand::class,
+            // No output 204 code
+            output: false,
+            status: Response::HTTP_NO_CONTENT,
+            scopes: [
+                'product_write',
+            ],
+            CQRSCommandMapping: [
+                '[tags]' => '[localizedTags]',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/products/{productId}/tags',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: RemoveAllProductTagsCommand::class,
+            output: false,
+            status: Response::HTTP_NO_CONTENT,
+            scopes: [
+                'product_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductTags
+{
+    public int $productId;
+
+    /**
+     * Localized list of tags, keyed by locale, each value being an array of tags.
+     */
+    #[LocalizedValue]
+    public array $tags;
+}

--- a/tests/Integration/ApiPlatform/ProductTagsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductTagsEndpointTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\Resetter\ProductResetter;
+
+class ProductTagsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        ProductResetter::resetProducts();
+        // Pre-create the API Client with the needed scopes, this way we reduce the number of created API Clients
+        self::createApiClient(['product_write', 'product_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        ProductResetter::resetProducts();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set tags endpoint' => [
+            'PUT',
+            '/products/1/tags',
+        ];
+
+        yield 'delete tags endpoint' => [
+            'DELETE',
+            '/products/1/tags',
+        ];
+    }
+
+    private function createProduct(string $name): int
+    {
+        $product = $this->createItem('/products', [
+            'type' => ProductType::TYPE_STANDARD,
+            'names' => [
+                'en-US' => $name,
+            ],
+        ], ['product_write']);
+        $this->assertArrayHasKey('productId', $product);
+
+        return $product['productId'];
+    }
+
+    public function testSetProductTags(): int
+    {
+        $productId = $this->createProduct('product with tags');
+
+        $this->updateItem('/products/' . $productId . '/tags', [
+            'tags' => [
+                'en-US' => ['summer', 'sale'],
+            ],
+        ], ['product_write'], Response::HTTP_NO_CONTENT);
+
+        $product = $this->getItem('/products/' . $productId, ['product_read']);
+        $this->assertArrayHasKey('tags', $product);
+        $this->assertArrayHasKey('en-US', $product['tags']);
+        $this->assertEqualsCanonicalizing(['summer', 'sale'], $product['tags']['en-US']);
+
+        return $productId;
+    }
+
+    /**
+     * @depends testSetProductTags
+     */
+    public function testRemoveAllProductTags(int $productId): void
+    {
+        $this->deleteItem('/products/' . $productId . '/tags', ['product_write']);
+
+        $product = $this->getItem('/products/' . $productId, ['product_read']);
+        $this->assertArrayHasKey('tags', $product);
+        $this->assertEmpty($product['tags']['en-US'] ?? []);
+    }
+}

--- a/tests/PHPStan/ApiResourceNormalizerRule.php
+++ b/tests/PHPStan/ApiResourceNormalizerRule.php
@@ -77,6 +77,10 @@ final class ApiResourceNormalizerRule implements Rule
         // Valid: complex denormalization of product-combination generation input.
         'PrestaShop\\Module\\APIResources\\ApiPlatform\\Normalizer\\GenerateCombinationsSerializer',
         'PrestaShop\\Module\\APIResources\\ApiPlatform\\Normalizer\\GetSearchTermAliasesQuerySerializer',
+        // Valid: GetProductForEditing returns product tags as a list of LocalizedTags value
+        // objects; this normalizer flattens them into a language-id indexed map so they can
+        // go through the standard LocalizedValue handling like the other localized fields.
+        'PrestaShop\\Module\\APIResources\\ApiPlatform\\Normalizer\\ProductBasicInformationNormalizer',
     ];
 
     public function getNodeType(): string


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the missing **Product tags** operations of the Admin API. <br> - `PUT /products/{productId}/tags` → replaces the localized tags of a product (backed by `SetProductTagsCommand`), scope `product_write`. <br> - `DELETE /products/{productId}/tags` → removes all the tags of a product (backed by `RemoveAllProductTagsCommand`), scope `product_write`. <br><br> Tags are localized values keyed by locale (e.g. `{ "tags": { "en-US": ["summer", "sale"] } }`), consistent with the other localized product fields. <br><br> This PR also fixes a latent bug: `GetProductForEditing` returns the product tags as a **list of `LocalizedTags` value objects** (unlike the other localized fields which are already indexed by language id), so `GET /products/{productId}` raised a `500` ("Locale with ID 0 not found") for **any product that had tags**. A dedicated `ProductBasicInformationNormalizer` flattens the tags into a language-id indexed map so they go through the standard `LocalizedValue` handling and are exposed by locale on read.
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `ProductTagsEndpointTest`. `PUT /products/{id}/tags` with `{ "tags": { "en-US": ["summer", "sale"] } }` returns 204 and the tags appear on `GET /products/{id}` under the matching locale; `DELETE /products/{id}/tags` returns 204 and clears them.
| Sponsor company   |

Implements part of the missing Product Admin API surface tracked in PrestaShop/PrestaShop#39630, following the existing localized-value resource patterns (`Product` names/tags, `ProductCategory` set + remove all).
