### PR TITLE
Add OrderMessage Admin API endpoints (CRUD + list + bulk delete)

### DIFF
--- a/src/ApiPlatform/Resources/OrderMessage/BulkDeleteOrderMessage.php
+++ b/src/ApiPlatform/Resources/OrderMessage/BulkDeleteOrderMessage.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderMessage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Command\BulkDeleteOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Exception\OrderMessageNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/order-messages/bulk-delete',
+            CQRSCommand: BulkDeleteOrderMessageCommand::class,
+            scopes: [
+                'order_message_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        OrderMessageNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteOrderMessage
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $orderMessageIds;
+}

--- a/src/ApiPlatform/Resources/OrderMessage/OrderMessage.php
+++ b/src/ApiPlatform/Resources/OrderMessage/OrderMessage.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderMessage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Command\AddOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Command\DeleteOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Command\EditOrderMessageCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Exception\OrderMessageConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Exception\OrderMessageNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderMessage\Query\GetOrderMessageForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/order-messages/{orderMessageId}',
+            requirements: ['orderMessageId' => '\d+'],
+            CQRSQuery: GetOrderMessageForEditing::class,
+            scopes: [
+                'order_message_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/order-messages',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddOrderMessageCommand::class,
+            CQRSQuery: GetOrderMessageForEditing::class,
+            scopes: [
+                'order_message_write',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/order-messages/{orderMessageId}',
+            requirements: ['orderMessageId' => '\d+'],
+            CQRSCommand: EditOrderMessageCommand::class,
+            CQRSQuery: GetOrderMessageForEditing::class,
+            scopes: [
+                'order_message_write',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/order-messages/{orderMessageId}',
+            requirements: ['orderMessageId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteOrderMessageCommand::class,
+            scopes: [
+                'order_message_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderMessageNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderMessageConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderMessage
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderMessageId;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'names')]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'names', allowNull: true)]
+    public array $names;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'messages')]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'messages', allowNull: true)]
+    public array $messages;
+
+    public const QUERY_MAPPING = [
+        '[localizedName]' => '[names]',
+        '[localizedMessage]' => '[messages]',
+    ];
+
+    public const COMMAND_MAPPING = [
+        '[names]' => '[localizedName]',
+        '[messages]' => '[localizedMessage]',
+    ];
+}

