### PR TITLE
Add Language status & delete endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Language/BulkLanguages.php
+++ b/src/ApiPlatform/Resources/Language/BulkLanguages.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Language;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Language\Command\BulkDeleteLanguagesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\DefaultLanguageException;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/languages/bulk-delete',
+            CQRSCommand: BulkDeleteLanguagesCommand::class,
+            scopes: ['language_write'],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        LanguageNotFoundException::class => Response::HTTP_NOT_FOUND,
+        DefaultLanguageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        LanguageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkLanguages
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $languageIds;
+}

--- a/src/ApiPlatform/Resources/Language/BulkUpdateStatusLanguages.php
+++ b/src/ApiPlatform/Resources/Language/BulkUpdateStatusLanguages.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Language;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Language\Command\BulkToggleLanguagesStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/languages/bulk-update-status',
+            // No output, 204 code
+            output: false,
+            CQRSCommand: BulkToggleLanguagesStatusCommand::class,
+            CQRSCommandMapping: [
+                '[enabled]' => '[expectedStatus]',
+            ],
+            scopes: ['language_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        LanguageNotFoundException::class => Response::HTTP_NOT_FOUND,
+        LanguageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkUpdateStatusLanguages
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $languageIds;
+
+    public bool $enabled;
+}

--- a/src/ApiPlatform/Resources/Language/Language.php
+++ b/src/ApiPlatform/Resources/Language/Language.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Language;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Language\Command\DeleteLanguageCommand;
+use PrestaShop\PrestaShop\Core\Domain\Language\Command\ToggleLanguageStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\DefaultLanguageException;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageException;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSPartialUpdate(
+            uriTemplate: '/languages/{languageId}/set-status',
+            requirements: ['languageId' => '\d+'],
+            // No output, 204 code
+            output: false,
+            read: false,
+            CQRSCommand: ToggleLanguageStatusCommand::class,
+            CQRSCommandMapping: [
+                '[enabled]' => '[expectedStatus]',
+            ],
+            scopes: ['language_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/languages/{languageId}',
+            requirements: ['languageId' => '\d+'],
+            CQRSCommand: DeleteLanguageCommand::class,
+            scopes: ['language_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        LanguageNotFoundException::class => Response::HTTP_NOT_FOUND,
+        DefaultLanguageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        LanguageException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class Language
+{
+    #[ApiProperty(identifier: true)]
+    public int $languageId;
+
+    /**
+     * Only used by the set-status operation, mapped to the command expected status.
+     */
+    public bool $enabled;
+}

--- a/tests/Integration/ApiPlatform/LanguageEndpointTest.php
+++ b/tests/Integration/ApiPlatform/LanguageEndpointTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\Resetter\LanguageResetter;
+
+class LanguageEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['language_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        // Reset the languages (and the related tables) to the state they had before this test
+        LanguageResetter::resetLanguages();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set status endpoint' => [
+            'PATCH',
+            '/languages/1/set-status',
+        ];
+
+        yield 'delete endpoint' => [
+            'DELETE',
+            '/languages/1',
+        ];
+
+        yield 'bulk update status endpoint' => [
+            'PUT',
+            '/languages/bulk-update-status',
+        ];
+
+        yield 'bulk delete endpoint' => [
+            'DELETE',
+            '/languages/bulk-delete',
+        ];
+    }
+
+    public function testSetStatus(): void
+    {
+        $languageId = self::addLanguageByLocale('es-ES');
+        $this->assertTrue($this->getLanguageActiveStatus($languageId));
+
+        $this->partialUpdateItem('/languages/' . $languageId . '/set-status', [
+            'enabled' => false,
+        ], ['language_write'], Response::HTTP_NO_CONTENT);
+        $this->assertFalse($this->getLanguageActiveStatus($languageId));
+
+        $this->partialUpdateItem('/languages/' . $languageId . '/set-status', [
+            'enabled' => true,
+        ], ['language_write'], Response::HTTP_NO_CONTENT);
+        $this->assertTrue($this->getLanguageActiveStatus($languageId));
+    }
+
+    public function testSetStatusNotFound(): void
+    {
+        $this->partialUpdateItem('/languages/999999/set-status', [
+            'enabled' => false,
+        ], ['language_write'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testBulkUpdateStatus(): void
+    {
+        $languageId1 = self::addLanguageByLocale('it-IT');
+        $languageId2 = self::addLanguageByLocale('de-DE');
+
+        $this->updateItem('/languages/bulk-update-status', [
+            'languageIds' => [$languageId1, $languageId2],
+            'enabled' => false,
+        ], ['language_write'], Response::HTTP_NO_CONTENT);
+
+        $this->assertFalse($this->getLanguageActiveStatus($languageId1));
+        $this->assertFalse($this->getLanguageActiveStatus($languageId2));
+
+        $this->updateItem('/languages/bulk-update-status', [
+            'languageIds' => [$languageId1, $languageId2],
+            'enabled' => true,
+        ], ['language_write'], Response::HTTP_NO_CONTENT);
+
+        $this->assertTrue($this->getLanguageActiveStatus($languageId1));
+        $this->assertTrue($this->getLanguageActiveStatus($languageId2));
+    }
+
+    public function testDelete(): void
+    {
+        $languageId = self::addLanguageByLocale('pt-PT');
+        $this->assertTrue(\Validate::isLoadedObject(new \Language($languageId)));
+
+        $this->deleteItem('/languages/' . $languageId, ['language_write']);
+
+        $this->assertFalse(\Validate::isLoadedObject(new \Language($languageId)));
+    }
+
+    public function testBulkDelete(): void
+    {
+        $languageId1 = self::addLanguageByLocale('nl-NL');
+        $languageId2 = self::addLanguageByLocale('pl-PL');
+
+        $this->bulkDeleteItems('/languages/bulk-delete', [
+            'languageIds' => [$languageId1, $languageId2],
+        ], ['language_write']);
+
+        $this->assertFalse(\Validate::isLoadedObject(new \Language($languageId1)));
+        $this->assertFalse(\Validate::isLoadedObject(new \Language($languageId2)));
+    }
+
+    private function getLanguageActiveStatus(int $languageId): bool
+    {
+        return (bool) (new \Language($languageId))->active;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                       |
|-------------------|---------------------------------------------------------------|
| Description?      | Adds the Language status and deletion endpoints to the Admin API. The upload-heavy create/edit operations (flag & no-picture images) are intentionally left out of this PR. |
| Type?             | new feature                                                   |
| BC breaks?        | no                                                            |
| Deprecations?     | no                                                            |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                         |
| Sponsor company   |                                                               |
| How to test?      | Run `tests/Integration/ApiPlatform/LanguageEndpointTest.php`, or call the new endpoints with a `language_write` scoped API client. |

### Endpoints added

- `PATCH /languages/{languageId}/set-status` — `{ enabled }` (`ToggleLanguageStatusCommand`, 204)
- `PUT /languages/bulk-update-status` — `{ languageIds, enabled }` (`BulkToggleLanguagesStatusCommand`, 204)
- `DELETE /languages/{languageId}` — (`DeleteLanguageCommand`, 204)
- `DELETE /languages/bulk-delete` — `{ languageIds }` (`BulkDeleteLanguagesCommand`, 204)

All operations use the `language_write` scope. The default language cannot be deleted nor disabled (mapped to `422`), and a missing language returns `404`.
