### PR TITLE
Add CatalogPriceRule Admin API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/CatalogPriceRule/CatalogPriceRule.php
+++ b/src/ApiPlatform/Resources/CatalogPriceRule/CatalogPriceRule.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CatalogPriceRule;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\AddCatalogPriceRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\DeleteCatalogPriceRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Command\EditCatalogPriceRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Exception\CatalogPriceRuleConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Exception\CatalogPriceRuleNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Query\GetCatalogPriceRuleForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/catalog-price-rules/{catalogPriceRuleId}',
+            requirements: ['catalogPriceRuleId' => '\d+'],
+            CQRSQuery: GetCatalogPriceRuleForEditing::class,
+            scopes: ['catalog_price_rule_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/catalog-price-rules',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddCatalogPriceRuleCommand::class,
+            scopes: ['catalog_price_rule_write'],
+            CQRSQuery: GetCatalogPriceRuleForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/catalog-price-rules/{catalogPriceRuleId}',
+            requirements: ['catalogPriceRuleId' => '\d+'],
+            validationContext: ['groups' => ['Default', 'Update']],
+            CQRSCommand: EditCatalogPriceRuleCommand::class,
+            CQRSQuery: GetCatalogPriceRuleForEditing::class,
+            scopes: ['catalog_price_rule_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::UPDATE_COMMAND_MAPPING,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/catalog-price-rules/{catalogPriceRuleId}',
+            requirements: ['catalogPriceRuleId' => '\d+'],
+            CQRSCommand: DeleteCatalogPriceRuleCommand::class,
+            scopes: ['catalog_price_rule_write'],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        CatalogPriceRuleNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CatalogPriceRuleConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CatalogPriceRule
+{
+    #[ApiProperty(identifier: true)]
+    public int $catalogPriceRuleId;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $name;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public int $shopId;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public int $currencyId;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public int $countryId;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public int $groupId;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public int $fromQuantity;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $reductionType;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public DecimalNumber $reductionValue;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $includeTax;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public DecimalNumber $price;
+
+    public const QUERY_MAPPING = [
+        '[reduction][type]' => '[reductionType]',
+        '[reduction][value]' => '[reductionValue]',
+        '[taxIncluded]' => '[includeTax]',
+    ];
+
+    // AddCatalogPriceRuleCommand takes reductionType/reductionValue as flat constructor
+    // arguments, but EditCatalogPriceRuleCommand exposes them through the multi-parameter
+    // setter setReduction(string $type, string $value). The mapper fills that setter from a
+    // nested "reduction" object whose keys match the parameter names.
+    public const UPDATE_COMMAND_MAPPING = [
+        '[reductionType]' => '[reduction][type]',
+        '[reductionValue]' => '[reduction][value]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CatalogPriceRuleEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CatalogPriceRuleEndpointTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CatalogPriceRuleEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['catalog_price_rule_read', 'catalog_price_rule_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['specific_price_rule']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => ['POST', '/catalog-price-rules'];
+        yield 'get endpoint' => ['GET', '/catalog-price-rules/1'];
+        yield 'update endpoint' => ['PATCH', '/catalog-price-rules/1'];
+        yield 'delete endpoint' => ['DELETE', '/catalog-price-rules/1'];
+    }
+
+    public function testAddCatalogPriceRule(): int
+    {
+        $catalogPriceRule = $this->createItem('/catalog-price-rules', $this->getCreatePayload(), ['catalog_price_rule_write']);
+
+        $this->assertArrayHasKey('catalogPriceRuleId', $catalogPriceRule);
+
+        return $catalogPriceRule['catalogPriceRuleId'];
+    }
+
+    /**
+     * @depends testAddCatalogPriceRule
+     */
+    public function testGetCatalogPriceRule(int $catalogPriceRuleId): int
+    {
+        $catalogPriceRule = $this->getItem('/catalog-price-rules/' . $catalogPriceRuleId, ['catalog_price_rule_read']);
+
+        $this->assertEquals($catalogPriceRuleId, $catalogPriceRule['catalogPriceRuleId']);
+        $this->assertEquals('Test catalog price rule', $catalogPriceRule['name']);
+        $this->assertEquals(1, $catalogPriceRule['shopId']);
+        $this->assertEquals(0, $catalogPriceRule['currencyId']);
+        $this->assertEquals(0, $catalogPriceRule['countryId']);
+        $this->assertEquals(0, $catalogPriceRule['groupId']);
+        $this->assertEquals(1, $catalogPriceRule['fromQuantity']);
+        $this->assertEquals('amount', $catalogPriceRule['reductionType']);
+        $this->assertEquals(10.0, (float) $catalogPriceRule['reductionValue']);
+        $this->assertTrue($catalogPriceRule['includeTax']);
+        $this->assertEquals(-1.0, (float) $catalogPriceRule['price']);
+
+        return $catalogPriceRuleId;
+    }
+
+    /**
+     * @depends testGetCatalogPriceRule
+     */
+    public function testUpdateCatalogPriceRule(int $catalogPriceRuleId): int
+    {
+        $updatedRule = $this->partialUpdateItem(
+            '/catalog-price-rules/' . $catalogPriceRuleId,
+            [
+                'name' => 'Updated catalog price rule',
+                'fromQuantity' => 5,
+                'reductionType' => 'percentage',
+                'reductionValue' => '15',
+            ],
+            ['catalog_price_rule_write']
+        );
+
+        $this->assertEquals('Updated catalog price rule', $updatedRule['name']);
+        $this->assertEquals(5, $updatedRule['fromQuantity']);
+        $this->assertEquals('percentage', $updatedRule['reductionType']);
+        $this->assertEquals(15.0, (float) $updatedRule['reductionValue']);
+
+        // GET reflects the update
+        $fetched = $this->getItem('/catalog-price-rules/' . $catalogPriceRuleId, ['catalog_price_rule_read']);
+        $this->assertEquals('Updated catalog price rule', $fetched['name']);
+        $this->assertEquals('percentage', $fetched['reductionType']);
+
+        return $catalogPriceRuleId;
+    }
+
+    /**
+     * @depends testUpdateCatalogPriceRule
+     */
+    public function testDeleteCatalogPriceRule(int $catalogPriceRuleId): void
+    {
+        $this->deleteItem('/catalog-price-rules/' . $catalogPriceRuleId, ['catalog_price_rule_write']);
+        $this->getItem(
+            '/catalog-price-rules/' . $catalogPriceRuleId,
+            ['catalog_price_rule_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+
+    public function testInvalidCatalogPriceRule(): void
+    {
+        $invalidData = array_merge($this->getCreatePayload(), [
+            // Name is required (NotBlank) on creation.
+            'name' => '',
+        ]);
+
+        $validationErrorsResponse = $this->createItem(
+            '/catalog-price-rules',
+            $invalidData,
+            ['catalog_price_rule_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+        $this->assertIsArray($validationErrorsResponse);
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'name',
+                'message' => 'This value should not be blank.',
+            ],
+        ], $validationErrorsResponse);
+    }
+
+    private function getCreatePayload(): array
+    {
+        return [
+            'name' => 'Test catalog price rule',
+            'shopId' => 1,
+            'currencyId' => 0,
+            'countryId' => 0,
+            'groupId' => 0,
+            'fromQuantity' => 1,
+            'reductionType' => 'amount',
+            'reductionValue' => '10',
+            'includeTax' => true,
+            'price' => -1.0,
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds `GET` / `POST` / `PATCH` / `DELETE` `/catalog-price-rules` Admin API endpoints, exposing the existing `CatalogPriceRule` CQRS (`Add`/`Edit`/`Delete` commands + `GetCatalogPriceRuleForEditing`) as an ApiPlatform resource, following the established conventions (e.g. `Country`, `Tax`).
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Contributes to https://github.com/PrestaShop/PrestaShop/issues/39630
| Sponsor company   | Boring Investments
| How to test?      | Run the new `CatalogPriceRuleEndpointTest` (`composer run-module-tests`). It covers create/get/update/delete, protected-endpoint authentication and validation. Endpoints require a client with the `catalog_price_rule_read` / `catalog_price_rule_write` scopes.

### Implementation notes

- `reductionValue` and `price` are typed `DecimalNumber` (the module bans the raw `float` type on API resource properties).
- `AddCatalogPriceRuleCommand` takes `reductionType` / `reductionValue` as flat constructor arguments, while `EditCatalogPriceRuleCommand` exposes them through the multi-parameter setter `setReduction(string $type, string $value)`. The partial-update operation therefore uses a dedicated command mapping that nests the two fields into a `reduction` object so the setter is populated correctly.

Verified locally against a 9.2/develop install — `CatalogPriceRuleEndpointTest` passes (9 tests, 57 assertions), and `php-cs-fixer` / PHPStan are clean on the added files.
