### PR TITLE
Add GetAliasForEditing and SearchForSearchTerm Admin API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/SearchAlias/Alias.php
+++ b/src/ApiPlatform/Resources/SearchAlias/Alias.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SearchAlias;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Alias\Exception\AliasNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Alias\Query\GetAliasForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/search-aliases/aliases/{aliasId}',
+            requirements: ['aliasId' => '\d+'],
+            CQRSQuery: GetAliasForEditing::class,
+            scopes: ['search_alias_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        AliasNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class Alias
+{
+    #[ApiProperty(identifier: true)]
+    public int $aliasId;
+
+    public string $searchTerm = '';
+
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'array',
+            'items' => [
+                'type' => 'object',
+                'properties' => [
+                    'alias' => ['type' => 'string'],
+                    'enabled' => ['type' => 'boolean'],
+                ],
+            ],
+        ]
+    )]
+    public array $aliases = [];
+
+    protected const QUERY_MAPPING = [
+        '[aliases][@index][alias]' => '[aliases][@index][alias]',
+        '[aliases][@index][active]' => '[aliases][@index][enabled]',
+    ];
+}

--- a/src/ApiPlatform/Resources/SearchAlias/FoundSearchTerm.php
+++ b/src/ApiPlatform/Resources/SearchAlias/FoundSearchTerm.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SearchAlias;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\Alias\Query\SearchForSearchTerm;
+use PrestaShop\PrestaShop\Core\Exception\InvalidArgumentException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/search-terms',
+            CQRSQuery: SearchForSearchTerm::class,
+            scopes: ['search_alias_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'phrase',
+                    required: true,
+                    description: 'Search phrase used to find matching search terms'
+                ),
+                new QueryParameter(
+                    key: 'limit',
+                    schema: ['type' => 'integer', 'default' => '20'],
+                    required: false,
+                    description: 'Maximum number of search terms to return'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    [
+                        'name' => 'phrase',
+                        'in' => 'query',
+                        'required' => true,
+                        'schema' => ['type' => 'string'],
+                        'description' => 'Search phrase used to find matching search terms',
+                    ],
+                    [
+                        'name' => 'limit',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => ['type' => 'integer', 'default' => 20],
+                        'description' => 'Maximum number of search terms to return',
+                    ],
+                ],
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        InvalidArgumentException::class => Response::HTTP_BAD_REQUEST,
+    ],
+)]
+class FoundSearchTerm
+{
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'array',
+            'items' => ['type' => 'string'],
+        ]
+    )]
+    public array $searchTerms = [];
+
+    public const QUERY_MAPPING = [
+        '[phrase]' => '[searchTerm]',
+        '[@index]' => '[searchTerms][@index]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/SearchAliasEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SearchAliasEndpointTest.php
@@ -72,6 +72,16 @@ class SearchAliasEndpointTest extends ApiTestCase
             'DELETE',
             '/search-aliases/bulk-delete',
         ];
+
+        yield 'get alias by id endpoint' => [
+            'GET',
+            '/search-aliases/aliases/1',
+        ];
+
+        yield 'search terms endpoint' => [
+            'GET',
+            '/search-terms?phrase=blo',
+        ];
     }
 
     public function testCreateSearchAlias(): void
@@ -535,6 +545,88 @@ class SearchAliasEndpointTest extends ApiTestCase
             }
         }
         $this->assertTrue($hasAliasError, 'Should have validation error about missing alias field');
