### PR TITLE
Add CmsPageCategory Admin API endpoints (CRUD + status + bulk)

### DIFF
--- a/src/ApiPlatform/Resources/CmsPageCategory/BulkDeleteCmsPageCategory.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/BulkDeleteCmsPageCategory.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\BulkDeleteCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/cms-page-categories/bulk-delete',
+            CQRSCommand: BulkDeleteCmsPageCategoryCommand::class,
+            scopes: [
+                'cms_page_category_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageCategoryException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteCmsPageCategory
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $cmsPageCategoryIds;
+}

--- a/src/ApiPlatform/Resources/CmsPageCategory/BulkUpdateStatusCmsPageCategory.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/BulkUpdateStatusCmsPageCategory.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\BulkDisableCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\BulkEnableCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/cms-page-categories/bulk-enable',
+            output: false,
+            CQRSCommand: BulkEnableCmsPageCategoryCommand::class,
+            scopes: [
+                'cms_page_category_write',
+            ],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/cms-page-categories/bulk-disable',
+            output: false,
+            CQRSCommand: BulkDisableCmsPageCategoryCommand::class,
+            scopes: [
+                'cms_page_category_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageCategoryException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkUpdateStatusCmsPageCategory
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $cmsPageCategoryIds;
+}

--- a/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategory.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategory.php
@@ -144,4 +144,13 @@ class CmsPageCategory
         '[metaDescriptions]' => '[localisedMetaDescription]',
         '[shopIds]' => '[shopAssociation]',
     ];
+
+    // The legacy query result may expose the status as a string ("1"/"0"), so we
+    // coerce it here to keep the typed bool property happy across versions.
+    public function setDisplayed(string|int|bool $displayed): self
+    {
+        $this->displayed = (bool) $displayed;
+
+        return $this;
+    }
 }

--- a/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategory.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategory.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\AddCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\DeleteCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\EditCmsPageCategoryCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Command\ToggleCmsPageCategoryStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Exception\CmsPageCategoryNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageCategoryForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}',
+            requirements: ['cmsPageCategoryId' => '\d+'],
+            CQRSQuery: GetCmsPageCategoryForEditing::class,
+            scopes: [
+                'cms_page_category_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/cms-page-categories',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddCmsPageCategoryCommand::class,
+            CQRSQuery: GetCmsPageCategoryForEditing::class,
+            scopes: [
+                'cms_page_category_write',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}',
+            requirements: ['cmsPageCategoryId' => '\d+'],
+            CQRSCommand: EditCmsPageCategoryCommand::class,
+            CQRSQuery: GetCmsPageCategoryForEditing::class,
+            scopes: [
+                'cms_page_category_write',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}/toggle-status',
+            requirements: ['cmsPageCategoryId' => '\d+'],
+            output: false,
+            allowEmptyBody: true,
+            CQRSCommand: ToggleCmsPageCategoryStatusCommand::class,
+            scopes: [
+                'cms_page_category_write',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}',
+            requirements: ['cmsPageCategoryId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteCmsPageCategoryCommand::class,
+            scopes: [
+                'cms_page_category_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageCategoryNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CmsPageCategoryConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CmsPageCategory
+{
+    #[ApiProperty(identifier: true)]
+    public int $cmsPageCategoryId;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'names')]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'names', allowNull: true)]
+    public array $names;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'linkRewrites')]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'linkRewrites', allowNull: true)]
+    public array $linkRewrites;
+
+    public int $parentId;
+
+    public bool $displayed;
+
+    #[LocalizedValue]
+    public array $descriptions;
+
+    #[LocalizedValue]
+    public array $metaTitles;
+
+    #[LocalizedValue]
+    public array $metaDescriptions;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    public array $shopIds;
+
+    public const QUERY_MAPPING = [
+        '[localisedName]' => '[names]',
+        '[localisedFriendlyUrl]' => '[linkRewrites]',
+        '[localisedDescription]' => '[descriptions]',
+        '[metaTitle]' => '[metaTitles]',
+        '[localisedMetaDescription]' => '[metaDescriptions]',
+    ];
+
+    public const COMMAND_MAPPING = [
+        '[names]' => '[localisedName]',
+        '[linkRewrites]' => '[localisedFriendlyUrl]',
+        '[displayed]' => '[isDisplayed]',
+        '[descriptions]' => '[localisedDescription]',
+        '[metaTitles]' => '[localisedMetaTitle]',
+        '[metaDescriptions]' => '[localisedMetaDescription]',
+        '[shopIds]' => '[shopAssociation]',
+    ];
+}

