### PR TITLE
Add Product feature values read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductFeatureValueList.php
+++ b/src/ApiPlatform/Resources/Product/ProductFeatureValueList.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Query\GetProductFeatureValues;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/products/{productId}/feature-values',
+            CQRSQuery: GetProductFeatureValues::class,
+            scopes: ['product_read'],
+            CQRSQueryMapping: [
+                '[_context][shopId]' => '[shopId]',
+            ],
+            ApiResourceMapping: [
+                '[localizedCustomValues]' => '[customValues]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductFeatureValueList
+{
+    public int $productId;
+
+    public int $featureId;
+
+    public ?int $featureValueId;
+
+    #[LocalizedValue]
+    public ?array $customValues;
+}

--- a/tests/Integration/ApiPlatform/ProductFeatureValueListEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductFeatureValueListEndpointTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ProductFeatureValueListEndpointTest extends ApiTestCase
+{
+    private static int $productId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_read']);
+
+        // Demo products already have feature values.
+        self::$productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'feature_product` ORDER BY `id_product` ASC'
+        );
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list feature values endpoint' => ['GET', '/products/1/feature-values'];
+    }
+
+    public function testListProductFeatureValues(): void
+    {
+        $result = $this->getItem('/products/' . self::$productId . '/feature-values', ['product_read']);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('featureId', $result[0]);
+        $this->assertArrayHasKey('featureValueId', $result[0]);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the Product feature values read endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`GET /products/{productId}/feature-values`** — `GetProductFeatureValues`: lists a product's
feature values (`featureId`, `featureValueId`, localized `customValues`). Companion read to the
feature-values set/remove endpoints (`CQRSGetCollection`, context `shopId`).

The integration test reads a demo product that already has feature values. Reuses the `product_read`
scope.
