### PR TITLE
Add SpecificPrice Admin API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/SpecificPrice/SpecificPrice.php
+++ b/src/ApiPlatform/Resources/SpecificPrice/SpecificPrice.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SpecificPrice;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Command\AddSpecificPriceCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Command\DeleteSpecificPriceCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Command\EditSpecificPriceCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Exception\SpecificPriceConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Exception\SpecificPriceNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Query\GetSpecificPriceForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/specific-prices/{specificPriceId}',
+            requirements: ['specificPriceId' => '\d+'],
+            CQRSQuery: GetSpecificPriceForEditing::class,
+            scopes: ['specific_price_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/specific-prices',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddSpecificPriceCommand::class,
+            CQRSQuery: GetSpecificPriceForEditing::class,
+            scopes: ['specific_price_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/specific-prices/{specificPriceId}',
+            requirements: ['specificPriceId' => '\d+'],
+            CQRSCommand: EditSpecificPriceCommand::class,
+            CQRSQuery: GetSpecificPriceForEditing::class,
+            scopes: ['specific_price_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::UPDATE_COMMAND_MAPPING,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/specific-prices/{specificPriceId}',
+            requirements: ['specificPriceId' => '\d+'],
+            CQRSCommand: DeleteSpecificPriceCommand::class,
+            scopes: ['specific_price_write'],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        SpecificPriceNotFoundException::class => Response::HTTP_NOT_FOUND,
+        SpecificPriceConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class SpecificPrice
+{
+    #[ApiProperty(identifier: true)]
+    public int $specificPriceId;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public int $productId;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $reductionType;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public DecimalNumber $reductionValue;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $includeTax;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public DecimalNumber $fixedPrice;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public int $fromQuantity;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $dateTimeFrom;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $dateTimeTo;
+
+    public ?int $shopId = null;
+
+    public ?int $combinationId = null;
+
+    public ?int $currencyId = null;
+
+    public ?int $countryId = null;
+
+    public ?int $groupId = null;
+
+    public ?int $customerId = null;
+
+    public const QUERY_MAPPING = [
+        '[reductionAmount]' => '[reductionValue]',
+        '[includesTax]' => '[includeTax]',
+        '[fixedPrice][value]' => '[fixedPrice]',
+    ];
+
+    // AddSpecificPriceCommand takes reductionType/reductionValue as flat constructor args, while
+    // EditSpecificPriceCommand exposes them through the multi-parameter setter
+    // setReduction(string $type, string $value). The mapper fills that setter from a nested
+    // "reduction" object whose keys match the parameter names. setIncludesTax(bool $includesTax)
+    // likewise expects the "includesTax" key.
+    public const UPDATE_COMMAND_MAPPING = [
+        '[reductionType]' => '[reduction][reductionType]',
+        '[reductionValue]' => '[reduction][reductionValue]',
+        '[includeTax]' => '[includesTax]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/SpecificPriceEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SpecificPriceEndpointTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class SpecificPriceEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['specific_price']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['specific_price']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => ['POST', '/specific-prices'];
+        yield 'get endpoint' => ['GET', '/specific-prices/1'];
+        yield 'update endpoint' => ['PATCH', '/specific-prices/1'];
+        yield 'delete endpoint' => ['DELETE', '/specific-prices/1'];
+    }
+
+    public function testAddSpecificPrice(): int
+    {
+        $specificPrice = $this->requestApi('POST', '/specific-prices', [
+            'productId' => 1,
+            'reductionType' => 'amount',
+            'reductionValue' => '5.000000',
+            'includeTax' => true,
+            'fixedPrice' => '-1',
+            'fromQuantity' => 1,
+            'dateTimeFrom' => '2026-06-01 00:00:00',
+            'dateTimeTo' => '2026-06-30 00:00:00',
+        ], ['specific_price_write'], Response::HTTP_CREATED);
+
+        $this->assertArrayHasKey('specificPriceId', $specificPrice);
+        $this->assertIsInt($specificPrice['specificPriceId']);
+        $this->assertGreaterThan(0, $specificPrice['specificPriceId']);
+        $this->assertSame(1, $specificPrice['productId']);
+        $this->assertSame('amount', $specificPrice['reductionType']);
+
+        return $specificPrice['specificPriceId'];
+    }
+
+    /**
+     * @depends testAddSpecificPrice
+     */
+    public function testGetSpecificPrice(int $specificPriceId): int
+    {
+        $specificPrice = $this->getItem('/specific-prices/' . $specificPriceId, ['specific_price_read']);
+
+        $this->assertSame($specificPriceId, $specificPrice['specificPriceId']);
+        $this->assertEquals(5, $specificPrice['reductionValue']);
+        $this->assertSame(1, $specificPrice['fromQuantity']);
+
+        return $specificPriceId;
+    }
+
+    /**
+     * @depends testGetSpecificPrice
+     */
+    public function testUpdateSpecificPrice(int $specificPriceId): int
+    {
+        $specificPrice = $this->requestApi('PATCH', '/specific-prices/' . $specificPriceId, [
+            'reductionType' => 'amount',
+            'reductionValue' => '8.000000',
+            'fromQuantity' => 3,
+        ], ['specific_price_write'], Response::HTTP_OK);
+
+        $this->assertEquals(8, $specificPrice['reductionValue']);
+        $this->assertSame(3, $specificPrice['fromQuantity']);
+
+        return $specificPriceId;
+    }
+
+    /**
+     * @depends testUpdateSpecificPrice
+     */
+    public function testDeleteSpecificPrice(int $specificPriceId): void
+    {
+        $this->requestApi('DELETE', '/specific-prices/' . $specificPriceId, null, ['specific_price_write'], Response::HTTP_NO_CONTENT);
+        $this->getItem('/specific-prices/' . $specificPriceId, ['specific_price_read'], Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | Adds CRUD Admin API endpoints for product specific prices: `GET/POST/PATCH/DELETE /specific-prices`. Covers the reduction (type + value), fixed price, from-quantity, date range, and the optional scope (shop, combination, currency, country, group, customer). Wires to the existing CQRS (`AddSpecificPriceCommand`, `EditSpecificPriceCommand`, `DeleteSpecificPriceCommand`, `GetSpecificPriceForEditing`). Covered by `SpecificPriceEndpointTest` — full CRUD — 8 tests / 39 assertions green against the local integration harness. (Per-product specific-price priority commands remain a follow-up.)
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run `SpecificPriceEndpointTest`. Or POST to `/specific-prices` with `productId`, `reductionType`, `reductionValue`, `includeTax`, `fixedPrice`, `fromQuantity`, `dateTimeFrom`, `dateTimeTo`; then GET/PATCH/DELETE `/specific-prices/{id}`.
| Fixed ticket?     | Contributes to PrestaShop/PrestaShop#39630
| Related PRs       | 
| Sponsor company   | Boring Investments
