### PR TITLE
Add customer service signature read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/CustomerService/CustomerServiceSignature.php
+++ b/src/ApiPlatform/Resources/CustomerService/CustomerServiceSignature.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CustomerService;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerServiceSignature;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/customer-services/signatures/{languageId}',
+            requirements: ['languageId' => '\d+'],
+            CQRSQuery: GetCustomerServiceSignature::class,
+            CQRSQueryMapping: [
+                '[_queryResult]' => '[signature]',
+            ],
+            scopes: ['customer_service_read'],
+        ),
+    ],
+)]
+class CustomerServiceSignature
+{
+    #[ApiProperty(identifier: true)]
+    public int $languageId;
+
+    public string $signature;
+}

--- a/tests/Integration/ApiPlatform/CustomerServiceSignatureEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerServiceSignatureEndpointTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class CustomerServiceSignatureEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['customer_service_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get signature endpoint' => ['GET', '/customer-services/signatures/1'];
+    }
+
+    public function testGetCustomerServiceSignature(): void
+    {
+        $result = $this->getItem('/customer-services/signatures/1', ['customer_service_read']);
+
+        $this->assertSame(1, $result['languageId']);
+        $this->assertArrayHasKey('signature', $result);
+        $this->assertIsString($result['signature']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the customer service signature read endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`GET /customer-services/signatures/{languageId}`** — `GetCustomerServiceSignature`: returns the
customer service e-mail signature for a language. The scalar result is mapped to the `signature`
property (same `_queryResult` pattern as `ShowcaseCard`).

The integration test reads it for the default language. Declares the `customer_service_read` scope.
