### PR TITLE
Add Product customization fields endpoints (set + remove all)

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductCustomizationFields.php
+++ b/src/ApiPlatform/Resources/Product/ProductCustomizationFields.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\RemoveAllCustomizationFieldsFromProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Command\SetProductCustomizationFieldsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Exception\CustomizationException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/customization-fields',
+            requirements: ['productId' => '\d+'],
+            output: false,
+            CQRSCommand: SetProductCustomizationFieldsCommand::class,
+            CQRSCommandMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+            scopes: ['product_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/products/{productId}/customization-fields',
+            requirements: ['productId' => '\d+'],
+            output: false,
+            CQRSCommand: RemoveAllCustomizationFieldsFromProductCommand::class,
+            scopes: ['product_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomizationException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ProductCustomizationFields
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    /**
+     * Each entry describes a customization field. `type` is 1 for a text field, 0 for a file field.
+     *
+     * @var array<int, array{type: int, localized_names: array<int, string>, is_required: bool, added_by_module: bool, id?: int}>
+     */
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => ['type' => 'object'],
+        'example' => [['type' => 1, 'localized_names' => [1 => 'Custom text'], 'is_required' => false, 'added_by_module' => false]],
+    ])]
+    public array $customizationFields;
+}

--- a/tests/Integration/ApiPlatform/ProductCustomizationFieldsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductCustomizationFieldsEndpointTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class ProductCustomizationFieldsEndpointTest extends ApiTestCase
+{
+    private static int $productId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_write']);
+
+        self::$productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['customization_field', 'customization_field_lang', 'product']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set customization fields endpoint' => ['PUT', '/products/1/customization-fields'];
+        yield 'remove all customization fields endpoint' => ['DELETE', '/products/1/customization-fields'];
+    }
+
+    private function countFields(): int
+    {
+        return (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'customization_field` WHERE `id_product` = ' . self::$productId
+        );
+    }
+
+    public function testSetProductCustomizationFields(): int
+    {
+        $this->updateItem(
+            '/products/' . self::$productId . '/customization-fields',
+            ['customizationFields' => [
+                [
+                    'type' => 1,
+                    'localized_names' => [1 => 'Engraving text'],
+                    'is_required' => false,
+                    'added_by_module' => false,
+                ],
+            ]],
+            ['product_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $this->assertGreaterThanOrEqual(1, $this->countFields());
+
+        return self::$productId;
+    }
+
+    /**
+     * @depends testSetProductCustomizationFields
+     */
+    public function testRemoveAllProductCustomizationFields(int $productId): void
+    {
+        $this->deleteItem('/products/' . $productId . '/customization-fields', ['product_write']);
+
+        $this->assertSame(0, $this->countFields());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Product customization fields endpoints (set + remove all)
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints to manage a product's customization fields:

- `PUT /products/{productId}/customization-fields` — `SetProductCustomizationFieldsCommand`
- `DELETE /products/{productId}/customization-fields` — `RemoveAllCustomizationFieldsFromProductCommand`

Each `PUT` entry describes a customization field (`type` 1 = text / 0 = file, `localized_names`,
`is_required`, `added_by_module`). The shop constraint is taken from the request context. Both return `204`.

The integration test sets a text field on a fixture product, verifies a field exists via the
`customization_field` table, then removes all. Reuses the `product_write` scope.
