### PR TITLE
Add Security session endpoints (customer & employee: list + delete + bulk delete)

### DIFF
--- a/src/ApiPlatform/Resources/CustomerSession/BulkDeleteCustomerSessions.php
+++ b/src/ApiPlatform/Resources/CustomerSession/BulkDeleteCustomerSessions.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CustomerSession;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Security\Command\BulkDeleteCustomerSessionsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Security\Exception\SessionNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/customer-sessions/bulk-delete',
+            CQRSCommand: BulkDeleteCustomerSessionsCommand::class,
+            scopes: [
+                'customer_session_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        SessionNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteCustomerSessions
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $sessionIds;
+}

--- a/src/ApiPlatform/Resources/CustomerSession/CustomerSession.php
+++ b/src/ApiPlatform/Resources/CustomerSession/CustomerSession.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CustomerSession;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Security\Command\DeleteCustomerSessionCommand;
+use PrestaShop\PrestaShop\Core\Domain\Security\Exception\SessionNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/customer-sessions/{sessionId}',
+            requirements: ['sessionId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteCustomerSessionCommand::class,
+            scopes: [
+                'customer_session_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        SessionNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CustomerSession
+{
+    #[ApiProperty(identifier: true)]
+    public int $sessionId;
+}

--- a/src/ApiPlatform/Resources/CustomerSession/CustomerSessionList.php
+++ b/src/ApiPlatform/Resources/CustomerSession/CustomerSessionList.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CustomerSession;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Search\Filters\Security\Session\CustomerFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/customer-sessions',
+            scopes: [
+                'customer_session_read',
+            ],
+            ApiResourceMapping: self::MAPPING,
+            gridDataFactory: 'prestashop.core.grid.data_factory.security.session.customer',
+            filtersClass: CustomerFilters::class,
+            filtersMapping: [
+                '[sessionId]' => '[id_customer_session]',
+            ],
+        ),
+    ]
+)]
+class CustomerSessionList
+{
+    #[ApiProperty(identifier: true)]
+    public int $sessionId;
+
+    public int $customerId;
+
+    public string $firstname;
+
+    public string $lastname;
+
+    public string $email;
+
+    public const MAPPING = [
+        '[id_customer_session]' => '[sessionId]',
+        '[id_customer]' => '[customerId]',
+    ];
+}

--- a/src/ApiPlatform/Resources/EmployeeSession/BulkDeleteEmployeeSessions.php
+++ b/src/ApiPlatform/Resources/EmployeeSession/BulkDeleteEmployeeSessions.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\EmployeeSession;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Security\Command\BulkDeleteEmployeeSessionsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Security\Exception\SessionNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/employee-sessions/bulk-delete',
+            CQRSCommand: BulkDeleteEmployeeSessionsCommand::class,
+            scopes: [
+                'employee_session_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        SessionNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteEmployeeSessions
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $sessionIds;
+}

