### PR TITLE
Assert AttributeGroup create Location header has no admin token

### DIFF
--- a/tests/Integration/ApiPlatform/AttributeGroupEndpointTest.php
+++ b/tests/Integration/ApiPlatform/AttributeGroupEndpointTest.php
@@ -558,4 +558,25 @@ class AttributeGroupEndpointTest extends ApiTestCase
             $this->assertValidationErrors($updateData['expectedErrors'], $validationErrorsResponse);
         }
     }
+
+    /**
+     * The Admin API is stateless and OAuth-authenticated, so the IRIs it returns (here the
+     * Location header of a POST) must not carry the admin CSRF _token. See PrestaShop/PrestaShop#39496.
+     */
+    public function testCreateResponseLocationHeaderHasNoAdminToken(): void
+    {
+        $bearerToken = $this->getBearerToken(['attribute_group_write', 'attribute_group_read']);
+        $response = static::createClient()->request('POST', '/attributes/groups', [
+            'auth_bearer' => $bearerToken,
+            'json' => [
+                'names' => ['en-US' => 'name en', 'fr-FR' => 'name fr'],
+                'publicNames' => ['en-US' => 'public name en', 'fr-FR' => 'public name fr'],
+                'type' => 'select',
+                'shopIds' => [1],
+            ],
+        ]);
+        self::assertResponseStatusCodeSame(201);
+        $location = $response->getHeaders(false)['location'][0] ?? '';
+        $this->assertStringNotContainsString('_token', $location);
+    }
 }


### PR DESCRIPTION
| Questions   | Answers
| ----------- | -------------------------------------------------------
| Branch?     | dev
| Description?| Assert the AttributeGroup create response `Location` header carries no admin `_token`.
| Type?       | bug fix
| Fixed issue | Companion to PrestaShop/PrestaShop#41847 (fixes PrestaShop/PrestaShop#39496)

## Context

PrestaShop/PrestaShop#39496: Admin API IRIs leaked the admin CSRF `_token`. The core fix PrestaShop/PrestaShop#41847 stops adding it to API Platform routes.

This adds a regression test asserting the `POST /attributes/groups` `Location` header has no `_token`.

## Verification

Against an install with the core fix: green. Without it: red (`Location: /attributes/groups/5?_token=…`).
