### PR TITLE
Add Product type endpoint (update product type)

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductType.php
+++ b/src/ApiPlatform/Resources/Product/ProductType.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\UpdateProductTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/types',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: UpdateProductTypeCommand::class,
+            // No output 204 code
+            output: false,
+            status: Response::HTTP_NO_CONTENT,
+            scopes: [
+                'product_write',
+            ],
+            CQRSCommandMapping: [
+                '[type]' => '[productType]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductType
+{
+    public int $productId;
+
+    /**
+     * Product type: standard, pack, virtual or combinations.
+     */
+    public string $type;
+}

--- a/tests/Integration/ApiPlatform/ProductTypeEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductTypeEndpointTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\Resetter\ProductResetter;
+
+class ProductTypeEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        ProductResetter::resetProducts();
+        // Pre-create the API Client with the needed scopes, this way we reduce the number of created API Clients
+        self::createApiClient(['product_write', 'product_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        ProductResetter::resetProducts();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'update type endpoint' => [
+            'PUT',
+            '/products/1/types',
+        ];
+    }
+
+    public function testUpdateProductType(): void
+    {
+        $product = $this->createItem('/products', [
+            'type' => ProductType::TYPE_STANDARD,
+            'names' => [
+                'en-US' => 'product type update',
+            ],
+        ], ['product_write']);
+        $this->assertArrayHasKey('productId', $product);
+        $productId = $product['productId'];
+        $this->assertEquals(ProductType::TYPE_STANDARD, $product['type']);
+
+        $this->updateItem('/products/' . $productId . '/types', [
+            'type' => ProductType::TYPE_VIRTUAL,
+        ], ['product_write'], Response::HTTP_NO_CONTENT);
+
+        $updatedProduct = $this->getItem('/products/' . $productId, ['product_read']);
+        $this->assertEquals(ProductType::TYPE_VIRTUAL, $updatedProduct['type']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the missing **Product type** operation of the Admin API. <br> - `PUT /products/{productId}/types` → updates the product type (`standard`, `pack`, `virtual` or `combinations`), backed by `UpdateProductTypeCommand`, scope `product_write`.
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `ProductTypeEndpointTest`. Create a `standard` product, `PUT /products/{id}/types` with `{ "type": "virtual" }` returns 204 and `GET /products/{id}` reflects the new type.
| Sponsor company   |

Implements part of the missing Product Admin API surface tracked in PrestaShop/PrestaShop#39630, following the existing CQRS resource patterns.