--- a/src/ApiPlatform/Resources/EmployeeSession/EmployeeSession.php
+++ b/src/ApiPlatform/Resources/EmployeeSession/EmployeeSession.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\EmployeeSession;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Security\Command\DeleteEmployeeSessionCommand;
+use PrestaShop\PrestaShop\Core\Domain\Security\Exception\SessionNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/employee-sessions/{sessionId}',
+            requirements: ['sessionId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteEmployeeSessionCommand::class,
+            scopes: [
+                'employee_session_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        SessionNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class EmployeeSession
+{
+    #[ApiProperty(identifier: true)]
+    public int $sessionId;
+}

--- a/src/ApiPlatform/Resources/EmployeeSession/EmployeeSessionList.php
+++ b/src/ApiPlatform/Resources/EmployeeSession/EmployeeSessionList.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\EmployeeSession;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Search\Filters\Security\Session\EmployeeFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/employee-sessions',
+            scopes: [
+                'employee_session_read',
+            ],
+            ApiResourceMapping: self::MAPPING,
+            gridDataFactory: 'prestashop.core.grid.data_factory.security.session.employee',
+            filtersClass: EmployeeFilters::class,
+            filtersMapping: [
+                '[sessionId]' => '[id_employee_session]',
+            ],
+        ),
+    ]
+)]
+class EmployeeSessionList
+{
+    #[ApiProperty(identifier: true)]
+    public int $sessionId;
+
+    public int $employeeId;
+
+    public string $firstname;
+
+    public string $lastname;
+
+    public string $email;
+
+    public const MAPPING = [
+        '[id_employee_session]' => '[sessionId]',
+        '[id_employee]' => '[employeeId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/SecuritySessionEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SecuritySessionEndpointTest.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Tests\Resources\DatabaseDump;
+
+class SecuritySessionEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient([
+            'customer_session_read', 'customer_session_write',
+            'employee_session_read', 'employee_session_write',
+        ]);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'customer_session',
+            'employee_session',
+        ]);
+    }
+
+    private function seedCustomerSession(int $idCustomer = 1): int
+    {
+        \Db::getInstance()->insert('customer_session', [
+            'id_customer' => $idCustomer,
+            'token' => bin2hex(random_bytes(16)),
+            'date_add' => date('Y-m-d H:i:s'),
+            'date_upd' => date('Y-m-d H:i:s'),
+        ]);
+
+        return (int) \Db::getInstance()->Insert_ID();
+    }
+
+    private function seedEmployeeSession(int $idEmployee = 1): int
+    {
+        \Db::getInstance()->insert('employee_session', [
+            'id_employee' => $idEmployee,
+            'token' => bin2hex(random_bytes(16)),
+            'date_add' => date('Y-m-d H:i:s'),
+            'date_upd' => date('Y-m-d H:i:s'),
+        ]);
+
+        return (int) \Db::getInstance()->Insert_ID();
+    }
+
+    /**
+     * @param string[] $scopes
+     *
+     * @return int[]
+     */
+    private function listedIds(string $url, array $scopes): array
+    {
+        return array_column($this->listItems($url, $scopes)['items'], 'sessionId');
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'customer list endpoint' => ['GET', '/customer-sessions'];
+        yield 'customer delete endpoint' => ['DELETE', '/customer-sessions/1'];
+        yield 'employee list endpoint' => ['GET', '/employee-sessions'];
+        yield 'employee delete endpoint' => ['DELETE', '/employee-sessions/1'];
+    }
+
+    public function testListCustomerSessions(): void
+    {
+        $sessionId = $this->seedCustomerSession();
+
+        $paginated = $this->listItems('/customer-sessions?orderBy=sessionId&sortOrder=desc', ['customer_session_read']);
+        $this->assertGreaterThanOrEqual(1, $paginated['totalItems']);
+        $this->assertEquals('sessionId', $paginated['orderBy']);
+
+        $first = $paginated['items'][0];
+        $this->assertEquals($sessionId, $first['sessionId']);
+        $this->assertEquals(1, $first['customerId']);
+        $this->assertArrayHasKey('firstname', $first);
+        $this->assertArrayHasKey('email', $first);
+    }
+
+    public function testDeleteCustomerSession(): void
+    {
+        $sessionId = $this->seedCustomerSession();
+
+        $return = $this->deleteItem('/customer-sessions/' . $sessionId, ['customer_session_write']);
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+
+        $this->assertNotContains(
+            $sessionId,
+            $this->listedIds('/customer-sessions?orderBy=sessionId&sortOrder=desc', ['customer_session_read'])
+        );
+    }
+
+    public function testBulkDeleteCustomerSessions(): void
+    {
+        $bulkIds = [$this->seedCustomerSession(), $this->seedCustomerSession()];
+
+        $this->bulkDeleteItems('/customer-sessions/bulk-delete', [
+            'sessionIds' => $bulkIds,
+        ], ['customer_session_write']);
+
+        $listed = $this->listedIds('/customer-sessions?orderBy=sessionId&sortOrder=desc', ['customer_session_read']);
+        foreach ($bulkIds as $sessionId) {
+            $this->assertNotContains($sessionId, $listed);
+        }
+    }
+
+    public function testListEmployeeSessions(): void
+    {
+        $sessionId = $this->seedEmployeeSession();
+
+        $paginated = $this->listItems('/employee-sessions?orderBy=sessionId&sortOrder=desc', ['employee_session_read']);
+        $this->assertGreaterThanOrEqual(1, $paginated['totalItems']);
+        $this->assertEquals('sessionId', $paginated['orderBy']);
+
+        $first = $paginated['items'][0];
+        $this->assertEquals($sessionId, $first['sessionId']);
+        $this->assertEquals(1, $first['employeeId']);
+        $this->assertArrayHasKey('firstname', $first);
+        $this->assertArrayHasKey('email', $first);
+    }
+
+    public function testDeleteEmployeeSession(): void
+    {
+        $sessionId = $this->seedEmployeeSession();
+
+        $return = $this->deleteItem('/employee-sessions/' . $sessionId, ['employee_session_write']);
+        $this->assertNull($return);
+
+        $this->assertNotContains(
+            $sessionId,
+            $this->listedIds('/employee-sessions?orderBy=sessionId&sortOrder=desc', ['employee_session_read'])
+        );
+    }
+
+    public function testBulkDeleteEmployeeSessions(): void
+    {
+        $bulkIds = [$this->seedEmployeeSession(), $this->seedEmployeeSession()];
+
+        $this->bulkDeleteItems('/employee-sessions/bulk-delete', [
+            'sessionIds' => $bulkIds,
+        ], ['employee_session_write']);
+
+        $listed = $this->listedIds('/employee-sessions?orderBy=sessionId&sortOrder=desc', ['employee_session_read']);
+        foreach ($bulkIds as $sessionId) {
+            $this->assertNotContains($sessionId, $listed);
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes the BO **Security > Sessions** management through the Admin API, for both customer and employee sessions. <br> - `GET /customer-sessions` paginated list (scope `customer_session_read`) <br> - `DELETE /customer-sessions/{sessionId}` (scope `customer_session_write`) <br> - `DELETE /customer-sessions/bulk-delete` (scope `customer_session_write`) <br> - `GET /employee-sessions` paginated list (scope `employee_session_read`) <br> - `DELETE /employee-sessions/{sessionId}` (scope `employee_session_write`) <br> - `DELETE /employee-sessions/bulk-delete` (scope `employee_session_write`) <br><br> The `ClearOutdated{Customer,Employee}Session` commands are deferred to a follow-up (their natural URI clashes with the Rector pluralization rule).
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `SecuritySessionEndpointTest`. It seeds rows in `customer_session` / `employee_session`, lists them via `GET /customer-sessions` / `GET /employee-sessions`, deletes one via `DELETE /…-sessions/{sessionId}`, and removes several at once via `DELETE /…-sessions/bulk-delete` with `{ sessionIds }`.
| Sponsor company   |

Exposes the customer & employee session listing + delete + bulk-delete of the `Security` domain. All commands take scalar ctor args (`int $sessionId` / `array $sessionIds`) so there is no value-object-as-scalar issue, and the lists reuse the existing `prestashop.core.grid.data_factory.security.session.{customer,employee}` grid factories. All underlying CQRS classes were verified to exist as of tag `9.0.3`, so this is compatible with the lower bound of the CI test matrix.