### PR TITLE
Add country list endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Country/CountryList.php
+++ b/src/ApiPlatform/Resources/Country/CountryList.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Country;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use PrestaShop\PrestaShop\Core\Search\Filters\CountryFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+use PrestaShopBundle\ApiPlatform\Provider\QueryListProvider;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/countries',
+            scopes: ['country_read'],
+            ApiResourceMapping: [
+                '[id_country]' => '[countryId]',
+                '[iso_code]' => '[isoCode]',
+                '[call_prefix]' => '[callPrefix]',
+                '[zone_name]' => '[zoneName]',
+                '[active]' => '[enabled]',
+            ],
+            gridDataFactory: 'prestashop.core.grid.data.factory.country',
+            provider: QueryListProvider::class,
+            filtersClass: CountryFilters::class,
+            filtersMapping: [
+                '[countryId]' => '[id_country]',
+                '[isoCode]' => '[iso_code]',
+                '[callPrefix]' => '[call_prefix]',
+                '[zoneName]' => '[zone_name]',
+                '[enabled]' => '[active]',
+            ],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        InvalidFieldNameException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CountryList
+{
+    #[ApiProperty(identifier: true)]
+    public int $countryId;
+
+    public string $name;
+
+    public string $isoCode;
+
+    public int $callPrefix;
+
+    public string $zoneName;
+
+    public bool $enabled;
+}

--- a/tests/Integration/ApiPlatform/CountryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CountryEndpointTest.php
@@ -58,6 +58,7 @@ class CountryEndpointTest extends ApiTestCase
         yield 'get endpoint' => ['GET', '/countries/1'];
         yield 'update endpoint' => ['PATCH', '/countries/1'];
         yield 'delete endpoint' => ['DELETE', '/countries/1'];
+        yield 'list endpoint' => ['GET', '/countries'];
     }
 
     public function testAddCountry(): int
@@ -133,12 +134,75 @@ class CountryEndpointTest extends ApiTestCase
     }
 
     /**
+     * @depends testEditCountry
+     */
+    public function testListCountries(int $countryId): int
+    {
+        // Every exposed field is sortable; sorting by countryId in descending order
+        // also puts the country created by the previous tests first
+        foreach (['countryId', 'name', 'isoCode', 'callPrefix', 'zoneName', 'enabled'] as $orderBy) {
+            $paginatedCountries = $this->listItems('/countries?orderBy=' . $orderBy . '&sortOrder=desc', ['country_read']);
+            $this->assertGreaterThanOrEqual(1, $paginatedCountries['totalItems']);
+
+            // Check the details to make sure filters mapping is correct
+            $this->assertEquals($orderBy, $paginatedCountries['orderBy']);
+        }
+
+        $expectedCountry = [
+            'countryId' => $countryId,
+            'name' => 'Updated Country EN',
+            'isoCode' => 'ZZ',
+            'callPrefix' => 999,
+            // The country was created with zoneId 1, which is Europe in the default fixtures
+            'zoneName' => 'Europe',
+            // It was disabled by testEditCountry
+            'enabled' => false,
+        ];
+
+        // Test country has the highest ID so it comes first when sorted by countryId desc
+        $paginatedCountries = $this->listItems('/countries?orderBy=countryId&sortOrder=desc', ['country_read']);
+        $this->assertEquals($expectedCountry, $paginatedCountries['items'][0]);
+
+        // Pagination: the default fixtures contain way more than ten countries
+        $paginatedCountries = $this->listItems('/countries?limit=10', ['country_read']);
+        $this->assertEquals(10, $paginatedCountries['limit']);
+        $this->assertCount(10, $paginatedCountries['items']);
+        $this->assertGreaterThan(10, $paginatedCountries['totalItems']);
+
+        // Filtering: the ZZ iso code only matches the test country
+        $filteredCountries = $this->listItems('/countries', ['country_read'], [
+            'isoCode' => 'ZZ',
+        ]);
+        $this->assertEquals(1, $filteredCountries['totalItems']);
+        $this->assertEquals($expectedCountry, $filteredCountries['items'][0]);
+
+        // Check the filters details
+        $this->assertEquals([
+            'isoCode' => 'ZZ',
+        ], $filteredCountries['filters']);
+
+        // Filtering on the exact country ID also matches the test country only
+        $filteredCountries = $this->listItems('/countries', ['country_read'], [
+            'countryId' => $countryId,
+        ]);
+        $this->assertEquals(1, $filteredCountries['totalItems']);
+        $this->assertEquals($expectedCountry, $filteredCountries['items'][0]);
+
+        return $countryId;
+    }
+
+    public function testListCountriesWithInvalidOrderBy(): void
+    {
+        $this->requestApi('GET', '/countries?orderBy=INVALID_FILTER&sortOrder=desc', null, ['country_read'], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    /**
      * Order-critical: must run after every other test that needs the created
      * country alive. The validation tests below also chain off testGetCountry
      * and PATCH the same record, so listing them here forces PHPUnit to
      * schedule the delete last.
      *
-     * @depends testEditCountry
+     * @depends testListCountries
      * @depends testAddCountryWithInvalidAddressFormat
      * @depends testEditCountryWithInvalidAddressFormat
      */


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | Adds the missing collection endpoint `GET /countries` to the Admin API, as a `PaginatedList` operation backed by the core country grid data factory (`prestashop.core.grid.data.factory.country`) and `CountryFilters`. The list exposes `countryId`, `name`, `isoCode`, `callPrefix`, `zoneName` and `enabled`, supports sorting on every exposed field (`orderBy` / `sortOrder`), pagination (`limit` / `offset`) and filtering (`filters[isoCode]`, `filters[countryId]`, `filters[name]`, `filters[zoneName]`, `filters[callPrefix]`, `filters[enabled]`). An invalid `orderBy` returns a 422. Authentication uses the existing `country_read` scope.
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the integration tests: `composer create-test-db` then `_PS_ROOT_DIR_=$(pwd) php -d date.timezone=UTC ./vendor/phpunit/phpunit/phpunit -c modules/ps_apiresources/tests/Integration/phpunit-local.xml --filter=CountryEndpointTest` (25 tests, including list sorting/pagination/filtering and the auth check on `GET /countries`). You can also create an API client with the `country_read` scope and call `GET /admin-api/countries?orderBy=countryId&sortOrder=desc&filters[isoCode]=FR` manually. Note: correct `totalItems` requires the related core PR fixing the country grid count query on `develop`.
| Fixed issue or discussion?     | Fixes PrestaShop/PrestaShop#41676
| Related PRs       | Core fix for the country grid count query (regression on develop): to be cross-linked once opened
| Sponsor company   | Mintfull Agency
