### PR TITLE
Add Product stock update endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductStock.php
+++ b/src/ApiPlatform/Resources/Product/ProductStock.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command\UpdateProductStockAvailableCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\ProductStockConstraintException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/stocks',
+            requirements: ['productId' => '\d+'],
+            output: false,
+            CQRSCommand: UpdateProductStockAvailableCommand::class,
+            scopes: ['product_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ProductStockConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ProductStock
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    /**
+     * Quantity to add (positive) or remove (negative) from the available stock.
+     */
+    public ?int $deltaQuantity;
+
+    public ?int $outOfStockType;
+
+    public ?string $location;
+}

--- a/src/ApiPlatform/Resources/Product/ProductStock.php
+++ b/src/ApiPlatform/Resources/Product/ProductStock.php
@@ -37,6 +37,9 @@ use Symfony\Component\HttpFoundation\Response;
             requirements: ['productId' => '\d+'],
             output: false,
             CQRSCommand: UpdateProductStockAvailableCommand::class,
+            CQRSCommandMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
             scopes: ['product_write'],
         ),
     ],

--- a/tests/Integration/ApiPlatform/ProductStockEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductStockEndpointTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class ProductStockEndpointTest extends ApiTestCase
+{
+    private static int $productId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_write']);
+
+        // A simple product (no combinations) so the product-level stock is unambiguous
+        self::$productId = (int) \Db::getInstance()->getValue(
+            'SELECT p.`id_product` FROM `' . _DB_PREFIX_ . 'product` p
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM `' . _DB_PREFIX_ . 'product_attribute` pa WHERE pa.`id_product` = p.`id_product`
+             )
+             ORDER BY p.`id_product` ASC'
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['stock_available']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'update stock endpoint' => ['PUT', '/products/1/stocks'];
+    }
+
+    public function testUpdateProductStock(): void
+    {
+        $initial = (int) \StockAvailable::getQuantityAvailableByProduct(self::$productId);
+
+        $this->updateItem(
+            '/products/' . self::$productId . '/stocks',
+            ['deltaQuantity' => 5],
+            ['product_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $this->assertSame($initial + 5, (int) \StockAvailable::getQuantityAvailableByProduct(self::$productId));
+    }
+
+    public function testUpdateStockOnMissingProductReturnsNotFound(): void
+    {
+        $this->updateItem(
+            '/products/999999/stocks',
+            ['deltaQuantity' => 5],
+            ['product_write'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Product stock update endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`PUT /products/{productId}/stocks`** — `UpdateProductStockAvailableCommand`: adjusts a
product's available stock via `deltaQuantity` (positive to add, negative to remove), and optionally
its out-of-stock behaviour (`outOfStockType`) and stock `location`. The shop constraint is taken
from the request context. `404` when the product does not exist.

### ⚠️ Depends on a core fix — kept as a draft

A stock quantity change records a `StockMvt` attributed to the current employee. In the API context
there is no logged-in employee, so `StockManager` called `StockMvt::setIdEmployee(null)` →
`TypeError`. The core PR **PrestaShop/PrestaShop#41803** guards that (keeps `id_employee = 0` when the
context employee has no id). This PR stays a draft and red on the released-core matrices until that
fix ships; it goes green on `develop` once #41803 is merged.

The integration test picks a simple fixture product (no combinations), applies a `+5` delta and
verifies the resulting quantity via `StockAvailable`. Reuses the `product_write` scope.