### PR TITLE
Add Profile tab/module permission endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Profile/ProfileModulePermission.php
+++ b/src/ApiPlatform/Resources/Profile/ProfileModulePermission.php
@@ -60,12 +60,12 @@ class ProfileModulePermission
     #[Assert\NotBlank]
     public string $permission;
 
-    public bool $active;
+    public bool $enabled;
 
     /**
      * UpdateModulePermissionsCommand expects an $isActive constructor argument.
      */
     public const COMMAND_MAPPING = [
-        '[active]' => '[isActive]',
+        '[enabled]' => '[isActive]',
     ];
 }

--- a/src/ApiPlatform/Resources/Profile/ProfileModulePermission.php
+++ b/src/ApiPlatform/Resources/Profile/ProfileModulePermission.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Profile;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Command\UpdateModulePermissionsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Exception\InvalidPermissionValueException;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Exception\PermissionUpdateException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/profiles/{profileId}/module-permissions',
+            requirements: ['profileId' => '\d+'],
+            output: false,
+            CQRSCommand: UpdateModulePermissionsCommand::class,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            scopes: ['profile_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        InvalidPermissionValueException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        PermissionUpdateException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ProfileModulePermission
+{
+    #[ApiProperty(identifier: true)]
+    public int $profileId;
+
+    public int $moduleId;
+
+    /**
+     * One of view, add, edit, delete, all.
+     */
+    #[Assert\NotBlank]
+    public string $permission;
+
+    public bool $active;
+
+    /**
+     * UpdateModulePermissionsCommand expects an $isActive constructor argument.
+     */
+    public const COMMAND_MAPPING = [
+        '[active]' => '[isActive]',
+    ];
+}

--- a/src/ApiPlatform/Resources/Profile/ProfileTabPermission.php
+++ b/src/ApiPlatform/Resources/Profile/ProfileTabPermission.php
@@ -60,12 +60,12 @@ class ProfileTabPermission
     #[Assert\NotBlank]
     public string $permission;
 
-    public bool $active;
+    public bool $enabled;
 
     /**
      * UpdateTabPermissionsCommand expects an $isActive constructor argument.
      */
     public const COMMAND_MAPPING = [
-        '[active]' => '[isActive]',
+        '[enabled]' => '[isActive]',
     ];
 }

