### PR TITLE
Add Product customization fields read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductCustomizationFieldList.php
+++ b/src/ApiPlatform/Resources/Product/ProductCustomizationFieldList.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
 
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;

--- a/src/ApiPlatform/Resources/Product/ProductCustomizationFieldList.php
+++ b/src/ApiPlatform/Resources/Product/ProductCustomizationFieldList.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Customization\Query\GetProductCustomizationFields;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/products/{productId}/customization-fields',
+            CQRSQuery: GetProductCustomizationFields::class,
+            scopes: ['product_read'],
+            CQRSQueryMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+            ApiResourceMapping: [
+                '[localizedNames]' => '[names]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductCustomizationFieldList
+{
+    public int $productId;
+
+    public int $customizationFieldId;
+
+    public int $type;
+
+    #[LocalizedValue]
+    public array $names;
+
+    public bool $required;
+
+    public bool $addedByModule;
+}

--- a/tests/Integration/ApiPlatform/ProductCustomizationFieldListEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductCustomizationFieldListEndpointTest.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ProductCustomizationFieldListEndpointTest extends ApiTestCase
+{
+    private static int $productId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_read']);
+
+        // A demo product (the customizable mug) already has a customization field.
+        self::$productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'customization_field` WHERE `deleted` = 0 ORDER BY `id_customization_field` ASC'
+        );
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list customization fields endpoint' => ['GET', '/products/1/customization-fields'];
+    }
+
+    public function testListProductCustomizationFields(): void
+    {
+        $result = $this->getItem('/products/' . self::$productId . '/customization-fields', ['product_read']);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('customizationFieldId', $result[0]);
+        $this->assertArrayHasKey('type', $result[0]);
+        $this->assertArrayHasKey('names', $result[0]);
+    }
+}

--- a/tests/Integration/ApiPlatform/ProductCustomizationFieldListEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductCustomizationFieldListEndpointTest.php
@@ -33,7 +33,7 @@ class ProductCustomizationFieldListEndpointTest extends ApiTestCase
 
         // A demo product (the customizable mug) already has a customization field.
         self::$productId = (int) \Db::getInstance()->getValue(
-            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'customization_field` WHERE `deleted` = 0 ORDER BY `id_customization_field` ASC'
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'customization_field` ORDER BY `id_customization_field` ASC'
         );
     }
 


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Product customization fields read endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`GET /products/{productId}/customization-fields`** — `GetProductCustomizationFields`: lists a
product's customization fields (`customizationFieldId`, `type`, localized `names`, `required`,
`addedByModule`). Companion read to the customization-fields set/remove endpoints, following the
product image list pattern (`CQRSGetCollection`).

The integration test reads a demo product that already has a customization field. Reuses the
`product_read` scope.
