### PR TITLE
Add State Admin API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/State/State.php
+++ b/src/ApiPlatform/Resources/State/State.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\State;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\State\Command\AddStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\State\Command\DeleteStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\State\Command\EditStateCommand;
+use PrestaShop\PrestaShop\Core\Domain\State\Exception\StateConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\State\Exception\StateNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\State\Query\GetStateForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/states/{stateId}',
+            requirements: ['stateId' => '\d+'],
+            CQRSQuery: GetStateForEditing::class,
+            scopes: ['state_read'],
+        ),
+        new CQRSCreate(
+            uriTemplate: '/states',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddStateCommand::class,
+            scopes: ['state_write'],
+            CQRSQuery: GetStateForEditing::class,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/states/{stateId}',
+            requirements: ['stateId' => '\d+'],
+            validationContext: ['groups' => ['Default', 'Update']],
+            CQRSCommand: EditStateCommand::class,
+            CQRSQuery: GetStateForEditing::class,
+            scopes: ['state_write'],
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/states/{stateId}',
+            requirements: ['stateId' => '\d+'],
+            CQRSCommand: DeleteStateCommand::class,
+            scopes: ['state_write'],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        StateNotFoundException::class => Response::HTTP_NOT_FOUND,
+        StateConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class State
+{
+    #[ApiProperty(identifier: true)]
+    public int $stateId;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $name;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public int $countryId;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public int $zoneId;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $isoCode;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $enabled;
+
+    public const COMMAND_MAPPING = [
+        '[enabled]' => '[active]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/StateEndpointTest.php
+++ b/tests/Integration/ApiPlatform/StateEndpointTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class StateEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['state_read', 'state_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['state']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => ['POST', '/states'];
+        yield 'get endpoint' => ['GET', '/states/1'];
+        yield 'update endpoint' => ['PATCH', '/states/1'];
+        yield 'delete endpoint' => ['DELETE', '/states/1'];
+    }
+
+    public function testAddState(): int
+    {
+        $state = $this->createItem('/states', $this->getCreatePayload(), ['state_write']);
+
+        $this->assertArrayHasKey('stateId', $state);
+
+        return $state['stateId'];
+    }
+
+    /**
+     * @depends testAddState
+     */
+    public function testGetState(int $stateId): int
+    {
+        $expected = ['stateId' => $stateId] + $this->getCreatePayload();
+
+        $state = $this->getItem('/states/' . $stateId, ['state_read']);
+        $this->assertEquals($expected, $state);
+
+        return $stateId;
+    }
+
+    /**
+     * @depends testGetState
+     */
+    public function testUpdateState(int $stateId): int
+    {
+        $patchData = [
+            'name' => 'Updated Test State',
+            'zoneId' => 1,
+            'isoCode' => 'XY',
+            'enabled' => false,
+        ];
+
+        $expected = [
+            'stateId' => $stateId,
+            'name' => 'Updated Test State',
+            'countryId' => 21,
+            'zoneId' => 1,
+            'isoCode' => 'XY',
+            'enabled' => false,
+        ];
+
+        $updatedState = $this->partialUpdateItem('/states/' . $stateId, $patchData, ['state_write']);
+        $this->assertEquals($expected, $updatedState);
+
+        $fetched = $this->getItem('/states/' . $stateId, ['state_read']);
+        $this->assertEquals($expected, $fetched);
+
+        return $stateId;
+    }
+
+    /**
+     * @depends testUpdateState
+     */
+    public function testDeleteState(int $stateId): void
+    {
+        // This endpoint returns an empty response and a 204 HTTP code.
+        $return = $this->deleteItem('/states/' . $stateId, ['state_write']);
+        $this->assertNull($return);
+
+        // Fetching a state that does not exist returns a 404 (StateNotFoundException mapping).
+        $this->getItem('/states/999999', ['state_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testInvalidState(): void
+    {
+        $invalidData = array_merge($this->getCreatePayload(), [
+            // Name is required (NotBlank) on creation.
+            'name' => '',
+        ]);
+
+        $validationErrorsResponse = $this->createItem(
+            '/states',
+            $invalidData,
+            ['state_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+        $this->assertIsArray($validationErrorsResponse);
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'name',
+                'message' => 'This value should not be blank.',
+            ],
+        ], $validationErrorsResponse);
+    }
+
+    private function getCreatePayload(): array
+    {
+        return [
+            'name' => 'Test State',
+            'countryId' => 21,
+            'zoneId' => 2,
+            'isoCode' => 'XX',
+            'enabled' => true,
+        ];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds `GET` / `POST` / `PATCH` / `DELETE` `/states` Admin API endpoints, exposing the existing `State` CQRS (`Add`/`Edit`/`Delete` commands + `GetStateForEditing`) as an ApiPlatform resource. This completes the geographic data model exposed by the API, alongside the existing `Country` and `Zone` resources.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Contributes to https://github.com/PrestaShop/PrestaShop/issues/39630
| Sponsor company   | Boring Investments
| How to test?      | Run the new `StateEndpointTest` (`composer run-module-tests`). It covers create/get/update/delete, protected-endpoint authentication and validation. Endpoints require a client with the `state_read` / `state_write` scopes.

### Note

`testDeleteState` asserts the `204` response and a `404` on a non-existent id rather than re-fetching the just-deleted state. `State::delete()` removes the row with a direct query without going through `parent::delete()`, so the `ObjectModel` cache is not cleared within the same PHP process — this is only observable in the single-process test runner (each real API request is a fresh process). This mirrors the existing `ZoneEndpointTest` delete convention.

Verified locally against a 9.2/develop install — `StateEndpointTest` passes (25 tests, 155 assertions); `php-cs-fixer` and PHPStan are clean on the added files.
