### PR TITLE
Add OrderState Admin API endpoints (CRUD + list + bulk delete)

### DIFF
--- a/src/ApiPlatform/Resources/OrderState/BulkDeleteOrderState.php
+++ b/src/ApiPlatform/Resources/OrderState/BulkDeleteOrderState.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderState;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\BulkDeleteOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/order-states/bulk-delete',
+            CQRSCommand: BulkDeleteOrderStateCommand::class,
+            scopes: [
+                'order_state_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        OrderStateException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteOrderState
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $orderStateIds;
+}

--- a/src/ApiPlatform/Resources/OrderState/OrderState.php
+++ b/src/ApiPlatform/Resources/OrderState/OrderState.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderState;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\AddOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\DeleteOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Command\EditOrderStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\DuplicateOrderStateNameException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Exception\OrderStateNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderState\Query\GetOrderStateForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/order-states/{orderStateId}',
+            requirements: ['orderStateId' => '\d+'],
+            CQRSQuery: GetOrderStateForEditing::class,
+            scopes: [
+                'order_state_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/order-states',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddOrderStateCommand::class,
+            CQRSQuery: GetOrderStateForEditing::class,
+            scopes: [
+                'order_state_write',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::CREATE_COMMAND_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/order-states/{orderStateId}',
+            requirements: ['orderStateId' => '\d+'],
+            CQRSCommand: EditOrderStateCommand::class,
+            CQRSQuery: GetOrderStateForEditing::class,
+            scopes: [
+                'order_state_write',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::UPDATE_COMMAND_MAPPING,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/order-states/{orderStateId}',
+            requirements: ['orderStateId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteOrderStateCommand::class,
+            scopes: [
+                'order_state_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderStateNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderStateConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        DuplicateOrderStateNameException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderState
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderStateId;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'names')]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'names', allowNull: true)]
+    public array $names;
+
+    #[LocalizedValue]
+    public array $templates;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $color;
+
+    public bool $loggable;
+
+    public bool $invoice;
+
+    public bool $hidden;
+
+    public bool $sendEmail;
+
+    public bool $pdfInvoice;
+
+    public bool $pdfDelivery;
+
+    public bool $shipped;
+
+    public bool $paid;
+
+    public bool $delivery;
+
+    public const QUERY_MAPPING = [
+        '[localizedNames]' => '[names]',
+        '[localizedTemplates]' => '[templates]',
+        '[sendEmailEnabled]' => '[sendEmail]',
+    ];
+
+    public const CREATE_COMMAND_MAPPING = [
+        '[names]' => '[localizedNames]',
+        '[templates]' => '[localizedTemplates]',
+    ];
+
+    public const UPDATE_COMMAND_MAPPING = [
+        '[names]' => '[name]',
+        '[templates]' => '[template]',
+    ];
+}