+    }
+
+    public function testGetAliasForEditing(): void
+    {
+        // Create a search alias, then resolve one of its alias row IDs from the database
+        $postData = [
+            'searchTerm' => 'editing-term',
+            'aliases' => [
+                ['alias' => 'editing-alias-one', 'enabled' => true],
+                ['alias' => 'editing-alias-two', 'enabled' => false],
+            ],
+        ];
+        $this->createItem('/search-aliases', $postData, ['search_alias_write'], Response::HTTP_CREATED);
+
+        $aliasId = $this->getAliasIdFromDatabase('editing-term', 'editing-alias-one');
+
+        // Getting an alias by its ID returns the whole search-term group it belongs to.
+        // Like the search-term GET, the response carries both 'active' and 'enabled'.
+        $response = $this->getItem('/search-aliases/aliases/' . $aliasId, ['search_alias_read']);
+        $this->assertEquals([
+            'aliasId' => $aliasId,
+            'searchTerm' => 'editing-term',
+            'aliases' => [
+                ['alias' => 'editing-alias-one', 'active' => 1, 'enabled' => 1],
+                ['alias' => 'editing-alias-two', 'active' => 0, 'enabled' => 0],
+            ],
+        ], $response);
+    }
+
+    public function testGetAliasForEditingNotFound(): void
+    {
+        $this->getItem('/search-aliases/aliases/99999999', ['search_alias_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testSearchForSearchTerm(): void
+    {
+        // Create several search terms sharing a common prefix
+        foreach (['autocomplete-alpha', 'autocomplete-beta', 'autocomplete-gamma'] as $term) {
+            $this->createItem('/search-aliases', [
+                'searchTerm' => $term,
+                'aliases' => [['alias' => $term . '-alias', 'enabled' => true]],
+            ], ['search_alias_write'], Response::HTTP_CREATED);
+        }
+
+        // All matching terms, sorted alphabetically
+        $response = $this->getItem('/search-terms?phrase=autocomplete', ['search_alias_read']);
+        $this->assertEquals([
+            'searchTerms' => ['autocomplete-alpha', 'autocomplete-beta', 'autocomplete-gamma'],
+        ], $response);
+
+        // The limit parameter caps the number of returned terms
+        $limited = $this->getItem('/search-terms?phrase=autocomplete&limit=2', ['search_alias_read']);
+        $this->assertEquals(['searchTerms' => ['autocomplete-alpha', 'autocomplete-beta']], $limited);
+
+        // A phrase matching nothing returns an empty list
+        $empty = $this->getItem('/search-terms?phrase=no-such-search-term', ['search_alias_read']);
+        $this->assertEquals(['searchTerms' => []], $empty);
+    }
+
+    public function testSearchForSearchTermMissingPhrase(): void
+    {
+        // The phrase query parameter is required
+        $this->requestApi('GET', '/search-terms', null, ['search_alias_read'], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function testSearchForSearchTermInvalidLimit(): void
+    {
+        // A non-positive limit is rejected by the CQRS query
+        $this->requestApi('GET', '/search-terms?phrase=autocomplete&limit=0', null, ['search_alias_read'], Response::HTTP_BAD_REQUEST);
+    }
+
+    private function getAliasIdFromDatabase(string $searchTerm, string $alias): int
+    {
+        $connection = static::getContainer()->get('doctrine.dbal.default_connection');
+        $id = $connection->fetchOne(
+            'SELECT id_alias FROM ' . _DB_PREFIX_ . 'alias WHERE search = ? AND alias = ?',
+            [$searchTerm, $alias]
+        );
+
+        $this->assertNotFalse($id, "Alias '$alias' for term '$searchTerm' should exist in database");
+
+        return (int) $id;
     }
 
     private function createTestSearchAlias2(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | Exposes two read-only `Alias` domain CQRS queries that were still missing from the Admin API. Adds two resource classes under `src/ApiPlatform/Resources/SearchAlias/`, both reusing the existing `search_alias_read` scope (no new scopes). **`Alias`** (`CQRSGet` → `GET /search-aliases/aliases/{aliasId}`) wraps `GetAliasForEditing`: given an alias row id, it returns the whole search-term group it belongs to (`searchTerm` + `aliases[{alias, active, enabled}]`), and `404`s when the id is unknown. **`FoundSearchTerm`** (`CQRSGet` → `GET /search-terms?phrase=…&limit=…`) wraps `SearchForSearchTerm` for autocomplete. Because that query returns a flat `string[]`, which `CQRSGetCollection` cannot serialize (its provider `array_merge`s each item, expecting arrays), it is intentionally modelled as a single `CQRSGet` that wraps the list in a `searchTerms` container property (mapped via `[@index]`); `phrase` is required (`422` if missing) and a non-positive `limit` is rejected (`400`).
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `composer run-module-tests` (filter `SearchAliasEndpointTest`) — 22 tests pass — or exercise via Swagger UI (`/admin-api`) with the `search_alias_read` scope. <br> 1. `GET /search-aliases/aliases/{aliasId}` returns `{aliasId, searchTerm, aliases[]}` for an existing alias id, and `404` for an unknown id. <br> 2. `GET /search-terms?phrase=blo` returns `{"searchTerms":["blouse"]}` against the default fixtures. <br> 3. `GET /search-terms?phrase=…&limit=2` caps the result to 2 terms. <br> 4. `GET /search-terms` (no `phrase`) returns `422`; `&limit=0` returns `400`.
