### PR TITLE
Add Product pack products endpoints (set + remove all)

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductPackProducts.php
+++ b/src/ApiPlatform/Resources/Product/ProductPackProducts.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\InvalidProductTypeException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\RemoveAllProductsFromPackCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Command\SetPackProductsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Exception\ProductPackException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/pack-products',
+            requirements: ['productId' => '\d+'],
+            output: false,
+            CQRSCommand: SetPackProductsCommand::class,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            scopes: ['product_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/products/{productId}/pack-products',
+            requirements: ['productId' => '\d+'],
+            output: false,
+            CQRSCommand: RemoveAllProductsFromPackCommand::class,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            scopes: ['product_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        InvalidProductTypeException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        ProductPackException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ProductPackProducts
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    /**
+     * The products contained in the pack.
+     *
+     * @var array<int, array{product_id: int, quantity: int, combination_id?: int}>
+     */
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => ['type' => 'object'],
+        'example' => [['product_id' => 1, 'quantity' => 2]],
+    ])]
+    public array $products;
+
+    /**
+     * The pack commands expect a $packId constructor argument built from the product id.
+     */
+    public const COMMAND_MAPPING = [
+        '[productId]' => '[packId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/ProductPackProductsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductPackProductsEndpointTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class ProductPackProductsEndpointTest extends ApiTestCase
+{
+    private static int $packId;
+    private static int $itemProductId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_write']);
+
+        self::$packId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` WHERE `product_type` = "pack" ORDER BY `id_product` ASC'
+        );
+        self::$itemProductId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` WHERE `product_type` = "standard" ORDER BY `id_product` ASC'
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['pack', 'product']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set pack products endpoint' => ['PUT', '/products/1/pack-products'];
+        yield 'remove all pack products endpoint' => ['DELETE', '/products/1/pack-products'];
+    }
+
+    private function countPackItems(): int
+    {
+        return (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'pack` WHERE `id_product_pack` = ' . self::$packId
+        );
+    }
+
+    public function testSetPackProducts(): int
+    {
+        $this->updateItem(
+            '/products/' . self::$packId . '/pack-products',
+            ['products' => [
+                ['product_id' => self::$itemProductId, 'quantity' => 2],
+            ]],
+            ['product_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $count = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'pack`
+             WHERE `id_product_pack` = ' . self::$packId . ' AND `id_product_item` = ' . self::$itemProductId
+        );
+        $this->assertSame(1, $count);
+
+        return self::$packId;
+    }
+
+    /**
+     * @depends testSetPackProducts
+     */
+    public function testRemoveAllPackProducts(int $packId): void
+    {
+        $this->deleteItem('/products/' . $packId . '/pack-products', ['product_write']);
+
+        $this->assertSame(0, $this->countPackItems());
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Product pack products endpoints (set + remove all)
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints to manage the contents of a pack product:

- `PUT /products/{productId}/pack-products` — `SetPackProductsCommand`
- `DELETE /products/{productId}/pack-products` — `RemoveAllProductsFromPackCommand`

Each `PUT` entry is a contained product (`product_id` + `quantity`, optional `combination_id`). The
product id maps to the command's `packId`. The product must be of type `pack`. Both return `204`.

The integration test uses a fixture pack product, sets a contained product and verifies it via the
`pack` table, then removes all. Reuses the `product_write` scope.
