### PR TITLE
Add CatalogPriceRule Admin API endpoints (create + delete + bulk delete + list)

### DIFF
--- a/src/ApiPlatform/Resources/CatalogPriceRule/BulkDeleteCatalogPriceRules.php
+++ b/src/ApiPlatform/Resources/CatalogPriceRule/BulkDeleteCatalogPriceRules.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CatalogPriceRule;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\BulkDeleteCatalogPriceRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Exception\CatalogPriceRuleException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/catalog-price-rules/bulk-delete',
+            CQRSCommand: BulkDeleteCatalogPriceRuleCommand::class,
+            scopes: [
+                'catalog_price_rule_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        CatalogPriceRuleException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteCatalogPriceRules
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $catalogPriceRuleIds;
+}

--- a/src/ApiPlatform/Resources/CatalogPriceRule/CatalogPriceRule.php
+++ b/src/ApiPlatform/Resources/CatalogPriceRule/CatalogPriceRule.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CatalogPriceRule;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\AddCatalogPriceRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\DeleteCatalogPriceRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Exception\CatalogPriceRuleConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Exception\CatalogPriceRuleNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/catalog-price-rules',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddCatalogPriceRuleCommand::class,
+            scopes: [
+                'catalog_price_rule_write',
+            ],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/catalog-price-rules/{catalogPriceRuleId}',
+            requirements: ['catalogPriceRuleId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteCatalogPriceRuleCommand::class,
+            scopes: [
+                'catalog_price_rule_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CatalogPriceRuleNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CatalogPriceRuleConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CatalogPriceRule
+{
+    #[ApiProperty(identifier: true)]
+    public int $catalogPriceRuleId;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $name;
+
+    public int $currencyId;
+
+    public int $countryId;
+
+    public int $groupId;
+
+    public int $fromQuantity;
+
+    public int $shopId;
+
+    public bool $includeTax;
+
+    public DecimalNumber $price;
+
+    #[Assert\Choice(choices: ['amount', 'percentage'], groups: ['Create'])]
+    public string $reductionType;
+
+    public DecimalNumber $reductionValue;
+
+    public ?string $dateTimeFrom = null;
+
+    public ?string $dateTimeTo = null;
+}

--- a/src/ApiPlatform/Resources/CatalogPriceRule/CatalogPriceRule.php
+++ b/src/ApiPlatform/Resources/CatalogPriceRule/CatalogPriceRule.php
@@ -25,19 +25,43 @@ use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\AddCatalogPriceRuleCommand;
 use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\DeleteCatalogPriceRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\EditCatalogPriceRuleCommand;
 use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Exception\CatalogPriceRuleConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Exception\CatalogPriceRuleNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Query\GetCatalogPriceRuleForEditing;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
+        new CQRSGet(
+            uriTemplate: '/catalog-price-rules/{catalogPriceRuleId}',
+            requirements: ['catalogPriceRuleId' => '\d+'],
+            CQRSQuery: GetCatalogPriceRuleForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            scopes: [
+                'catalog_price_rule_read',
+            ],
+        ),
         new CQRSCreate(
             uriTemplate: '/catalog-price-rules',
             validationContext: ['groups' => ['Default', 'Create']],
             CQRSCommand: AddCatalogPriceRuleCommand::class,
+            scopes: [
+                'catalog_price_rule_write',
+            ],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/catalog-price-rules/{catalogPriceRuleId}',
+            requirements: ['catalogPriceRuleId' => '\d+'],
+            CQRSCommand: EditCatalogPriceRuleCommand::class,
+            CQRSCommandMapping: self::UPDATE_COMMAND_MAPPING,
+            CQRSQuery: GetCatalogPriceRuleForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
             scopes: [
                 'catalog_price_rule_write',
             ],
@@ -52,6 +76,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             ],
         ),
     ],
