### PR TITLE
Add Product carriers endpoint (set carriers)

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductCarriers.php
+++ b/src/ApiPlatform/Resources/Product/ProductCarriers.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\SetCarriersCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Exception\ShopAssociationNotFound;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/carriers',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: SetCarriersCommand::class,
+            // No output 204 code
+            output: false,
+            status: Response::HTTP_NO_CONTENT,
+            scopes: [
+                'product_write',
+            ],
+            CQRSCommandMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ShopAssociationNotFound::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductCarriers
+{
+    public int $productId;
+
+    /**
+     * @var int[] List of carrier reference ids
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 2]])]
+    public array $carrierReferenceIds;
+}

--- a/tests/Integration/ApiPlatform/ProductCarriersEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductCarriersEndpointTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\Resetter\ProductResetter;
+
+class ProductCarriersEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        ProductResetter::resetProducts();
+        // Pre-create the API Client with the needed scopes, this way we reduce the number of created API Clients
+        self::createApiClient(['product_write', 'product_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        ProductResetter::resetProducts();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set carriers endpoint' => [
+            'PUT',
+            '/products/1/carriers',
+        ];
+    }
+
+    public function testSetProductCarriers(): void
+    {
+        $product = $this->createItem('/products', [
+            'type' => ProductType::TYPE_STANDARD,
+            'names' => [
+                'en-US' => 'product with carriers',
+            ],
+        ], ['product_write']);
+        $this->assertArrayHasKey('productId', $product);
+        $productId = $product['productId'];
+
+        // Assigning an empty list of carrier references means the product uses the shop default carriers
+        $this->updateItem('/products/' . $productId . '/carriers', [
+            'carrierReferenceIds' => [],
+        ], ['product_write'], Response::HTTP_NO_CONTENT);
+
+        $updatedProduct = $this->getItem('/products/' . $productId, ['product_read']);
+        $this->assertArrayHasKey('carrierReferenceIds', $updatedProduct);
+        $this->assertEquals([], $updatedProduct['carrierReferenceIds']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the missing **Product carriers** operation of the Admin API. <br> - `PUT /products/{productId}/carriers` → assigns the carrier references of a product (backed by `SetCarriersCommand`), scope `product_write`. An empty `carrierReferenceIds` array means the product uses the shop default carriers.
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `ProductCarriersEndpointTest`. `PUT /products/{id}/carriers` with `{ "carrierReferenceIds": [...] }` returns 204 and the references are reflected on `GET /products/{id}`.
| Sponsor company   |

Implements part of the missing Product Admin API surface tracked in PrestaShop/PrestaShop#39630, following the existing CQRS resource patterns.