--- a/src/ApiPlatform/Resources/Profile/ProfileTabPermission.php
+++ b/src/ApiPlatform/Resources/Profile/ProfileTabPermission.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Profile;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Command\UpdateTabPermissionsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Exception\InvalidPermissionValueException;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Exception\PermissionUpdateException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/profiles/{profileId}/tab-permissions',
+            requirements: ['profileId' => '\d+'],
+            output: false,
+            CQRSCommand: UpdateTabPermissionsCommand::class,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            scopes: ['profile_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        InvalidPermissionValueException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        PermissionUpdateException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ProfileTabPermission
+{
+    #[ApiProperty(identifier: true)]
+    public int $profileId;
+
+    public int $tabId;
+
+    /**
+     * One of view, add, edit, delete, all.
+     */
+    #[Assert\NotBlank]
+    public string $permission;
+
+    public bool $active;
+
+    /**
+     * UpdateTabPermissionsCommand expects an $isActive constructor argument.
+     */
+    public const COMMAND_MAPPING = [
+        '[active]' => '[isActive]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/ProfilePermissionEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProfilePermissionEndpointTest.php
@@ -81,7 +81,7 @@ class ProfilePermissionEndpointTest extends ApiTestCase
         // Disable the "view" permission on the tab
         $this->updateItem(
             '/profiles/' . self::$profileId . '/tab-permissions',
-            ['tabId' => self::$tabId, 'permission' => 'view', 'active' => false],
+            ['tabId' => self::$tabId, 'permission' => 'view', 'enabled' => false],
             ['profile_write'],
             Response::HTTP_NO_CONTENT
         );
@@ -92,7 +92,7 @@ class ProfilePermissionEndpointTest extends ApiTestCase
         // Enable it
         $this->updateItem(
             '/profiles/' . self::$profileId . '/tab-permissions',
-            ['tabId' => self::$tabId, 'permission' => 'view', 'active' => true],
+            ['tabId' => self::$tabId, 'permission' => 'view', 'enabled' => true],
             ['profile_write'],
             Response::HTTP_NO_CONTENT
         );
@@ -105,7 +105,7 @@ class ProfilePermissionEndpointTest extends ApiTestCase
     {
         $this->updateItem(
             '/profiles/' . self::$profileId . '/tab-permissions',
-            ['tabId' => self::$tabId, 'permission' => 'not-a-permission', 'active' => true],
+            ['tabId' => self::$tabId, 'permission' => 'not-a-permission', 'enabled' => true],
             ['profile_write'],
             Response::HTTP_UNPROCESSABLE_ENTITY
         );
@@ -116,7 +116,7 @@ class ProfilePermissionEndpointTest extends ApiTestCase
         // Handler throws on failure, so a 204 confirms the module permission was updated
         $this->updateItem(
             '/profiles/' . self::$profileId . '/module-permissions',
-            ['moduleId' => self::$moduleId, 'permission' => 'view', 'active' => true],
+            ['moduleId' => self::$moduleId, 'permission' => 'view', 'enabled' => true],
             ['profile_write'],
             Response::HTTP_NO_CONTENT
         );

--- a/tests/Integration/ApiPlatform/ProfilePermissionEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProfilePermissionEndpointTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class ProfilePermissionEndpointTest extends ApiTestCase
+{
+    private static int $profileId;
+    private static int $tabId;
+    private static int $moduleId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['profile_write']);
+
+        $profile = new \Profile();
+        $profile->name = [];
+        foreach (\Language::getIDs(false) as $langId) {
+            $profile->name[(int) $langId] = 'API permission test profile';
+        }
+        $profile->add();
+        self::$profileId = (int) $profile->id;
+
+        // Pick a tab/module that actually has a "view" (READ) authorization role, otherwise
+        // updateLgcAccess() raises "slug not found" and the command fails.
+        self::$tabId = (int) \Db::getInstance()->getValue(
+            'SELECT t.`id_tab` FROM `' . _DB_PREFIX_ . 'tab` t
+             WHERE t.`class_name` != "" AND EXISTS (
+                 SELECT 1 FROM `' . _DB_PREFIX_ . 'authorization_role` r
+                 WHERE r.`slug` = CONCAT("ROLE_MOD_TAB_", UPPER(t.`class_name`), "_READ")
+             )
+             ORDER BY t.`id_tab` ASC'
+        );
+        self::$moduleId = (int) \Db::getInstance()->getValue(
+            'SELECT m.`id_module` FROM `' . _DB_PREFIX_ . 'module` m
+             WHERE EXISTS (
+                 SELECT 1 FROM `' . _DB_PREFIX_ . 'authorization_role` r
+                 WHERE r.`slug` = CONCAT("ROLE_MOD_MODULE_", UPPER(m.`name`), "_READ")
+             )
+             ORDER BY m.`id_module` ASC'
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['profile', 'profile_lang', 'access', 'module_access']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'tab permission endpoint' => ['PUT', '/profiles/1/tab-permissions'];
+        yield 'module permission endpoint' => ['PUT', '/profiles/1/module-permissions'];
+    }
+
+    public function testUpdateTabPermission(): void
+    {
+        // Disable the "view" permission on the tab
+        $this->updateItem(
+            '/profiles/' . self::$profileId . '/tab-permissions',
+            ['tabId' => self::$tabId, 'permission' => 'view', 'active' => false],
+            ['profile_write'],
+            Response::HTTP_NO_CONTENT
+        );
+        \Profile::resetStaticCache();
+        $access = \Profile::getProfileAccess(self::$profileId, self::$tabId);
+        $this->assertSame('0', $access['view']);
+
+        // Enable it
+        $this->updateItem(
+            '/profiles/' . self::$profileId . '/tab-permissions',
+            ['tabId' => self::$tabId, 'permission' => 'view', 'active' => true],
+            ['profile_write'],
+            Response::HTTP_NO_CONTENT
+        );
+        \Profile::resetStaticCache();
+        $access = \Profile::getProfileAccess(self::$profileId, self::$tabId);
+        $this->assertSame('1', $access['view']);
+    }
+
+    public function testUpdateTabPermissionWithInvalidPermissionIsRejected(): void
+    {
+        $this->updateItem(
+            '/profiles/' . self::$profileId . '/tab-permissions',
+            ['tabId' => self::$tabId, 'permission' => 'not-a-permission', 'active' => true],
+            ['profile_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+    }
+
+    public function testUpdateModulePermission(): void
+    {
+        // Handler throws on failure, so a 204 confirms the module permission was updated
+        $this->updateItem(
+            '/profiles/' . self::$profileId . '/module-permissions',
+            ['moduleId' => self::$moduleId, 'permission' => 'view', 'active' => true],
+            ['profile_write'],
+            Response::HTTP_NO_CONTENT
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Profile tab/module permission endpoints
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints to grant/revoke a profile's access permissions:

- `PUT /profiles/{profileId}/tab-permissions` — `UpdateTabPermissionsCommand`
- `PUT /profiles/{profileId}/module-permissions` — `UpdateModulePermissionsCommand`

Each takes a `{tabId | moduleId, permission, active}` body, where `permission` is one of
`view` / `add` / `edit` / `delete` / `all` (mapped to the command's `isActive` argument).
An invalid permission returns `422`.

The integration test seeds a profile via the `Profile` model, picks a tab/module that owns a
`READ` authorization role, toggles its `view` permission and verifies the result through
`Profile::getProfileAccess`. Declares no new scope — reuses `profile_write`.
