### PR TITLE
Add Order invoice generation endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderInvoiceGeneration.php
+++ b/src/ApiPlatform/Resources/Order/OrderInvoiceGeneration.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Invoice\Command\GenerateInvoiceCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/invoices',
+            requirements: ['orderId' => '\d+'],
+            output: false,
+            allowEmptyBody: true,
+            CQRSCommand: GenerateInvoiceCommand::class,
+            scopes: ['order_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderInvoiceGeneration
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+}

--- a/tests/Integration/ApiPlatform/OrderInvoiceGenerationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderInvoiceGenerationEndpointTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderInvoiceGenerationEndpointTest extends ApiTestCase
+{
+    private static int $orderId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+
+        // Pick an order that has no invoice yet.
+        self::$orderId = (int) \Db::getInstance()->getValue(
+            'SELECT o.`id_order` FROM `' . _DB_PREFIX_ . 'orders` o
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM `' . _DB_PREFIX_ . 'order_invoice` oi WHERE oi.`id_order` = o.`id_order`
+             )
+             ORDER BY o.`id_order` ASC'
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['orders', 'order_invoice', 'order_detail']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'generate invoice endpoint' => ['PUT', '/orders/1/invoices'];
+    }
+
+    public function testGenerateOrderInvoice(): void
+    {
+        $this->updateItem(
+            '/orders/' . self::$orderId . '/invoices',
+            [],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $invoiceCount = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'order_invoice` WHERE `id_order` = ' . self::$orderId
+        );
+        $this->assertGreaterThanOrEqual(1, $invoiceCount);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Order invoice generation endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`PUT /orders/{orderId}/invoices`** — `GenerateInvoiceCommand`: generates the invoice of an
order (`204`, empty body).

- `404` if the order does not exist (`OrderNotFoundException`)
- `422` if invoice management is disabled or the order already has an invoice (`OrderException`)

The integration test generates an invoice on a fixture order without one and verifies it via the
`order_invoice` table. Reuses the `order_write` scope.
