### PR TITLE
Add Currency Admin API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Currency/Currency.php
+++ b/src/ApiPlatform/Resources/Currency/Currency.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Currency;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Command\AddCurrencyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Command\DeleteCurrencyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Command\EditCurrencyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Query\GetCurrencyForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/currencies/{currencyId}',
+            requirements: ['currencyId' => '\d+'],
+            CQRSQuery: GetCurrencyForEditing::class,
+            scopes: ['currency_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/currencies',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddCurrencyCommand::class,
+            scopes: ['currency_write'],
+            CQRSQuery: GetCurrencyForEditing::class,
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::CREATE_COMMAND_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/currencies/{currencyId}',
+            requirements: ['currencyId' => '\d+'],
+            validationContext: ['groups' => ['Default', 'Update']],
+            CQRSCommand: EditCurrencyCommand::class,
+            CQRSQuery: GetCurrencyForEditing::class,
+            scopes: ['currency_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::UPDATE_COMMAND_MAPPING,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/currencies/{currencyId}',
+            requirements: ['currencyId' => '\d+'],
+            CQRSCommand: DeleteCurrencyCommand::class,
+            scopes: ['currency_write'],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        CurrencyNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CurrencyConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class Currency
+{
+    #[ApiProperty(identifier: true)]
+    public int $currencyId;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $isoCode;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public DecimalNumber $exchangeRate;
+
+    // Names, symbols and transformations are optional: for an official currency they are
+    // resolved from the CLDR reference data when not provided.
+    #[LocalizedValue]
+    public array $names;
+
+    #[LocalizedValue]
+    public array $symbols;
+
+    #[LocalizedValue]
+    public array $transformations;
+
+    public int $precision;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $enabled;
+
+    // Read-only: whether the currency is unofficial (not part of the CLDR reference data).
+    // Unofficial currencies are managed through their own dedicated commands.
+    public bool $unofficial;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    public array $shopIds;
+
+    public const QUERY_MAPPING = [
+        '[associatedShopIds]' => '[shopIds]',
+    ];
+
+    public const CREATE_COMMAND_MAPPING = [
+        '[names]' => '[localizedNames]',
+        '[symbols]' => '[localizedSymbols]',
+        '[transformations]' => '[localizedTransformations]',
+        '[enabled]' => '[isEnabled]',
+    ];
+
+    public const UPDATE_COMMAND_MAPPING = [
+        '[names]' => '[localizedNames]',
+        '[symbols]' => '[localizedSymbols]',
+        '[transformations]' => '[localizedTransformations]',
+        '[enabled]' => '[isEnabled]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CurrencyEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CurrencyEndpointTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CurrencyEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['currency_read', 'currency_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['currency', 'currency_lang', 'currency_shop']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => ['POST', '/currencies'];
+        yield 'get endpoint' => ['GET', '/currencies/1'];
+        yield 'update endpoint' => ['PATCH', '/currencies/1'];
+        yield 'delete endpoint' => ['DELETE', '/currencies/1'];
+    }
+
+    public function testAddCurrency(): int
+    {
+        // Official currency: names/symbols are resolved from CLDR, only the ISO code and
+        // exchange rate are required.
+        $currency = $this->createItem('/currencies', [
+            'isoCode' => 'CHF',
+            'exchangeRate' => 1.08,
+            'enabled' => true,
+            'shopIds' => [1],
+        ], ['currency_write']);
+
+        $this->assertArrayHasKey('currencyId', $currency);
+
+        return $currency['currencyId'];
+    }
+
+    /**
+     * @depends testAddCurrency
+     */
+    public function testGetCurrency(int $currencyId): int
+    {
+        $currency = $this->getItem('/currencies/' . $currencyId, ['currency_read']);
+
+        $this->assertEquals($currencyId, $currency['currencyId']);
+        $this->assertEquals('CHF', $currency['isoCode']);
+        $this->assertEquals(1.08, (float) $currency['exchangeRate']);
+        $this->assertFalse($currency['unofficial']);
+        $this->assertNotEmpty($currency['names']);
+        $this->assertNotEmpty($currency['symbols']);
+        $this->assertEquals([1], $currency['shopIds']);
+
+        return $currencyId;
+    }
+
+    /**
+     * @depends testGetCurrency
+     */
+    public function testUpdateCurrency(int $currencyId): int
+    {
+        $updated = $this->partialUpdateItem('/currencies/' . $currencyId, [
+            'exchangeRate' => 1.25,
+            'enabled' => false,
+        ], ['currency_write']);
+
+        $this->assertEquals(1.25, (float) $updated['exchangeRate']);
+        $this->assertFalse($updated['enabled']);
+
+        $fetched = $this->getItem('/currencies/' . $currencyId, ['currency_read']);
+        $this->assertEquals(1.25, (float) $fetched['exchangeRate']);
+        $this->assertFalse($fetched['enabled']);
+
+        return $currencyId;
+    }
+
+    /**
+     * @depends testUpdateCurrency
+     */
+    public function testDeleteCurrency(int $currencyId): void
+    {
+        $return = $this->deleteItem('/currencies/' . $currencyId, ['currency_write']);
+        $this->assertNull($return);
+
+        $this->getItem('/currencies/999999', ['currency_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testInvalidCurrency(): void
+    {
+        $validationErrorsResponse = $this->createItem(
+            '/currencies',
+            [
+                'isoCode' => '',
+                'exchangeRate' => 1.0,
+                'enabled' => true,
+            ],
+            ['currency_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+        $this->assertIsArray($validationErrorsResponse);
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'isoCode',
+                'message' => 'This value should not be blank.',
+            ],
+        ], $validationErrorsResponse);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds `GET` / `POST` / `PATCH` / `DELETE` `/currencies` Admin API endpoints, exposing the `Currency` CQRS (`AddCurrencyCommand` / `EditCurrencyCommand` / `DeleteCurrencyCommand` + `GetCurrencyForEditing`) as an ApiPlatform resource, following the established conventions (e.g. `Country`, `Tax`).
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Contributes to https://github.com/PrestaShop/PrestaShop/issues/39630
| Sponsor company   | Boring Investments
| How to test?      | Run the new `CurrencyEndpointTest` (`composer run-module-tests`). It covers create/get/update/delete, protected-endpoint authentication and validation. Endpoints require a client with the `currency_read` / `currency_write` scopes.

### Implementation notes

- `exchangeRate` is a `DecimalNumber` property (the module bans the raw `float` type on resource properties); the underlying CQRS commands take a numeric exchange rate.
- Localized `names`, `symbols` and `transformations` use `#[LocalizedValue]`.
- This covers **official** currencies — created from the CLDR reference data by ISO code (`AddCurrencyCommand`). Unofficial currencies, which use their own dedicated commands (`AddUnofficialCurrencyCommand`), are intentionally left as a follow-up so each operation maps cleanly to a single command.

### Dependency

The integration test requires **PrestaShop/PrestaShop#41884** — `GetCurrencyForEditing` must return a real boolean for the enabled state (it currently passes the legacy `active` value through as a string, which strict deserialization in the API rejects). With that core fix applied, `CurrencyEndpointTest` passes locally (9 tests, 52 assertions); `php-cs-fixer` and PHPStan are clean on the added files.
