### PR TITLE
Add Order product line endpoints (update + delete)

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderProduct.php
+++ b/src/ApiPlatform/Resources/Order/OrderProduct.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\DeleteProductFromOrderCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateProductInOrderCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/products/{orderDetailId}',
+            requirements: ['orderId' => '\d+', 'orderDetailId' => '\d+'],
+            output: false,
+            CQRSCommand: UpdateProductInOrderCommand::class,
+            scopes: ['order_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/orders/{orderId}/products/{orderDetailId}',
+            requirements: ['orderId' => '\d+', 'orderDetailId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteProductFromOrderCommand::class,
+            scopes: ['order_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderProduct
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    #[ApiProperty(identifier: true)]
+    public int $orderDetailId;
+
+    public string $priceTaxIncluded;
+
+    public string $priceTaxExcluded;
+
+    public int $quantity;
+
+    public ?int $orderInvoiceId;
+}

--- a/src/ApiPlatform/Resources/Order/OrderProduct.php
+++ b/src/ApiPlatform/Resources/Order/OrderProduct.php
@@ -24,10 +24,10 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
-use PrestaShop\PrestaShop\Core\Domain\Order\Command\DeleteProductFromOrderCommand;
-use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateProductInOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\DeleteProductFromOrderCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Product\Command\UpdateProductInOrderCommand;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/Integration/ApiPlatform/OrderProductEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderProductEndpointTest.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderProductEndpointTest extends ApiTestCase
+{
+    private static int $orderId;
+    private static int $updateDetailId;
+    private static int $deleteDetailId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+
+        // Pick an order that has at least two products, so one can be deleted without removing the last one.
+        self::$orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'order_detail`
+             GROUP BY `id_order` HAVING COUNT(*) >= 2 ORDER BY `id_order` ASC'
+        );
+        $details = \Db::getInstance()->executeS(
+            'SELECT `id_order_detail` FROM `' . _DB_PREFIX_ . 'order_detail`
+             WHERE `id_order` = ' . self::$orderId . ' ORDER BY `id_order_detail` ASC'
+        );
+        self::$updateDetailId = (int) $details[0]['id_order_detail'];
+        self::$deleteDetailId = (int) $details[1]['id_order_detail'];
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables([
+            'orders',
+            'order_detail',
+            'order_invoice',
+            'order_cart_rule',
+            'stock_available',
+            'cart',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'update order product endpoint' => ['PUT', '/orders/1/products/1'];
+        yield 'delete order product endpoint' => ['DELETE', '/orders/1/products/1'];
+    }
+
+    public function testUpdateProductInOrder(): void
+    {
+        $detail = \Db::getInstance()->getRow(
+            'SELECT `product_quantity`, `unit_price_tax_incl`, `unit_price_tax_excl`
+             FROM `' . _DB_PREFIX_ . 'order_detail` WHERE `id_order_detail` = ' . self::$updateDetailId
+        );
+        $newQuantity = (int) $detail['product_quantity'] + 1;
+
+        $this->updateItem(
+            '/orders/' . self::$orderId . '/products/' . self::$updateDetailId,
+            [
+                'priceTaxIncluded' => (string) $detail['unit_price_tax_incl'],
+                'priceTaxExcluded' => (string) $detail['unit_price_tax_excl'],
+                'quantity' => $newQuantity,
+            ],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $storedQuantity = (int) \Db::getInstance()->getValue(
+            'SELECT `product_quantity` FROM `' . _DB_PREFIX_ . 'order_detail` WHERE `id_order_detail` = ' . self::$updateDetailId
+        );
+        $this->assertSame($newQuantity, $storedQuantity);
+    }
+
+    public function testDeleteProductFromOrder(): void
+    {
+        $this->deleteItem(
+            '/orders/' . self::$orderId . '/products/' . self::$deleteDetailId,
+            ['order_write']
+        );
+
+        $count = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'order_detail` WHERE `id_order_detail` = ' . self::$deleteDetailId
+        );
+        $this->assertSame(0, $count);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Order product line endpoints (update + delete)
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints to manage the product lines of an order:

- `PUT /orders/{orderId}/products/{orderDetailId}` — `UpdateProductInOrderCommand` (quantity / price)
- `DELETE /orders/{orderId}/products/{orderDetailId}` — `DeleteProductFromOrderCommand`

`AddProductToOrder` is intentionally left out: its command has a private constructor and cannot be
instantiated by the API normalizer.

### ⚠️ Depends on a core fix — kept as a draft

Changing an order line's quantity records a `StockMvt` attributed to the current employee. In the API
context there is no logged-in employee, so `StockManager` calls `StockMvt::setIdEmployee(null)` →
`TypeError`. The core PR **PrestaShop/PrestaShop#41803** guards that (same fix as the product stock
endpoint). This PR stays a draft and red on the released-core matrices until that fix ships; it goes
green on `develop` once #41803 is merged.

The integration test uses a fixture order with at least two products, updates one line's quantity and
deletes another, verifying via the `order_detail` table. Reuses the `order_write` scope.