### PR TITLE
Add delete-images-from-type endpoint

### DIFF
--- a/src/ApiPlatform/Resources/ImageType/DeleteImagesFromType.php
+++ b/src/ApiPlatform/Resources/ImageType/DeleteImagesFromType.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\ImageType;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\DeleteImagesFromTypeCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/image-types/{imageTypeId}/images',
+            requirements: ['imageTypeId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteImagesFromTypeCommand::class,
+            scopes: ['image_type_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ImageTypeNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ImageTypeException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class DeleteImagesFromType
+{
+    #[ApiProperty(identifier: true)]
+    public int $imageTypeId;
+}

--- a/tests/Integration/ApiPlatform/DeleteImagesFromTypeEndpointTest.php
+++ b/tests/Integration/ApiPlatform/DeleteImagesFromTypeEndpointTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class DeleteImagesFromTypeEndpointTest extends ApiTestCase
+{
+    private static int $imageTypeId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['image_type_write']);
+
+        self::$imageTypeId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_image_type` FROM `' . _DB_PREFIX_ . 'image_type` ORDER BY `id_image_type` ASC'
+        );
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'delete images from type endpoint' => ['DELETE', '/image-types/1/images'];
+    }
+
+    public function testDeleteImagesFromType(): void
+    {
+        // Removes the generated thumbnail files of the given image type (none in a fresh install),
+        // so a 204 confirms the command ran successfully.
+        $return = $this->deleteItem('/image-types/' . self::$imageTypeId . '/images', ['image_type_write']);
+        $this->assertNull($return);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the delete-images-from-type endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`DELETE /image-types/{imageTypeId}/images`** — `DeleteImagesFromTypeCommand`: removes the
generated thumbnail files for a given image type (`204`).

- `404` if the image type does not exist (`ImageTypeNotFoundException`)

Complements the ImageType resource. The integration test calls it on a fixture image type and asserts
a `204`. Reuses the `image_type_write` scope.
