### PR TITLE
Add SQL request settings endpoint

### DIFF
--- a/src/ApiPlatform/Resources/SqlRequestSettings/SqlRequestSettings.php
+++ b/src/ApiPlatform/Resources/SqlRequestSettings/SqlRequestSettings.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SqlRequestSettings;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Command\SaveSqlRequestSettingsCommand;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlRequestSettingsConstraintException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/sql-request-settings',
+            read: false,
+            output: false,
+            CQRSCommand: SaveSqlRequestSettingsCommand::class,
+            scopes: ['sql_management_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        SqlRequestSettingsConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class SqlRequestSettings
+{
+    /**
+     * One of utf-8, iso-8859-1.
+     */
+    #[Assert\NotBlank]
+    public string $fileEncoding;
+
+    #[Assert\NotBlank]
+    public string $fileSeparator;
+}

--- a/tests/Integration/ApiPlatform/SqlRequestSettingsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SqlRequestSettingsEndpointTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class SqlRequestSettingsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['sql_management_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['configuration']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'save sql request settings endpoint' => ['PUT', '/sql-request-settings'];
+    }
+
+    public function testSaveSqlRequestSettings(): void
+    {
+        $this->updateItem(
+            '/sql-request-settings',
+            ['fileEncoding' => 'utf-8', 'fileSeparator' => ';'],
+            ['sql_management_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $this->assertSame('utf-8', \Configuration::get('PS_ENCODING_FILE_MANAGER_SQL'));
+        $this->assertSame(';', \Configuration::get('PS_SEPARATOR_FILE_MANAGER_SQL'));
+    }
+}

--- a/tests/Integration/ApiPlatform/SqlRequestSettingsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SqlRequestSettingsEndpointTest.php
@@ -53,7 +53,7 @@ class SqlRequestSettingsEndpointTest extends ApiTestCase
             Response::HTTP_NO_CONTENT
         );
 
-        $this->assertSame('utf-8', \Configuration::get('PS_ENCODING_FILE_MANAGER_SQL'));
+        $this->assertSame(1, (int) \Configuration::get('PS_ENCODING_FILE_MANAGER_SQL'));
         $this->assertSame(';', \Configuration::get('PS_SEPARATOR_FILE_MANAGER_SQL'));
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the SQL request settings endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`PUT /sql-request-settings`** — `SaveSqlRequestSettingsCommand`: sets the SQL manager export
file encoding (`utf-8` / `iso-8859-1`) and separator (`204`). A singleton resource.

The integration test updates the settings and verifies them through `Configuration`. Reuses the
`sql_management_write` scope.
