### PR TITLE
Add CmsPage Admin API endpoints (CRUD + status + bulk)

### DIFF
--- a/src/ApiPlatform/Resources/CmsPage/BulkDeleteCmsPage.php
+++ b/src/ApiPlatform/Resources/CmsPage/BulkDeleteCmsPage.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkDeleteCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/cms-pages/bulk-delete',
+            CQRSCommand: BulkDeleteCmsPageCommand::class,
+            scopes: [
+                'cms_page_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteCmsPage
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $cmsPageIds;
+}

--- a/src/ApiPlatform/Resources/CmsPage/BulkUpdateStatusCmsPage.php
+++ b/src/ApiPlatform/Resources/CmsPage/BulkUpdateStatusCmsPage.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkDisableCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\BulkEnableCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/cms-pages/bulk-enable',
+            output: false,
+            CQRSCommand: BulkEnableCmsPageCommand::class,
+            scopes: [
+                'cms_page_write',
+            ],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/cms-pages/bulk-disable',
+            output: false,
+            CQRSCommand: BulkDisableCmsPageCommand::class,
+            scopes: [
+                'cms_page_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkUpdateStatusCmsPage
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $cmsPageIds;
+}

--- a/src/ApiPlatform/Resources/CmsPage/CmsPage.php
+++ b/src/ApiPlatform/Resources/CmsPage/CmsPage.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\ConstraintValidator\Constraints\DefaultLanguage;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\AddCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\DeleteCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\EditCmsPageCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Command\ToggleCmsPageStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Exception\CmsPageNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Query\GetCmsPageForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/cms-pages/{cmsPageId}',
+            requirements: ['cmsPageId' => '\d+'],
+            CQRSQuery: GetCmsPageForEditing::class,
+            scopes: [
+                'cms_page_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/cms-pages',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddCmsPageCommand::class,
+            CQRSQuery: GetCmsPageForEditing::class,
+            scopes: [
+                'cms_page_write',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::CREATE_COMMAND_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/cms-pages/{cmsPageId}',
+            requirements: ['cmsPageId' => '\d+'],
+            CQRSCommand: EditCmsPageCommand::class,
+            CQRSQuery: GetCmsPageForEditing::class,
+            scopes: [
+                'cms_page_write',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::UPDATE_COMMAND_MAPPING,
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/cms-pages/{cmsPageId}/toggle-status',
+            requirements: ['cmsPageId' => '\d+'],
+            output: false,
+            allowEmptyBody: true,
+            CQRSCommand: ToggleCmsPageStatusCommand::class,
+            scopes: [
+                'cms_page_write',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/cms-pages/{cmsPageId}',
+            requirements: ['cmsPageId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteCmsPageCommand::class,
+            scopes: [
+                'cms_page_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CmsPageNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CmsPageConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CmsPage
+{
+    #[ApiProperty(identifier: true)]
+    public int $cmsPageId;
+
+    public int $cmsPageCategoryId;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'titles')]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'titles', allowNull: true)]
+    public array $titles;
+
+    #[LocalizedValue]
+    #[DefaultLanguage(groups: ['Create'], fieldName: 'linkRewrites')]
+    #[DefaultLanguage(groups: ['Update'], fieldName: 'linkRewrites', allowNull: true)]
+    public array $linkRewrites;
+
+    #[LocalizedValue]
+    public array $metaTitles;
+
+    #[LocalizedValue]
+    public array $metaDescriptions;
+
+    #[LocalizedValue]
+    public array $contents;
+
+    public bool $indexedForSearch;
+
+    public bool $displayed;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    public array $shopIds;
+
+    public const QUERY_MAPPING = [
+        '[localizedTitle]' => '[titles]',
+        '[localizedMetaTitle]' => '[metaTitles]',
+        '[localizedMetaDescription]' => '[metaDescriptions]',
+        '[localizedFriendlyUrl]' => '[linkRewrites]',
+        '[localizedContent]' => '[contents]',
+        '[shopAssociation]' => '[shopIds]',
+    ];
+
+    public const CREATE_COMMAND_MAPPING = [
+        '[titles]' => '[localizedTitle]',
+        '[metaTitles]' => '[localizedMetaTitle]',
+        '[metaDescriptions]' => '[localizedMetaDescription]',
+        '[linkRewrites]' => '[localizedFriendlyUrl]',
+        '[contents]' => '[localizedContent]',
+        '[shopIds]' => '[shopAssociation]',
+    ];
+
+    public const UPDATE_COMMAND_MAPPING = [
+        '[titles]' => '[localizedTitle]',
+        '[metaTitles]' => '[localizedMetaTitle]',
+        '[metaDescriptions]' => '[localizedMetaDescription]',
+        '[linkRewrites]' => '[localizedFriendlyUrl]',
+        '[contents]' => '[localizedContent]',
+        '[shopIds]' => '[shopAssociation]',
+        '[indexedForSearch]' => '[isIndexedForSearch]',
+        '[displayed]' => '[isDisplayed]',
+    ];
+
+    // The legacy query result may expose the booleans as strings ("1"/"0"), so we
+    // coerce them here to keep the typed bool properties happy across versions.
+    public function setIndexedForSearch(string|int|bool $indexedForSearch): self
+    {
+        $this->indexedForSearch = (bool) $indexedForSearch;
+
+        return $this;
+    }
+
+    public function setDisplayed(string|int|bool $displayed): self
+    {
+        $this->displayed = (bool) $displayed;
+
+        return $this;
+    }
+}

--- a/src/ApiPlatform/Resources/CmsPage/CmsPageList.php
+++ b/src/ApiPlatform/Resources/CmsPage/CmsPageList.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Search\Filters\CmsPageFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/cms-pages',
+            scopes: [
+                'cms_page_read',
+            ],
+            ApiResourceMapping: self::MAPPING,
+            gridDataFactory: 'prestashop.core.grid.data_provider.cms_page',
+            filtersClass: CmsPageFilters::class,
+            filtersMapping: [
+                '[cmsPageId]' => '[id_cms]',
+            ],
+        ),
+    ]
+)]
+class CmsPageList
+{
+    #[ApiProperty(identifier: true)]
+    public int $cmsPageId;
+
+    public string $metaTitle;
+
+    public string $linkRewrite;
+
+    public const MAPPING = [
+        '[id_cms]' => '[cmsPageId]',
+        '[meta_title]' => '[metaTitle]',
+        '[link_rewrite]' => '[linkRewrite]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CmsPageEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CmsPageEndpointTest.php
@@ -1,0 +1,289 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CmsPageEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient(['cms_page_read', 'cms_page_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'cms',
+            'cms_lang',
+            'cms_shop',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get endpoint' => [
+            'GET',
+            '/cms-pages/1',
+        ];
+
+        yield 'create endpoint' => [
+            'POST',
+            '/cms-pages',
+        ];
+
+        yield 'patch endpoint' => [
+            'PATCH',
+            '/cms-pages/1',
+        ];
+
+        yield 'list endpoint' => [
+            'GET',
+            '/cms-pages',
+        ];
+    }
+
+    private function getCreateData(): array
+    {
+        return [
+            'cmsPageCategoryId' => 1,
+            'titles' => [
+                'en-US' => 'Page EN',
+                'fr-FR' => 'Page FR',
+            ],
+            'metaTitles' => [
+                'en-US' => 'Meta title EN',
+                'fr-FR' => 'Meta title FR',
+            ],
+            'metaDescriptions' => [
+                'en-US' => '',
+                'fr-FR' => '',
+            ],
+            'linkRewrites' => [
+                'en-US' => 'page-en',
+                'fr-FR' => 'page-fr',
+            ],
+            'contents' => [
+                'en-US' => '<p>Content EN</p>',
+                'fr-FR' => '<p>Content FR</p>',
+            ],
+            'indexedForSearch' => true,
+            'displayed' => true,
+            'shopIds' => [1],
+        ];
+    }
+
+    public function testAddCmsPage(): int
+    {
+        $cmsPage = $this->createItem('/cms-pages', $this->getCreateData(), ['cms_page_write']);
+        $this->assertArrayHasKey('cmsPageId', $cmsPage);
+        $cmsPageId = $cmsPage['cmsPageId'];
+
+        $this->assertSame($this->getCreateData()['titles'], $cmsPage['titles']);
+        $this->assertSame($this->getCreateData()['linkRewrites'], $cmsPage['linkRewrites']);
+        $this->assertEquals(1, $cmsPage['cmsPageCategoryId']);
+        $this->assertTrue($cmsPage['displayed']);
+
+        return $cmsPageId;
+    }
+
+    /**
+     * @depends testAddCmsPage
+     */
+    public function testGetCmsPage(int $cmsPageId): int
+    {
+        $cmsPage = $this->getItem('/cms-pages/' . $cmsPageId, ['cms_page_read']);
+        $this->assertEquals($cmsPageId, $cmsPage['cmsPageId']);
+        $this->assertArrayHasKey('titles', $cmsPage);
+        $this->assertArrayHasKey('linkRewrites', $cmsPage);
+        $this->assertEquals(1, $cmsPage['cmsPageCategoryId']);
+
+        return $cmsPageId;
+    }
+
+    /**
+     * @depends testGetCmsPage
+     */
+    public function testPartialUpdateCmsPage(int $cmsPageId): int
+    {
+        $patchData = [
+            'titles' => [
+                'en-US' => 'Updated page EN',
+                'fr-FR' => 'Updated page FR',
+            ],
+            'displayed' => false,
+        ];
+
+        $updatedCmsPage = $this->partialUpdateItem('/cms-pages/' . $cmsPageId, $patchData, ['cms_page_write']);
+        $this->assertSame($patchData['titles'], $updatedCmsPage['titles']);
+        $this->assertFalse($updatedCmsPage['displayed']);
+
+        // We check that when we GET the item it is updated as expected
+        $cmsPage = $this->getItem('/cms-pages/' . $cmsPageId, ['cms_page_read']);
+        $this->assertSame($patchData['titles'], $cmsPage['titles']);
+        $this->assertFalse($cmsPage['displayed']);
+
+        return $cmsPageId;
+    }
+
+    /**
+     * @depends testPartialUpdateCmsPage
+     */
+    public function testToggleStatusCmsPage(int $cmsPageId): int
+    {
+        // Status is currently false (set by the partial update), toggling it should enable it back
+        $this->updateItem('/cms-pages/' . $cmsPageId . '/toggle-status', [], ['cms_page_write'], Response::HTTP_NO_CONTENT);
+
+        $cmsPage = $this->getItem('/cms-pages/' . $cmsPageId, ['cms_page_read']);
+        $this->assertTrue($cmsPage['displayed']);
+
+        return $cmsPageId;
+    }
+
+    /**
+     * @depends testToggleStatusCmsPage
+     */
+    public function testListCmsPages(int $cmsPageId): int
+    {
+        $paginatedCmsPages = $this->listItems('/cms-pages?orderBy=cmsPageId&sortOrder=desc', ['cms_page_read']);
+        $this->assertGreaterThanOrEqual(1, $paginatedCmsPages['totalItems']);
+        $this->assertEquals('cmsPageId', $paginatedCmsPages['orderBy']);
+
+        $firstCmsPage = $paginatedCmsPages['items'][0];
+        $this->assertEquals($cmsPageId, $firstCmsPage['cmsPageId']);
+
+        return $cmsPageId;
+    }
+
+    /**
+     * @depends testListCmsPages
+     */
+    public function testDeleteCmsPage(int $cmsPageId): void
+    {
+        $return = $this->deleteItem('/cms-pages/' . $cmsPageId, ['cms_page_write']);
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+
+        // Getting the item should result in a 404 now
+        $this->getItem('/cms-pages/' . $cmsPageId, ['cms_page_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * @depends testDeleteCmsPage
+     */
+    public function testBulkUpdateStatusCmsPages(): void
+    {
+        $bulkIds = $this->createSeveral(['Bulk status A', 'Bulk status B']);
+
+        // Disable both
+        $this->updateItem('/cms-pages/bulk-disable', [
+            'cmsPageIds' => $bulkIds,
+        ], ['cms_page_write'], Response::HTTP_NO_CONTENT);
+        foreach ($bulkIds as $id) {
+            $this->assertFalse($this->getItem('/cms-pages/' . $id, ['cms_page_read'])['displayed']);
+        }
+
+        // Enable both back
+        $this->updateItem('/cms-pages/bulk-enable', [
+            'cmsPageIds' => $bulkIds,
+        ], ['cms_page_write'], Response::HTTP_NO_CONTENT);
+        foreach ($bulkIds as $id) {
+            $this->assertTrue($this->getItem('/cms-pages/' . $id, ['cms_page_read'])['displayed']);
+        }
+    }
+
+    /**
+     * @depends testBulkUpdateStatusCmsPages
+     */
+    public function testBulkDeleteCmsPages(): void
+    {
+        $bulkIds = $this->createSeveral(['Bulk delete A', 'Bulk delete B']);
+
+        $this->bulkDeleteItems('/cms-pages/bulk-delete', [
+            'cmsPageIds' => $bulkIds,
+        ], ['cms_page_write']);
+
+        foreach ($bulkIds as $id) {
+            $this->getItem('/cms-pages/' . $id, ['cms_page_read'], Response::HTTP_NOT_FOUND);
+        }
+    }
+
+    public function testInvalidCmsPage(): void
+    {
+        $invalidData = $this->getCreateData();
+        $invalidData['titles'] = [
+            'fr-FR' => 'Titre FR uniquement',
+        ];
+        $invalidData['linkRewrites'] = [
+            'fr-FR' => 'titre-fr-uniquement',
+        ];
+
+        $validationErrorsResponse = $this->createItem('/cms-pages', $invalidData, ['cms_page_write'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertIsArray($validationErrorsResponse);
+
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'titles',
+                'message' => 'The field titles is required at least in your default language.',
+            ],
+            [
+                'propertyPath' => 'linkRewrites',
+                'message' => 'The field linkRewrites is required at least in your default language.',
+            ],
+        ], $validationErrorsResponse);
+    }
+
+    /**
+     * @param string[] $titles
+     *
+     * @return int[]
+     */
+    private function createSeveral(array $titles): array
+    {
+        $ids = [];
+        foreach ($titles as $index => $title) {
+            $data = $this->getCreateData();
+            $data['titles'] = [
+                'en-US' => $title,
+                'fr-FR' => $title,
+            ];
+            $data['linkRewrites'] = [
+                'en-US' => 'bulk-' . $index . '-en',
+                'fr-FR' => 'bulk-' . $index . '-fr',
+            ];
+            $created = $this->createItem('/cms-pages', $data, ['cms_page_write']);
+            $ids[] = $created['cmsPageId'];
+        }
+
+        return $ids;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the **CmsPage** domain through the Admin API. <br> - `GET /cms-pages/{cmsPageId}` (scope `cms_page_read`) <br> - `POST /cms-pages` (scope `cms_page_write`) <br> - `PATCH /cms-pages/{cmsPageId}` (scope `cms_page_write`) <br> - `PUT /cms-pages/{cmsPageId}/toggle-status` (scope `cms_page_write`) <br> - `DELETE /cms-pages/{cmsPageId}` (scope `cms_page_write`) <br> - `GET /cms-pages` paginated list (scope `cms_page_read`) <br> - `DELETE /cms-pages/bulk-delete` (scope `cms_page_write`) <br> - `PUT /cms-pages/bulk-enable` and `PUT /cms-pages/bulk-disable` (scope `cms_page_write`)
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `CmsPageEndpointTest`. Create a page via `POST /cms-pages` (localized `titles`/`linkRewrites`/`contents`/meta fields, `cmsPageCategoryId`, `displayed`, `indexedForSearch`), then `GET`/`PATCH`/toggle-status/`DELETE` it, list via `GET /cms-pages`, and exercise the bulk delete/enable/disable endpoints with `{ cmsPageIds }`.
| Sponsor company   |

Adds CRUD, status toggle, paginated list and bulk operations for the `CmsPage` domain, mirroring the existing `CmsPageCategory`/`Category`/`Zone` endpoints. Create and update use distinct command mappings for the two boolean fields (`AddCmsPageCommand` expects `displayed`/`indexedForSearch`, `EditCmsPageCommand` uses the `isDisplayed`/`isIndexedForSearch` setters), and both booleans are coerced through setters because the legacy editing query exposes them as strings on 9.0.x. All underlying CQRS classes were verified to exist as of tag `9.0.3`, so this is compatible with the lower bound of the CI test matrix.