### PR TITLE
Add Order details read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderDetails.php
+++ b/src/ApiPlatform/Resources/Order/OrderDetails.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderForViewing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/orders/{orderId}/details',
+            requirements: ['orderId' => '\d+'],
+            CQRSQuery: GetOrderForViewing::class,
+            scopes: [
+                'order_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class OrderDetails
+{
+    #[ApiProperty(identifier: true, openapiContext: ['type' => 'integer', 'example' => 1])]
+    public int $orderId;
+
+    public int $cartId;
+
+    public int $currencyId;
+
+    public int $carrierId;
+
+    public string $carrierName;
+
+    public int $shopId;
+
+    public string $reference;
+
+    public bool $valid;
+
+    public ?array $customer;
+
+    public array $shippingAddress;
+
+    public array $invoiceAddress;
+
+    public array $products;
+
+    public string $taxMethod;
+
+    public array $history;
+
+    public array $documents;
+
+    public array $shipping;
+
+    public array $returns;
+
+    public array $payments;
+
+    public array $messages;
+
+    public bool $delivered;
+
+    public bool $shipped;
+
+    public array $prices;
+
+    public bool $taxIncluded;
+
+    public array $discounts;
+
+    public array $linkedOrders;
+
+    public \DateTimeImmutable $createdAt;
+
+    public bool $virtual;
+
+    public bool $invoiceManagementIsEnabled;
+
+    public array $sources;
+
+    public bool $refundable;
+
+    public string $shippingAddressFormatted;
+
+    public string $invoiceAddressFormatted;
+
+    public string $note;
+
+    public string $paymentName;
+
+    public string $paymentModule;
+
+    public const QUERY_MAPPING = [
+        // Transforms the url orderId parameter into the $orderId parameter for GetOrderForViewing
+        '[orderId]' => '[orderId]',
+        // Transforms the query result OrderForViewing::getId into the API resource orderId
+        '[id]' => '[orderId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/OrderDetailsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderDetailsEndpointTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderDetailsEndpointTest extends ApiTestCase
+{
+    private static int $orderId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_read']);
+
+        // Orders cannot be created through a simple command, so reuse a demo order.
+        self::$orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` ASC'
+        );
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get order details endpoint' => ['GET', '/orders/1/details'];
+    }
+
+    public function testGetOrderDetails(): void
+    {
+        $order = $this->getItem('/orders/' . self::$orderId . '/details', ['order_read']);
+
+        $this->assertArrayHasKey('orderId', $order);
+        $this->assertSame(self::$orderId, $order['orderId']);
+        $this->assertArrayHasKey('reference', $order);
+        $this->assertArrayHasKey('valid', $order);
+        $this->assertArrayHasKey('customer', $order);
+        $this->assertArrayHasKey('shippingAddress', $order);
+        $this->assertArrayHasKey('invoiceAddress', $order);
+        $this->assertArrayHasKey('products', $order);
+        $this->assertArrayHasKey('history', $order);
+        $this->assertArrayHasKey('prices', $order);
+        $this->assertArrayHasKey('payments', $order);
+        $this->assertArrayHasKey('shipping', $order);
+        $this->assertArrayHasKey('createdAt', $order);
+    }
+
+    public function testGetNonExistentOrderDetails(): void
+    {
+        $this->requestApi('GET', '/orders/999999/details', null, ['order_read'], Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Adds a read endpoint exposing the full order "view" aggregate: `GET /orders/{orderId}/details`. It returns everything the BO order page shows — customer, shipping/invoice addresses, products, status history, documents, shipping, returns, payments, messages, prices, discounts, sources and the order flags (valid, virtual, delivered, shipped, refundable, ...) — for a given order (scope `order_read`). This is the `GetOrderForViewing` query, previously unexposed.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | Call `GET /orders/{id}/details` with a client granted the `order_read` scope and check the payload exposes `orderId`, `reference`, `customer`, `shippingAddress`, `invoiceAddress`, `products`, `history`, `prices`, `payments`, `shipping`, `createdAt`, etc. A non-existent id returns 404. Covered by `OrderDetailsEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.