### PR TITLE
Add packed products read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductPackedProductList.php
+++ b/src/ApiPlatform/Resources/Product/ProductPackedProductList.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Pack\Query\GetPackedProducts;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/products/{packId}/pack-products',
+            CQRSQuery: GetPackedProducts::class,
+            scopes: ['product_read'],
+            CQRSQueryMapping: [
+                '[_context][langId]' => '[languageId]',
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductPackedProductList
+{
+    public int $packId;
+
+    public int $productId;
+
+    public int $quantity;
+
+    public int $combinationId;
+
+    public string $productName;
+
+    public string $reference;
+
+    public string $imageUrl;
+}

--- a/tests/Integration/ApiPlatform/ProductPackedProductListEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductPackedProductListEndpointTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ProductPackedProductListEndpointTest extends ApiTestCase
+{
+    private static int $packId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_read']);
+
+        // A demo pack product already has packed products.
+        self::$packId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product_pack` FROM `' . _DB_PREFIX_ . 'pack` ORDER BY `id_product_pack` ASC'
+        );
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list packed products endpoint' => ['GET', '/products/1/pack-products'];
+    }
+
+    public function testListPackedProducts(): void
+    {
+        $result = $this->getItem('/products/' . self::$packId . '/pack-products', ['product_read']);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('productId', $result[0]);
+        $this->assertArrayHasKey('quantity', $result[0]);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add the packed products read endpoint
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| Sponsor company   |

Adds **`GET /products/{packId}/pack-products`** — `GetPackedProducts`: lists the products contained in
a pack (`productId`, `quantity`, `combinationId`, `productName`, `reference`, `imageUrl`). Companion
read to the pack-products set/remove endpoints (`CQRSGetCollection`, context language + shop constraint).

The integration test reads a demo pack product. Reuses the `product_read` scope.