--- a/src/ApiPlatform/Resources/OrderState/OrderStateList.php
+++ b/src/ApiPlatform/Resources/OrderState/OrderStateList.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderState;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Search\Filters\OrderStatesFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/order-states',
+            scopes: [
+                'order_state_read',
+            ],
+            ApiResourceMapping: self::MAPPING,
+            gridDataFactory: 'prestashop.core.grid.data_provider.order_states',
+            filtersClass: OrderStatesFilters::class,
+            filtersMapping: [
+                '[orderStateId]' => '[id_order_state]',
+            ],
+        ),
+    ]
+)]
+class OrderStateList
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderStateId;
+
+    public string $name;
+
+    public string $color;
+
+    public const MAPPING = [
+        '[id_order_state]' => '[orderStateId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/OrderStateEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderStateEndpointTest.php
@@ -1,0 +1,225 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderStateEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient(['order_state_read', 'order_state_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'order_state',
+            'order_state_lang',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get endpoint' => [
+            'GET',
+            '/order-states/1',
+        ];
+
+        yield 'create endpoint' => [
+            'POST',
+            '/order-states',
+        ];
+
+        yield 'patch endpoint' => [
+            'PATCH',
+            '/order-states/1',
+        ];
+
+        yield 'list endpoint' => [
+            'GET',
+            '/order-states',
+        ];
+    }
+
+    private function getCreateData(): array
+    {
+        return [
+            'names' => [
+                'en-US' => 'Awaiting review EN',
+                'fr-FR' => 'Awaiting review FR',
+            ],
+            'templates' => [
+                'en-US' => '',
+                'fr-FR' => '',
+            ],
+            'color' => '#4169E1',
+            'loggable' => false,
+            'invoice' => false,
+            'hidden' => false,
+            'sendEmail' => false,
+            'pdfInvoice' => false,
+            'pdfDelivery' => false,
+            'shipped' => false,
+            'paid' => false,
+            'delivery' => false,
+        ];
+    }
+
+    public function testAddOrderState(): int
+    {
+        $orderState = $this->createItem('/order-states', $this->getCreateData(), ['order_state_write']);
+        $this->assertArrayHasKey('orderStateId', $orderState);
+        $orderStateId = $orderState['orderStateId'];
+
+        $this->assertSame($this->getCreateData()['names'], $orderState['names']);
+        $this->assertSame('#4169E1', $orderState['color']);
+
+        return $orderStateId;
+    }
+
+    /**
+     * @depends testAddOrderState
+     */
+    public function testGetOrderState(int $orderStateId): int
+    {
+        $orderState = $this->getItem('/order-states/' . $orderStateId, ['order_state_read']);
+        $this->assertEquals($orderStateId, $orderState['orderStateId']);
+        $this->assertArrayHasKey('names', $orderState);
+        $this->assertArrayHasKey('color', $orderState);
+        $this->assertArrayHasKey('sendEmail', $orderState);
+
+        return $orderStateId;
+    }
+
+    /**
+     * @depends testGetOrderState
+     */
+    public function testPartialUpdateOrderState(int $orderStateId): int
+    {
+        $patchData = [
+            'names' => [
+                'en-US' => 'Updated status EN',
+                'fr-FR' => 'Updated status FR',
+            ],
+            'color' => '#32CD32',
+        ];
+
+        $updatedOrderState = $this->partialUpdateItem('/order-states/' . $orderStateId, $patchData, ['order_state_write']);
+        $this->assertSame($patchData['names'], $updatedOrderState['names']);
+        $this->assertSame($patchData['color'], $updatedOrderState['color']);
+
+        // We check that when we GET the item it is updated as expected
+        $orderState = $this->getItem('/order-states/' . $orderStateId, ['order_state_read']);
+        $this->assertSame($patchData['names'], $orderState['names']);
+        $this->assertSame($patchData['color'], $orderState['color']);
+
+        return $orderStateId;
+    }
+
+    /**
+     * @depends testPartialUpdateOrderState
+     */
+    public function testListOrderStates(int $orderStateId): int
+    {
+        $paginatedOrderStates = $this->listItems('/order-states?orderBy=orderStateId&sortOrder=desc', ['order_state_read']);
+        $this->assertGreaterThanOrEqual(1, $paginatedOrderStates['totalItems']);
+        $this->assertEquals('orderStateId', $paginatedOrderStates['orderBy']);
+
+        $firstOrderState = $paginatedOrderStates['items'][0];
+        $this->assertEquals($orderStateId, $firstOrderState['orderStateId']);
+
+        return $orderStateId;
+    }
+
+    /**
+     * @depends testListOrderStates
+     */
+    public function testDeleteOrderState(int $orderStateId): void
+    {
+        $return = $this->deleteItem('/order-states/' . $orderStateId, ['order_state_write']);
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+
+        // Getting the item should result in a 404 now
+        $this->getItem('/order-states/' . $orderStateId, ['order_state_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @depends testDeleteOrderState
+     */
+    public function testBulkDeleteOrderStates(): void
+    {
+        $bulkIds = [];
+        foreach (['A', 'B'] as $suffix) {
+            $data = $this->getCreateData();
+            $data['names'] = [
+                'en-US' => 'Bulk status ' . $suffix,
+                'fr-FR' => 'Bulk status ' . $suffix,
+            ];
+            $created = $this->createItem('/order-states', $data, ['order_state_write']);
+            $bulkIds[] = $created['orderStateId'];
+        }
+
+        $this->bulkDeleteItems('/order-states/bulk-delete', [
+            'orderStateIds' => $bulkIds,
+        ], ['order_state_write']);
+
+        // Assert the provided order states have been removed
+        foreach ($bulkIds as $orderStateId) {
+            $this->getItem('/order-states/' . $orderStateId, ['order_state_read'], Response::HTTP_NOT_FOUND);
+        }
+    }
+
+    public function testInvalidOrderState(): void
+    {
+        $invalidData = $this->getCreateData();
+        $invalidData['names'] = [
+            'fr-FR' => 'Nom FR uniquement',
+        ];
+        $invalidData['color'] = '';
+
+        $validationErrorsResponse = $this->createItem('/order-states', $invalidData, ['order_state_write'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertIsArray($validationErrorsResponse);
+
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'names',
+                'message' => 'The field names is required at least in your default language.',
+            ],
+            [
+                'propertyPath' => 'color',
+                'message' => 'This value should not be blank.',
+            ],
+        ], $validationErrorsResponse);
+    }
+}

--- a/tests/Integration/ApiPlatform/OrderStateEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderStateEndpointTest.php
@@ -170,8 +170,11 @@ class OrderStateEndpointTest extends ApiTestCase
         // This endpoint returns an empty response and a 204 HTTP code
         $this->assertNull($return);
 
-        // Getting the item should result in a 404 now
-        $this->getItem('/order-states/' . $orderStateId, ['order_state_read'], Response::HTTP_NOT_FOUND);
+        // Order states are soft-deleted (existing orders may reference them): the record is
+        // flagged as deleted and no longer appears in the listing.
+        $orderStates = $this->listItems('/order-states?orderBy=orderStateId&sortOrder=desc', ['order_state_read']);
+        $listedIds = array_column($orderStates['items'], 'orderStateId');
+        $this->assertNotContains($orderStateId, $listedIds);
     }
 
     /**
@@ -194,9 +197,11 @@ class OrderStateEndpointTest extends ApiTestCase
             'orderStateIds' => $bulkIds,
         ], ['order_state_write']);
 
-        // Assert the provided order states have been removed
+        // Soft-deleted order states no longer appear in the listing
+        $orderStates = $this->listItems('/order-states?orderBy=orderStateId&sortOrder=desc', ['order_state_read']);
+        $listedIds = array_column($orderStates['items'], 'orderStateId');
         foreach ($bulkIds as $orderStateId) {
-            $this->getItem('/order-states/' . $orderStateId, ['order_state_read'], Response::HTTP_NOT_FOUND);
+            $this->assertNotContains($orderStateId, $listedIds);
         }
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the **OrderState** domain through the Admin API. <br> - `GET /order-states/{orderStateId}` (scope `order_state_read`) <br> - `POST /order-states` (scope `order_state_write`) <br> - `PATCH /order-states/{orderStateId}` (scope `order_state_write`) <br> - `DELETE /order-states/{orderStateId}` (scope `order_state_write`) <br> - `GET /order-states` paginated list (scope `order_state_read`) <br> - `DELETE /order-states/bulk-delete` (scope `order_state_write`) <br><br> The status **icon upload** is intentionally not exposed in this first version (the icon is set through a separate `setFileInformation` call, not the command constructor) and can be added as a follow-up.
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `OrderStateEndpointTest`. Create an order state via `POST /order-states` (localized `names`/`templates`, `color`, and the boolean flags), then `GET`/`PATCH`/`DELETE` it, list via `GET /order-states`, and remove several at once via `DELETE /order-states/bulk-delete` with `{ orderStateIds }`.
| Sponsor company   |

Adds CRUD, paginated list and bulk-delete API Platform resources for the `OrderState` domain, mirroring the existing `Contact`/`Title` endpoints. Create and update use distinct command mappings (`AddOrderStateCommand` expects `localizedNames`/`localizedTemplates`, `EditOrderStateCommand` uses `name`/`template` setters). All underlying CQRS classes were verified to exist as of tag `9.0.3`, so this is compatible with the lower bound of the CI test matrix.