### PR TITLE
Add Product attachments endpoints (set + remove all)

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductAttachments.php
+++ b/src/ApiPlatform/Resources/Product/ProductAttachments.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Attachment\Command\RemoveAllAssociatedProductAttachmentsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Attachment\Command\SetAssociatedProductAttachmentsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/attachments',
+            requirements: ['productId' => '\d+'],
+            output: false,
+            CQRSCommand: SetAssociatedProductAttachmentsCommand::class,
+            scopes: ['product_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/products/{productId}/attachments',
+            requirements: ['productId' => '\d+'],
+            output: false,
+            CQRSCommand: RemoveAllAssociatedProductAttachmentsCommand::class,
+            scopes: ['product_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ProductConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ProductAttachments
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    /**
+     * @var int[] attachment ids to associate with the product
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 2]])]
+    public array $attachmentIds;
+}

--- a/tests/Integration/ApiPlatform/ProductAttachmentsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductAttachmentsEndpointTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class ProductAttachmentsEndpointTest extends ApiTestCase
+{
+    private static int $productId;
+    private static int $attachmentId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_write']);
+
+        self::$productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` WHERE `product_type` = "standard" ORDER BY `id_product` ASC'
+        );
+
+        // The demo data ships no attachments, so seed one.
+        $attachment = new \Attachment();
+        $attachment->file = 'apitest' . substr(bin2hex(random_bytes(8)), 0, 16);
+        $attachment->file_name = 'doc.pdf';
+        $attachment->mime = 'application/pdf';
+        foreach (\Language::getIDs(false) as $langId) {
+            $attachment->name[(int) $langId] = 'API attachment';
+        }
+        $attachment->add();
+        self::$attachmentId = (int) $attachment->id;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['product_attachment', 'attachment', 'attachment_lang']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set attachments endpoint' => ['PUT', '/products/1/attachments'];
+        yield 'remove all attachments endpoint' => ['DELETE', '/products/1/attachments'];
+    }
+
+    public function testSetProductAttachments(): int
+    {
+        $this->updateItem(
+            '/products/' . self::$productId . '/attachments',
+            ['attachmentIds' => [self::$attachmentId]],
+            ['product_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $count = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'product_attachment`
+             WHERE `id_product` = ' . self::$productId . ' AND `id_attachment` = ' . self::$attachmentId
+        );
+        $this->assertSame(1, $count);
+
+        return self::$productId;
+    }
+
+    /**
+     * @depends testSetProductAttachments
+     */
+    public function testRemoveAllProductAttachments(int $productId): void
+    {
+        $this->deleteItem('/products/' . $productId . '/attachments', ['product_write']);
+
+        $count = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'product_attachment` WHERE `id_product` = ' . $productId
+        );
+        $this->assertSame(0, $count);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Product attachments endpoints (set + remove all)
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds the Admin API endpoints to manage a product's attachment associations:

- `PUT /products/{productId}/attachments` — `SetAssociatedProductAttachmentsCommand`
- `DELETE /products/{productId}/attachments` — `RemoveAllAssociatedProductAttachmentsCommand`

Associate attachments (by id) with a product or remove all associations. Both return `204`. The
integration test seeds an attachment, associates it with a fixture product and verifies via the
`product_attachment` table, then removes all. Reuses the `product_write` scope.