--- a/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryList.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryList.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Search\Filters\CmsPageCategoryFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/cms-page-categories',
+            scopes: [
+                'cms_page_category_read',
+            ],
+            ApiResourceMapping: self::MAPPING,
+            gridDataFactory: 'prestashop.core.grid.data_provider.cms_page_category',
+            filtersClass: CmsPageCategoryFilters::class,
+            filtersMapping: [
+                '[cmsPageCategoryId]' => '[id_cms_category]',
+            ],
+        ),
+    ]
+)]
+class CmsPageCategoryList
+{
+    #[ApiProperty(identifier: true)]
+    public int $cmsPageCategoryId;
+
+    public string $name;
+
+    public string $description;
+
+    public const MAPPING = [
+        '[id_cms_category]' => '[cmsPageCategoryId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CmsPageCategoryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CmsPageCategoryEndpointTest.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CmsPageCategoryEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient(['cms_page_category_read', 'cms_page_category_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'cms_category',
+            'cms_category_lang',
+            'cms_category_shop',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get endpoint' => [
+            'GET',
+            '/cms-page-categories/1',
+        ];
+
+        yield 'create endpoint' => [
+            'POST',
+            '/cms-page-categories',
+        ];
+
+        yield 'patch endpoint' => [
+            'PATCH',
+            '/cms-page-categories/1',
+        ];
+
+        yield 'list endpoint' => [
+            'GET',
+            '/cms-page-categories',
+        ];
+    }
+
+    private function getCreateData(): array
+    {
+        return [
+            'names' => [
+                'en-US' => 'Category EN',
+                'fr-FR' => 'Category FR',
+            ],
+            'linkRewrites' => [
+                'en-US' => 'category-en',
+                'fr-FR' => 'category-fr',
+            ],
+            'parentId' => 1,
+            'displayed' => true,
+            'descriptions' => [
+                'en-US' => 'Description EN',
+                'fr-FR' => 'Description FR',
+            ],
+            'metaTitles' => [
+                'en-US' => 'Meta title EN',
+                'fr-FR' => 'Meta title FR',
+            ],
+            'metaDescriptions' => [
+                'en-US' => '',
+                'fr-FR' => '',
+            ],
+            'shopIds' => [1],
+        ];
+    }
+
+    public function testAddCmsPageCategory(): int
+    {
+        $cmsPageCategory = $this->createItem('/cms-page-categories', $this->getCreateData(), ['cms_page_category_write']);
+        $this->assertArrayHasKey('cmsPageCategoryId', $cmsPageCategory);
+        $cmsPageCategoryId = $cmsPageCategory['cmsPageCategoryId'];
+
+        $this->assertSame($this->getCreateData()['names'], $cmsPageCategory['names']);
+        $this->assertSame($this->getCreateData()['linkRewrites'], $cmsPageCategory['linkRewrites']);
+        $this->assertEquals(1, $cmsPageCategory['parentId']);
+        $this->assertTrue($cmsPageCategory['displayed']);
+
+        return $cmsPageCategoryId;
+    }
+
+    /**
+     * @depends testAddCmsPageCategory
+     */
+    public function testGetCmsPageCategory(int $cmsPageCategoryId): int
+    {
+        $cmsPageCategory = $this->getItem('/cms-page-categories/' . $cmsPageCategoryId, ['cms_page_category_read']);
+        $this->assertEquals($cmsPageCategoryId, $cmsPageCategory['cmsPageCategoryId']);
+        $this->assertArrayHasKey('names', $cmsPageCategory);
+        $this->assertArrayHasKey('linkRewrites', $cmsPageCategory);
+        $this->assertEquals(1, $cmsPageCategory['parentId']);
+
+        return $cmsPageCategoryId;
+    }
+
+    /**
+     * @depends testGetCmsPageCategory
+     */
+    public function testPartialUpdateCmsPageCategory(int $cmsPageCategoryId): int
+    {
+        $patchData = [
+            'names' => [
+                'en-US' => 'Updated category EN',
+                'fr-FR' => 'Updated category FR',
+            ],
+            'displayed' => false,
+        ];
+
+        $updatedCmsPageCategory = $this->partialUpdateItem('/cms-page-categories/' . $cmsPageCategoryId, $patchData, ['cms_page_category_write']);
+        $this->assertSame($patchData['names'], $updatedCmsPageCategory['names']);
+        $this->assertFalse($updatedCmsPageCategory['displayed']);
+
+        // We check that when we GET the item it is updated as expected
+        $cmsPageCategory = $this->getItem('/cms-page-categories/' . $cmsPageCategoryId, ['cms_page_category_read']);
+        $this->assertSame($patchData['names'], $cmsPageCategory['names']);
+        $this->assertFalse($cmsPageCategory['displayed']);
+
+        return $cmsPageCategoryId;
+    }
+
+    /**
+     * @depends testPartialUpdateCmsPageCategory
+     */
+    public function testToggleStatusCmsPageCategory(int $cmsPageCategoryId): int
+    {
+        // Status is currently false (set by the partial update), toggling it should enable it back
+        $this->updateItem('/cms-page-categories/' . $cmsPageCategoryId . '/toggle-status', [], ['cms_page_category_write'], Response::HTTP_NO_CONTENT);
+
+        $cmsPageCategory = $this->getItem('/cms-page-categories/' . $cmsPageCategoryId, ['cms_page_category_read']);
+        $this->assertTrue($cmsPageCategory['displayed']);
+
+        return $cmsPageCategoryId;
+    }
+
+    /**
+     * @depends testToggleStatusCmsPageCategory
+     */
+    public function testListCmsPageCategories(int $cmsPageCategoryId): int
+    {
+        $paginatedCmsPageCategories = $this->listItems('/cms-page-categories?orderBy=cmsPageCategoryId&sortOrder=desc', ['cms_page_category_read']);
+        $this->assertGreaterThanOrEqual(1, $paginatedCmsPageCategories['totalItems']);
+        $this->assertEquals('cmsPageCategoryId', $paginatedCmsPageCategories['orderBy']);
+
+        $firstCmsPageCategory = $paginatedCmsPageCategories['items'][0];
+        $this->assertEquals($cmsPageCategoryId, $firstCmsPageCategory['cmsPageCategoryId']);
+
+        return $cmsPageCategoryId;
+    }
+
+    /**
+     * @depends testListCmsPageCategories
+     */
+    public function testDeleteCmsPageCategory(int $cmsPageCategoryId): void
+    {
+        $return = $this->deleteItem('/cms-page-categories/' . $cmsPageCategoryId, ['cms_page_category_write']);
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+
+        // Getting the item should result in a 404 now
+        $this->getItem('/cms-page-categories/' . $cmsPageCategoryId, ['cms_page_category_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @depends testDeleteCmsPageCategory
+     */
+    public function testBulkUpdateStatusCmsPageCategories(): void
+    {
+        $bulkIds = $this->createSeveral(['Bulk status A', 'Bulk status B']);
+
+        // Disable both
+        $this->updateItem('/cms-page-categories/bulk-disable', [
+            'cmsPageCategoryIds' => $bulkIds,
+        ], ['cms_page_category_write'], Response::HTTP_NO_CONTENT);
+        foreach ($bulkIds as $id) {
+            $this->assertFalse($this->getItem('/cms-page-categories/' . $id, ['cms_page_category_read'])['displayed']);
+        }
+
+        // Enable both back
+        $this->updateItem('/cms-page-categories/bulk-enable', [
+            'cmsPageCategoryIds' => $bulkIds,
+        ], ['cms_page_category_write'], Response::HTTP_NO_CONTENT);
+        foreach ($bulkIds as $id) {
+            $this->assertTrue($this->getItem('/cms-page-categories/' . $id, ['cms_page_category_read'])['displayed']);
+        }
+    }
+
+    /**
+     * @depends testBulkUpdateStatusCmsPageCategories
+     */
+    public function testBulkDeleteCmsPageCategories(): void
+    {
+        $bulkIds = $this->createSeveral(['Bulk delete A', 'Bulk delete B']);
+
+        $this->bulkDeleteItems('/cms-page-categories/bulk-delete', [
+            'cmsPageCategoryIds' => $bulkIds,
+        ], ['cms_page_category_write']);
+
+        foreach ($bulkIds as $id) {
+            $this->getItem('/cms-page-categories/' . $id, ['cms_page_category_read'], Response::HTTP_NOT_FOUND);
+        }
+    }
+
+    public function testInvalidCmsPageCategory(): void
+    {
+        $invalidData = $this->getCreateData();
+        $invalidData['names'] = [
+            'fr-FR' => 'Nom FR uniquement',
+        ];
+        $invalidData['linkRewrites'] = [
+            'fr-FR' => 'nom-fr-uniquement',
+        ];
+
+        $validationErrorsResponse = $this->createItem('/cms-page-categories', $invalidData, ['cms_page_category_write'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertIsArray($validationErrorsResponse);
+
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'names',
+                'message' => 'The field names is required at least in your default language.',
+            ],
+            [
+                'propertyPath' => 'linkRewrites',
+                'message' => 'The field linkRewrites is required at least in your default language.',
+            ],
+        ], $validationErrorsResponse);
+    }
+
+    /**
+     * @param string[] $names
+     *
+     * @return int[]
+     */
+    private function createSeveral(array $names): array
+    {
+        $ids = [];
+        foreach ($names as $index => $name) {
+            $data = $this->getCreateData();
+            $data['names'] = [
+                'en-US' => $name,
+                'fr-FR' => $name,
+            ];
+            $data['linkRewrites'] = [
+                'en-US' => 'bulk-' . $index . '-en',
+                'fr-FR' => 'bulk-' . $index . '-fr',
+            ];
+            $created = $this->createItem('/cms-page-categories', $data, ['cms_page_category_write']);
+            $ids[] = $created['cmsPageCategoryId'];
+        }
+
+        return $ids;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the **CmsPageCategory** domain through the Admin API. <br> - `GET /cms-page-categories/{cmsPageCategoryId}` (scope `cms_page_category_read`) <br> - `POST /cms-page-categories` (scope `cms_page_category_write`) <br> - `PATCH /cms-page-categories/{cmsPageCategoryId}` (scope `cms_page_category_write`) <br> - `PUT /cms-page-categories/{cmsPageCategoryId}/toggle-status` (scope `cms_page_category_write`) <br> - `DELETE /cms-page-categories/{cmsPageCategoryId}` (scope `cms_page_category_write`) <br> - `GET /cms-page-categories` paginated list (scope `cms_page_category_read`) <br> - `DELETE /cms-page-categories/bulk-delete` (scope `cms_page_category_write`) <br> - `PUT /cms-page-categories/bulk-enable` and `PUT /cms-page-categories/bulk-disable` (scope `cms_page_category_write`)
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `CmsPageCategoryEndpointTest`. Create a category via `POST /cms-page-categories` (localized `names`/`linkRewrites`, `parentId`, `displayed`), then `GET`/`PATCH`/toggle-status/`DELETE` it, list via `GET /cms-page-categories`, and exercise the bulk delete/enable/disable endpoints with `{ cmsPageCategoryIds }`.
| Sponsor company   |

Adds CRUD, status toggle, paginated list and bulk operations for the `CmsPageCategory` domain, mirroring the existing `Category`/`Zone` endpoints. Create and update share a single command mapping (the edit command exposes the same property names through its setters). All underlying CQRS classes were verified to exist as of tag `9.0.3`, so this is compatible with the lower bound of the CI test matrix.