### PR TITLE
Add Product search-for-associations endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/Product.php
+++ b/src/ApiPlatform/Resources/Product/Product.php
@@ -43,6 +43,7 @@ use Symfony\Component\HttpFoundation\Response;
     operations: [
         new CQRSGet(
             uriTemplate: '/products/{productId}',
+            requirements: ['productId' => '\d+'],
             CQRSQuery: GetProductForEditing::class,
             scopes: [
                 'product_read',
@@ -61,6 +62,7 @@ use Symfony\Component\HttpFoundation\Response;
         ),
         new CQRSPartialUpdate(
             uriTemplate: '/products/{productId}',
+            requirements: ['productId' => '\d+'],
             CQRSCommand: UpdateProductCommand::class,
             CQRSQuery: GetProductForEditing::class,
             scopes: [
@@ -71,6 +73,7 @@ use Symfony\Component\HttpFoundation\Response;
         ),
         new CQRSDelete(
             uriTemplate: '/products/{productId}',
+            requirements: ['productId' => '\d+'],
             CQRSCommand: DeleteProductCommand::class,
             scopes: [
                 'product_write',

--- a/src/ApiPlatform/Resources/Product/ProductForAssociation.php
+++ b/src/ApiPlatform/Resources/Product/ProductForAssociation.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\SearchProductsForAssociation;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/products/search-for-associations',
+            scopes: [
+                'product_read',
+            ],
+            CQRSQuery: SearchProductsForAssociation::class,
+            CQRSQueryMapping: [
+                '[_context][langId]' => '[languageId]',
+                '[_context][shopId]' => '[shopId]',
+            ],
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'phrase',
+                    required: true,
+                    description: 'Search phrase to find products to associate (minimum 3 characters)'
+                ),
+                new QueryParameter(
+                    key: 'limit',
+                    schema: ['type' => 'integer'],
+                    required: false,
+                    description: 'Maximum number of results to return'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    [
+                        'name' => 'phrase',
+                        'in' => 'query',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                        'description' => 'Search phrase to find products to associate (minimum 3 characters)',
+                    ],
+                    [
+                        'name' => 'limit',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'integer',
+                        ],
+                        'description' => 'Maximum number of results to return',
+                    ],
+                ],
+            ]
+        ),
+    ],
+)]
+class ProductForAssociation
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    public string $name;
+
+    public string $reference;
+
+    public string $imageUrl;
+
+    public string $productType;
+}

--- a/tests/Integration/ApiPlatform/ProductSearchAssociationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductSearchAssociationEndpointTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
+use Tests\Resources\Resetter\ProductResetter;
+
+class ProductSearchAssociationEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        ProductResetter::resetProducts();
+        // Pre-create the API Client with the needed scopes, this way we reduce the number of created API Clients
+        self::createApiClient(['product_write', 'product_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        ProductResetter::resetProducts();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'search for association endpoint' => [
+            'GET',
+            '/products/search-for-associations?phrase=test',
+        ];
+    }
+
+    public function testSearchProductsForAssociation(): void
+    {
+        $product = $this->createItem('/products', [
+            'type' => ProductType::TYPE_STANDARD,
+            'names' => ['en-US' => 'Zztopassociationproduct'],
+        ], ['product_write']);
+        $this->assertArrayHasKey('productId', $product);
+        $productId = $product['productId'];
+
+        $results = $this->getItem('/products/search-for-associations?phrase=Zztopassociation&limit=10', ['product_read']);
+        $this->assertIsArray($results);
+        $productIds = array_column($results, 'productId');
+        $this->assertContains($productId, $productIds);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the missing **Product search-for-associations** operation of the Admin API. <br> - `GET /products/search-for-associations?phrase=...&limit=...` → searches products to associate (backed by `SearchProductsForAssociation`), returning each product's `productId`, `name`, `reference`, `imageUrl` and `productType`. Scope `product_read`. The language and shop come from the request context; `phrase` requires a minimum of 3 characters. <br><br> Also adds a numeric `requirements: ['productId' => '\d+']` on the `Product` `/products/{productId}` GET/PATCH/DELETE routes: without it the parameterized route greedily captures the static search route (casting the segment to product id `0` → 500). The requirement lets the static search route match, and makes non-numeric ids return 404 instead of a 500.
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `ProductSearchAssociationEndpointTest`. Create a product with a distinctive name, then `GET /products/search-for-associations?phrase=<name>&limit=10` returns it among the results.
| Sponsor company   |

Implements part of the missing Product Admin API surface tracked in PrestaShop/PrestaShop#39630, mirroring the existing `/products/search` (`FoundProduct`) resource, with the language/shop injected from the request context (like `CombinationList`).
