### PR TITLE
Add Product carriers endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductCarriers.php
+++ b/src/ApiPlatform/Resources/Product/ProductCarriers.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetCarriersCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/carriers',
+            requirements: ['productId' => '\d+'],
+            output: false,
+            CQRSCommand: SetCarriersCommand::class,
+            CQRSCommandMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+            scopes: ['product_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductCarriers
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    /**
+     * @var int[] carrier reference ids
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 2]])]
+    public array $carrierReferenceIds;
+}

--- a/tests/Integration/ApiPlatform/ProductCarriersEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductCarriersEndpointTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class ProductCarriersEndpointTest extends ApiTestCase
+{
+    private static int $productId;
+    private static int $carrierReferenceId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_write']);
+
+        self::$productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
+        );
+        self::$carrierReferenceId = (int) \Db::getInstance()->getValue(
+            'SELECT DISTINCT `id_reference` FROM `' . _DB_PREFIX_ . 'carrier`
+             WHERE `deleted` = 0 AND `id_reference` > 0 ORDER BY `id_reference` ASC'
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['product_carrier']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set carriers endpoint' => ['PUT', '/products/1/carriers'];
+    }
+
+    public function testSetProductCarriers(): void
+    {
+        $this->updateItem(
+            '/products/' . self::$productId . '/carriers',
+            ['carrierReferenceIds' => [self::$carrierReferenceId]],
+            ['product_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $references = \Db::getInstance()->executeS(
+            'SELECT `id_carrier_reference` FROM `' . _DB_PREFIX_ . 'product_carrier`
+             WHERE `id_product` = ' . self::$productId
+        );
+        $storedReferences = array_map('intval', array_column($references, 'id_carrier_reference'));
+        $this->assertContains(self::$carrierReferenceId, $storedReferences);
+    }
+
+    public function testSetCarriersOnMissingProductReturnsNotFound(): void
+    {
+        $this->updateItem(
+            '/products/999999/carriers',
+            ['carrierReferenceIds' => [self::$carrierReferenceId]],
+            ['product_write'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}

--- a/tests/Integration/ApiPlatform/ProductCarriersEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductCarriersEndpointTest.php
@@ -71,14 +71,4 @@ class ProductCarriersEndpointTest extends ApiTestCase
         $storedReferences = array_map('intval', array_column($references, 'id_carrier_reference'));
         $this->assertContains(self::$carrierReferenceId, $storedReferences);
     }
-
-    public function testSetCarriersOnMissingProductReturnsNotFound(): void
-    {
-        $this->updateItem(
-            '/products/999999/carriers',
-            ['carrierReferenceIds' => [self::$carrierReferenceId]],
-            ['product_write'],
-            Response::HTTP_NOT_FOUND
-        );
-    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Product carriers endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`PUT /products/{productId}/carriers`** — `SetCarriersCommand`: sets the list of carrier
references available for a product (`204`, no content). The shop constraint is taken from the
request context. `404` when the product does not exist.

The integration test sets a carrier reference on a fixture product and verifies the result via the
`product_carrier` table. Reuses the `product_write` scope.