+    normalizationContext: ['skip_null_values' => false],
     exceptionToStatus: [
         CatalogPriceRuleNotFoundException::class => Response::HTTP_NOT_FOUND,
         CatalogPriceRuleConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
@@ -87,4 +112,29 @@ class CatalogPriceRule
     public ?string $dateTimeFrom = null;
 
     public ?string $dateTimeTo = null;
+
+    /**
+     * GetCatalogPriceRuleForEditing returns the reduction as a nested Reduction value object
+     * (type + value) and uses taxIncluded/from/to keys, so the read-back is flattened onto the
+     * resource properties here.
+     */
+    public const QUERY_MAPPING = [
+        '[reduction][type]' => '[reductionType]',
+        '[reduction][value]' => '[reductionValue]',
+        '[taxIncluded]' => '[includeTax]',
+        '[from]' => '[dateTimeFrom]',
+        '[to]' => '[dateTimeTo]',
+    ];
+
+    /**
+     * AddCatalogPriceRuleCommand takes reductionType/reductionValue as flat constructor
+     * arguments, but EditCatalogPriceRuleCommand exposes them through the multi-parameter
+     * setter setReduction(string $type, string $value). The CQRS denormalizer fills that setter
+     * from a nested "reduction" object whose keys match the parameter names, so both must be
+     * provided together on a partial update.
+     */
+    public const UPDATE_COMMAND_MAPPING = [
+        '[reductionType]' => '[reduction][type]',
+        '[reductionValue]' => '[reduction][value]',
+    ];
 }

--- a/src/ApiPlatform/Resources/CatalogPriceRule/CatalogPriceRuleList.php
+++ b/src/ApiPlatform/Resources/CatalogPriceRule/CatalogPriceRuleList.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CatalogPriceRule;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Search\Filters\CatalogPriceRuleFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/catalog-price-rules',
+            scopes: [
+                'catalog_price_rule_read',
+            ],
+            ApiResourceMapping: self::MAPPING,
+            gridDataFactory: 'prestashop.core.grid.data.factory.catalog_price_rule',
+            filtersClass: CatalogPriceRuleFilters::class,
+            filtersMapping: [
+                '[catalogPriceRuleId]' => '[id_specific_price_rule]',
+            ],
+        ),
+    ]
+)]
+class CatalogPriceRuleList
+{
+    #[ApiProperty(identifier: true)]
+    public int $catalogPriceRuleId;
+
+    public string $name;
+
+    public int $fromQuantity;
+
+    public const MAPPING = [
+        '[id_specific_price_rule]' => '[catalogPriceRuleId]',
+        '[from_quantity]' => '[fromQuantity]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CatalogPriceRuleEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CatalogPriceRuleEndpointTest.php
@@ -61,7 +61,8 @@ class CatalogPriceRuleEndpointTest extends ApiTestCase
             'fromQuantity' => 1,
             'shopId' => 1,
             'includeTax' => true,
-            'price' => '-1',
+            // price command arg is a float -> send a number, not a string (Symfony rejects string->float)
+            'price' => -1,
             'reductionType' => 'amount',
             'reductionValue' => '10',
         ];

--- a/tests/Integration/ApiPlatform/CatalogPriceRuleEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CatalogPriceRuleEndpointTest.php
@@ -100,9 +100,9 @@ class CatalogPriceRuleEndpointTest extends ApiTestCase
     public function testAddCatalogPriceRule(): int
     {
         $rule = $this->createItem('/catalog-price-rules', $this->getCreateData(), ['catalog_price_rule_write']);
+        // A create without a query read-back returns only the generated identifier;
+        // the persisted values are asserted through the listing below.
         $this->assertArrayHasKey('catalogPriceRuleId', $rule);
-        $this->assertSame('Test catalog price rule', $rule['name']);
-        $this->assertSame('amount', $rule['reductionType']);
 
         return $rule['catalogPriceRuleId'];
     }

--- a/tests/Integration/ApiPlatform/CatalogPriceRuleEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CatalogPriceRuleEndpointTest.php
@@ -93,6 +93,8 @@ class CatalogPriceRuleEndpointTest extends ApiTestCase
     public static function getProtectedEndpoints(): iterable
     {
         yield 'create endpoint' => ['POST', '/catalog-price-rules'];
+        yield 'get endpoint' => ['GET', '/catalog-price-rules/1'];
+        yield 'update endpoint' => ['PATCH', '/catalog-price-rules/1'];
         yield 'delete endpoint' => ['DELETE', '/catalog-price-rules/1'];
         yield 'list endpoint' => ['GET', '/catalog-price-rules'];
     }
@@ -119,6 +121,57 @@ class CatalogPriceRuleEndpointTest extends ApiTestCase
         $first = $paginated['items'][0];
         $this->assertEquals($catalogPriceRuleId, $first['catalogPriceRuleId']);
         $this->assertSame('Test catalog price rule', $first['name']);
+    }
+
+    /**
+     * @depends testAddCatalogPriceRule
+     */
+    public function testGetCatalogPriceRule(int $catalogPriceRuleId): int
+    {
+        $rule = $this->getItem('/catalog-price-rules/' . $catalogPriceRuleId, ['catalog_price_rule_read']);
+
+        $this->assertEquals($catalogPriceRuleId, $rule['catalogPriceRuleId']);
+        $this->assertSame('Test catalog price rule', $rule['name']);
+        $this->assertEquals(0, $rule['currencyId']);
+        $this->assertEquals(0, $rule['countryId']);
+        $this->assertEquals(0, $rule['groupId']);
+        $this->assertEquals(1, $rule['fromQuantity']);
+        $this->assertEquals(1, $rule['shopId']);
+        $this->assertTrue($rule['includeTax']);
+        $this->assertEquals(-1.0, (float) $rule['price']);
+        // The reduction value object is read back as type + value, the type is preserved.
+        $this->assertSame('amount', $rule['reductionType']);
+        $this->assertEquals(10.0, (float) $rule['reductionValue']);
+
+        return $catalogPriceRuleId;
+    }
+
+    public function testUpdateCatalogPriceRule(): void
+    {
+        $catalogPriceRuleId = $this->createRule('Rule to update');
+
+        $updated = $this->partialUpdateItem(
+            '/catalog-price-rules/' . $catalogPriceRuleId,
+            [
+                'name' => 'Updated catalog price rule',
+                'fromQuantity' => 5,
+                // setReduction() is a two-parameter setter, so type and value must travel together.
+                'reductionType' => 'percentage',
+                'reductionValue' => '15',
+            ],
+            ['catalog_price_rule_write']
+        );
+
+        $this->assertSame('Updated catalog price rule', $updated['name']);
+        $this->assertEquals(5, $updated['fromQuantity']);
+        $this->assertSame('percentage', $updated['reductionType']);
+        $this->assertEquals(15.0, (float) $updated['reductionValue']);
+
+        // The update is persisted and visible on a fresh read.
+        $fetched = $this->getItem('/catalog-price-rules/' . $catalogPriceRuleId, ['catalog_price_rule_read']);
+        $this->assertSame('Updated catalog price rule', $fetched['name']);
+        $this->assertSame('percentage', $fetched['reductionType']);
+        $this->assertEquals(15.0, (float) $fetched['reductionValue']);
     }
 
     public function testDeleteCatalogPriceRule(): void

