### PR TITLE
Add Cart details read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Cart/CartDetails.php
+++ b/src/ApiPlatform/Resources/Cart/CartDetails.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Cart;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Query\GetCartForViewing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/carts/{cartId}/details',
+            requirements: ['cartId' => '\d+'],
+            CQRSQuery: GetCartForViewing::class,
+            scopes: [
+                'cart_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        CartNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CartDetails
+{
+    #[ApiProperty(identifier: true, openapiContext: ['type' => 'integer', 'example' => 1])]
+    public int $cartId;
+
+    public int $cartCurrencyId;
+
+    public array $customerInformation;
+
+    public array $orderInformation;
+
+    public array $cartSummary;
+
+    public const QUERY_MAPPING = [
+        '[cartId]' => '[cartId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CartDetailsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CartDetailsEndpointTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class CartDetailsEndpointTest extends ApiTestCase
+{
+    private static int $cartId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['cart_read']);
+
+        // Reuse a demo cart that is linked to an order, so it is a complete cart
+        // (products + addresses) exercising the whole cart view aggregate.
+        self::$cartId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_cart` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` ASC'
+        );
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get cart details endpoint' => ['GET', '/carts/1/details'];
+    }
+
+    public function testGetCartDetails(): void
+    {
+        $cart = $this->getItem('/carts/' . self::$cartId . '/details', ['cart_read']);
+
+        $this->assertArrayHasKey('cartId', $cart);
+        $this->assertSame(self::$cartId, $cart['cartId']);
+        $this->assertArrayHasKey('cartCurrencyId', $cart);
+        $this->assertArrayHasKey('customerInformation', $cart);
+        $this->assertArrayHasKey('orderInformation', $cart);
+        $this->assertArrayHasKey('cartSummary', $cart);
+    }
+
+    public function testGetNonExistentCartDetails(): void
+    {
+        $this->requestApi('GET', '/carts/999999/details', null, ['cart_read'], Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Adds a read endpoint exposing the cart "view" aggregate: `GET /carts/{cartId}/details`. It returns the customer information, the related order information, the cart currency and the full cart summary (products, totals, vouchers, ...) for a given cart (scope `cart_read`). This is the `GetCartForViewing` query used by the BO cart detail page, previously unexposed. It does not collide with the in-progress `GET /carts/{cartId}` (cart-for-order-creation) endpoint.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | Call `GET /carts/{id}/details` with a client granted the `cart_read` scope and check the payload exposes `cartId`, `cartCurrencyId`, `customerInformation`, `orderInformation` and `cartSummary`. A non-existent id returns 404. Covered by `CartDetailsEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.