### PR TITLE
Add Customer thread details read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/CustomerThread/CustomerThreadDetails.php
+++ b/src/ApiPlatform/Resources/CustomerThread/CustomerThreadDetails.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CustomerThread;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerThreadNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Query\GetCustomerThreadForViewing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/customer-threads/{customerThreadId}/details',
+            requirements: ['customerThreadId' => '\d+'],
+            CQRSQuery: GetCustomerThreadForViewing::class,
+            scopes: [
+                'customer_service_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerThreadNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CustomerThreadDetails
+{
+    #[ApiProperty(identifier: true, openapiContext: ['type' => 'integer', 'example' => 1])]
+    public int $customerThreadId;
+
+    public int $languageId;
+
+    public array $actions;
+
+    public array $customerInformation;
+
+    public ?string $contactName;
+
+    public array $messages;
+
+    public array $timeline;
+
+    public const QUERY_MAPPING = [
+        '[customerThreadId]' => '[customerThreadId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CustomerThreadDetailsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerThreadDetailsEndpointTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class CustomerThreadDetailsEndpointTest extends ApiTestCase
+{
+    private static int $customerThreadId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['customer_service_read']);
+
+        // No "Add customer thread" command exists, so seed one through the legacy object.
+        // id_customer = 0 keeps the customer-information path on the lightweight
+        // "email only" branch, and id_order = 0 skips the order-history timeline.
+        $customerThread = new \CustomerThread();
+        $customerThread->id_lang = 1;
+        $customerThread->id_contact = 1;
+        $customerThread->id_shop = 1;
+        $customerThread->id_customer = 0;
+        $customerThread->id_order = 0;
+        $customerThread->email = 'thread-details@example.com';
+        $customerThread->status = 'open';
+        $customerThread->token = bin2hex(random_bytes(6));
+        $customerThread->add();
+
+        self::$customerThreadId = (int) $customerThread->id;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $customerThread = new \CustomerThread(self::$customerThreadId);
+        if (\Validate::isLoadedObject($customerThread)) {
+            $customerThread->delete();
+        }
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get customer thread details endpoint' => ['GET', '/customer-threads/1/details'];
+    }
+
+    public function testGetCustomerThreadDetails(): void
+    {
+        $thread = $this->getItem('/customer-threads/' . self::$customerThreadId . '/details', ['customer_service_read']);
+
+        $this->assertArrayHasKey('customerThreadId', $thread);
+        $this->assertSame(self::$customerThreadId, $thread['customerThreadId']);
+        $this->assertArrayHasKey('languageId', $thread);
+        $this->assertSame(1, $thread['languageId']);
+        $this->assertArrayHasKey('actions', $thread);
+        $this->assertArrayHasKey('customerInformation', $thread);
+        $this->assertArrayHasKey('contactName', $thread);
+        $this->assertArrayHasKey('messages', $thread);
+        $this->assertArrayHasKey('timeline', $thread);
+    }
+
+    public function testGetNonExistentCustomerThreadDetails(): void
+    {
+        $this->requestApi('GET', '/customer-threads/999999/details', null, ['customer_service_read'], Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Adds a read endpoint exposing the customer-service thread "view" aggregate: `GET /customer-threads/{customerThreadId}/details`. It returns the customer information, the available status actions, the thread messages and the activity timeline for a given thread (scope `customer_service_read`). This is the rich `GetCustomerThreadForViewing` query that was deliberately left out of the thread-management endpoints.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | Call `GET /customer-threads/{id}/details` with a client granted the `customer_service_read` scope and check the payload exposes `customerThreadId`, `languageId`, `actions`, `customerInformation`, `contactName`, `messages` and `timeline`. A non-existent id returns 404. Covered by `CustomerThreadDetailsEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.