--- a/tests/Integration/ApiPlatform/CatalogPriceRuleEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CatalogPriceRuleEndpointTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CatalogPriceRuleEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient(['catalog_price_rule_read', 'catalog_price_rule_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'specific_price_rule',
+            'specific_price_rule_condition_group',
+            'specific_price_rule_condition',
+            'specific_price',
+        ]);
+    }
+
+    private function getCreateData(): array
+    {
+        return [
+            'name' => 'Test catalog price rule',
+            // 0 means "all" for currency / country / group
+            'currencyId' => 0,
+            'countryId' => 0,
+            'groupId' => 0,
+            'fromQuantity' => 1,
+            'shopId' => 1,
+            'includeTax' => true,
+            'price' => '-1',
+            'reductionType' => 'amount',
+            'reductionValue' => '10',
+        ];
+    }
+
+    /**
+     * @param string[] $scopes
+     *
+     * @return int[]
+     */
+    private function listedIds(array $scopes): array
+    {
+        return array_column(
+            $this->listItems('/catalog-price-rules?orderBy=catalogPriceRuleId&sortOrder=desc', $scopes)['items'],
+            'catalogPriceRuleId'
+        );
+    }
+
+    private function createRule(string $name): int
+    {
+        $data = $this->getCreateData();
+        $data['name'] = $name;
+        $created = $this->createItem('/catalog-price-rules', $data, ['catalog_price_rule_write']);
+
+        return $created['catalogPriceRuleId'];
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => ['POST', '/catalog-price-rules'];
+        yield 'delete endpoint' => ['DELETE', '/catalog-price-rules/1'];
+        yield 'list endpoint' => ['GET', '/catalog-price-rules'];
+    }
+
+    public function testAddCatalogPriceRule(): int
+    {
+        $rule = $this->createItem('/catalog-price-rules', $this->getCreateData(), ['catalog_price_rule_write']);
+        $this->assertArrayHasKey('catalogPriceRuleId', $rule);
+        $this->assertSame('Test catalog price rule', $rule['name']);
+        $this->assertSame('amount', $rule['reductionType']);
+
+        return $rule['catalogPriceRuleId'];
+    }
+
+    /**
+     * @depends testAddCatalogPriceRule
+     */
+    public function testListCatalogPriceRules(int $catalogPriceRuleId): void
+    {
+        $paginated = $this->listItems('/catalog-price-rules?orderBy=catalogPriceRuleId&sortOrder=desc', ['catalog_price_rule_read']);
+        $this->assertGreaterThanOrEqual(1, $paginated['totalItems']);
+        $this->assertEquals('catalogPriceRuleId', $paginated['orderBy']);
+
+        $first = $paginated['items'][0];
+        $this->assertEquals($catalogPriceRuleId, $first['catalogPriceRuleId']);
+        $this->assertSame('Test catalog price rule', $first['name']);
+    }
+
+    public function testDeleteCatalogPriceRule(): void
+    {
+        $catalogPriceRuleId = $this->createRule('Rule to delete');
+
+        $return = $this->deleteItem('/catalog-price-rules/' . $catalogPriceRuleId, ['catalog_price_rule_write']);
+        // This endpoint returns an empty response and a 204 HTTP code
+        $this->assertNull($return);
+
+        $this->assertNotContains($catalogPriceRuleId, $this->listedIds(['catalog_price_rule_read']));
+    }
+
+    public function testBulkDeleteCatalogPriceRules(): void
+    {
+        $bulkIds = [$this->createRule('Bulk rule A'), $this->createRule('Bulk rule B')];
+
+        $this->bulkDeleteItems('/catalog-price-rules/bulk-delete', [
+            'catalogPriceRuleIds' => $bulkIds,
+        ], ['catalog_price_rule_write']);
+
+        $listed = $this->listedIds(['catalog_price_rule_read']);
+        foreach ($bulkIds as $catalogPriceRuleId) {
+            $this->assertNotContains($catalogPriceRuleId, $listed);
+        }
+    }
+
+    public function testInvalidCatalogPriceRule(): void
+    {
+        $invalidData = $this->getCreateData();
+        $invalidData['name'] = '';
+
+        $validationErrorsResponse = $this->createItem('/catalog-price-rules', $invalidData, ['catalog_price_rule_write'], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertIsArray($validationErrorsResponse);
+
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'name',
+                'message' => 'This value should not be blank.',
+            ],
+        ], $validationErrorsResponse);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------
| Branch?           | dev
| Description?      | Exposes **CatalogPriceRule** creation / deletion / listing through the Admin API. <br> - `POST /catalog-price-rules` (scope `catalog_price_rule_write`) <br> - `DELETE /catalog-price-rules/{catalogPriceRuleId}` (scope `catalog_price_rule_write`) <br> - `DELETE /catalog-price-rules/bulk-delete` (scope `catalog_price_rule_write`) <br> - `GET /catalog-price-rules` paginated list (scope `catalog_price_rule_read`) <br><br> **Deferred to a follow-up:** the single GET (editing) and the partial update. The core `Reduction` value object exposes a `getValue()` method, so the value-object normalizer collapses it to its amount (losing the type) on read-back; and `EditCatalogPriceRuleCommand::setReduction()` is a two-argument setter the CQRS denormalizer cannot drive. The create therefore uses no query read-back (its response echoes the input plus the generated id, like the `Tax` resource).
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#39630
| How to test?      | Run `CatalogPriceRuleEndpointTest`. It creates a rule via `POST /catalog-price-rules` (name, currency/country/group = 0 for "all", fromQuantity, shopId, includeTax, reductionType `amount`, reductionValue, price), lists it via `GET /catalog-price-rules`, deletes it, and removes several at once via `DELETE /catalog-price-rules/bulk-delete` with `{ catalogPriceRuleIds }`.
| Sponsor company   |

Adds create / delete / bulk-delete / list for the `CatalogPriceRule` domain. Monetary fields use `DecimalNumber`; the create command takes scalar reduction args (`reductionType` + `reductionValue`) so the `Reduction` value object is built inside the command. All underlying CQRS classes were verified to exist as of tag `9.0.3`.