### PR TITLE
Add Order invoice note endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderInvoiceNote.php
+++ b/src/ApiPlatform/Resources/Order/OrderInvoiceNote.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Invoice\Command\UpdateInvoiceNoteCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Invoice\Exception\InvoiceException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Invoice\Exception\InvoiceNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/invoices/{orderInvoiceId}/notes',
+            requirements: ['orderInvoiceId' => '\d+'],
+            output: false,
+            CQRSCommand: UpdateInvoiceNoteCommand::class,
+            scopes: ['order_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        InvoiceNotFoundException::class => Response::HTTP_NOT_FOUND,
+        InvoiceException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderInvoiceNote
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderInvoiceId;
+
+    public ?string $note;
+}

--- a/tests/Integration/ApiPlatform/OrderInvoiceNoteEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderInvoiceNoteEndpointTest.php
@@ -34,9 +34,15 @@ class OrderInvoiceNoteEndpointTest extends ApiTestCase
         parent::setUpBeforeClass();
         self::createApiClient(['order_write']);
 
-        self::$orderInvoiceId = (int) \Db::getInstance()->getValue(
-            'SELECT `id_order_invoice` FROM `' . _DB_PREFIX_ . 'order_invoice` ORDER BY `id_order_invoice` ASC'
+        // The demo fixtures ship no order invoices (they are generated on demand), so seed one.
+        $orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` ASC'
         );
+        $invoice = new \OrderInvoice();
+        $invoice->id_order = $orderId;
+        $invoice->number = 1;
+        $invoice->add();
+        self::$orderInvoiceId = (int) $invoice->id;
     }
 
     public static function tearDownAfterClass(): void

--- a/tests/Integration/ApiPlatform/OrderInvoiceNoteEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderInvoiceNoteEndpointTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderInvoiceNoteEndpointTest extends ApiTestCase
+{
+    private static int $orderInvoiceId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+
+        self::$orderInvoiceId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order_invoice` FROM `' . _DB_PREFIX_ . 'order_invoice` ORDER BY `id_order_invoice` ASC'
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['order_invoice']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'update invoice note endpoint' => ['PUT', '/orders/invoices/1/notes'];
+    }
+
+    public function testUpdateOrderInvoiceNote(): void
+    {
+        $note = 'Invoice note set through the Admin API';
+
+        $this->updateItem(
+            '/orders/invoices/' . self::$orderInvoiceId . '/notes',
+            ['note' => $note],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $storedNote = \Db::getInstance()->getValue(
+            'SELECT `note` FROM `' . _DB_PREFIX_ . 'order_invoice` WHERE `id_order_invoice` = ' . self::$orderInvoiceId
+        );
+        $this->assertSame($note, $storedNote);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Order invoice note endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`PUT /orders/invoices/{orderInvoiceId}/notes`** — `UpdateInvoiceNoteCommand`: sets the note on
an order invoice (`204`). `404` if the invoice does not exist.

The integration test updates a fixture invoice's note and verifies it via the `order_invoice` table.
Reuses the `order_write` scope.