--- a/src/ApiPlatform/Resources/OrderMessage/OrderMessageList.php
+++ b/src/ApiPlatform/Resources/OrderMessage/OrderMessageList.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderMessage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Search\Filters\OrderMessageFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/order-messages',
+            scopes: [
+                'order_message_read',
+            ],
+            ApiResourceMapping: self::MAPPING,
+            gridDataFactory: 'prestashop.core.grid.data.factory.order_message',
+            filtersClass: OrderMessageFilters::class,
+            filtersMapping: [
+                '[orderMessageId]' => '[id_order_message]',
+            ],
+        ),
+    ]
+)]
+class OrderMessageList
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderMessageId;
+
+    public string $name;
+
+    public string $message;
+
+    public const MAPPING = [
+        '[id_order_message]' => '[orderMessageId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/OrderMessageEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderMessageEndpointTest.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderMessageEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient(['order_message_read', 'order_message_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'order_message',
+            'order_message_lang',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get endpoint' => [
+            'GET',
+            '/order-messages/1',
+        ];
+
+        yield 'create endpoint' => [
+            'POST',
+            '/order-messages',
+        ];
+
+        yield 'patch endpoint' => [
+            'PATCH',
+            '/order-messages/1',
+        ];
+
+        yield 'list endpoint' => [
+            'GET',
+            '/order-messages',
+        ];
+    }
+
+    public function testAddOrderMessage(): int
+    {
+        $postData = [
+            'names' => [
+                'en-US' => 'Order message EN',
+                'fr-FR' => 'Order message FR',
+            ],
+            'messages' => [
+                'en-US' => 'Message content EN',
+                'fr-FR' => 'Message content FR',
+            ],
+        ];
+
+        $orderMessage = $this->createItem('/order-messages', $postData, ['order_message_write']);
+        $this->assertArrayHasKey('orderMessageId', $orderMessage);
+        $orderMessageId = $orderMessage['orderMessageId'];
+
+        $this->assertSame($postData['names'], $orderMessage['names']);
+        $this->assertSame($postData['messages'], $orderMessage['messages']);
+
+        return $orderMessageId;
+    }
+
+    /**
+     * @depends testAddOrderMessage
+     */
+    public function testGetOrderMessage(int $orderMessageId): int
+    {
+        $orderMessage = $this->getItem('/order-messages/' . $orderMessageId, ['order_message_read']);
+        $this->assertEquals($orderMessageId, $orderMessage['orderMessageId']);
+        $this->assertArrayHasKey('names', $orderMessage);
+        $this->assertArrayHasKey('messages', $orderMessage);
+
+        return $orderMessageId;
+    }
+
+    /**
+     * @depends testGetOrderMessage
+     */
+    public function testPartialUpdateOrderMessage(int $orderMessageId): int
+    {
+        $patchData = [
+            'names' => [
+                'en-US' => 'Updated message EN',
+                'fr-FR' => 'Updated message FR',
+            ],
+            'messages' => [
+                'en-US' => 'Updated content EN',
+                'fr-FR' => 'Updated content FR',
+            ],
+        ];
+
+        $updatedOrderMessage = $this->partialUpdateItem('/order-messages/' . $orderMessageId, $patchData, ['order_message_write']);
+        $this->assertSame($patchData['names'], $updatedOrderMessage['names']);
+        $this->assertSame($patchData['messages'], $updatedOrderMessage['messages']);
+
+        // We check that when we GET the item it is updated as expected
+        $orderMessage = $this->getItem('/order-messages/' . $orderMessageId, ['order_message_read']);
+        $this->assertSame($patchData['names'], $orderMessage['names']);
+        $this->assertSame($patchData['messages'], $orderMessage['messages']);
+
+        return $orderMessageId;
+    }
+
+    /**
+     * @depends testPartialUpdateOrderMessage
+     */
+    public function testListOrderMessages(int $orderMessageId): int
+    {
+        $paginatedOrderMessages = $this->listItems('/order-messages?orderBy=orderMessageId&sortOrder=desc', ['order_message_read']);
+        $this->assertGreaterThanOrEqual(1, $paginatedOrderMessages['totalItems']);
+        $this->assertEquals('orderMessageId', $paginatedOrderMessages['orderBy']);
+
+        $firstOrderMessage = $paginatedOrderMessages['items'][0];
+        $this->assertEquals($orderMessageId, $firstOrderMessage['orderMessageId']);
+
+        return $orderMessageId;
+    }
+
+    /**
+     * @depends testListOrderMessages
+     */
+    public function testDeleteOrderMessage(int $orderMessageId): void
+    {
+        $return = $this->deleteItem('/order-messages/' . $orderMessageId, ['order_message_write']);
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+
+        // Getting the item should result in a 404 now
+        $this->getItem('/order-messages/' . $orderMessageId, ['order_message_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @depends testDeleteOrderMessage
+     */
+    public function testBulkDeleteOrderMessages(): void
+    {
+        $bulkIds = [];
+        foreach (['A', 'B'] as $suffix) {
+            $created = $this->createItem('/order-messages', [
+                'names' => ['en-US' => 'Bulk message ' . $suffix],
+                'messages' => ['en-US' => 'Bulk content ' . $suffix],
+            ], ['order_message_write']);
+            $bulkIds[] = $created['orderMessageId'];
+        }
+
+        $this->bulkDeleteItems('/order-messages/bulk-delete', [
+            'orderMessageIds' => $bulkIds,
+        ], ['order_message_write']);
+
+        // Assert the provided order messages have been removed
+        foreach ($bulkIds as $orderMessageId) {
+            $this->getItem('/order-messages/' . $orderMessageId, ['order_message_read'], Response::HTTP_NOT_FOUND);
+        }
+    }
+
+    public function testInvalidOrderMessage(): void
+    {
+        $invalidData = [
+            'names' => [
+                'fr-FR' => 'Nom FR',
+            ],
+            'messages' => [
+                'fr-FR' => 'Message FR',
+            ],
+        ];
+
+        $validationErrorsResponse = $this->createItem('/order-messages', $invalidData, ['order_message_write'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertIsArray($validationErrorsResponse);
+
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'names',
+                'message' => 'The field names is required at least in your default language.',
+            ],
+            [
+                'propertyPath' => 'messages',
+                'message' => 'The field messages is required at least in your default language.',
+            ],
+        ], $validationErrorsResponse);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the **OrderMessage** domain through the Admin API. <br> - `GET /order-messages/{orderMessageId}` (scope `order_message_read`) <br> - `POST /order-messages` (scope `order_message_write`) <br> - `PATCH /order-messages/{orderMessageId}` (scope `order_message_write`) <br> - `DELETE /order-messages/{orderMessageId}` (scope `order_message_write`) <br> - `GET /order-messages` paginated list (scope `order_message_read`) <br> - `DELETE /order-messages/bulk-delete` (scope `order_message_write`)
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `OrderMessageEndpointTest`. Create an order message via `POST /order-messages` with localized `names`/`messages`, then `GET`/`PATCH`/`DELETE` it, list via `GET /order-messages`, and remove several at once via `DELETE /order-messages/bulk-delete` with `{ orderMessageIds }`.
| Sponsor company   |

Adds CRUD, paginated list and bulk-delete API Platform resources for the `OrderMessage` domain, mirroring the existing `Contact`/`Title` endpoints. The underlying CQRS classes (`AddOrderMessageCommand`, `EditOrderMessageCommand`, `DeleteOrderMessageCommand`, `BulkDeleteOrderMessageCommand`, `GetOrderMessageForEditing`) were verified to exist as of tag `9.0.3`, so this is compatible with the lower bound of the CI test matrix.