### PR TITLE
Add categories tree read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Category/Category.php
+++ b/src/ApiPlatform/Resources/Category/Category.php
@@ -45,6 +45,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSGet(
             uriTemplate: '/categories/{categoryId}',
+            requirements: ['categoryId' => '\d+'],
             CQRSQuery: GetCategoryForEditing::class,
             scopes: [
                 'category_read',

--- a/src/ApiPlatform/Resources/Category/CategoryTree.php
+++ b/src/ApiPlatform/Resources/Category/CategoryTree.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Category;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Category\Query\GetCategoriesTree;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/categories/trees',
+            CQRSQuery: GetCategoriesTree::class,
+            scopes: [
+                'category_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][langId]' => '[languageId]',
+                '[_context][shopId]' => '[shopId]',
+            ],
+            ApiResourceMapping: [
+                '[active]' => '[enabled]',
+            ],
+        ),
+    ],
+)]
+class CategoryTree
+{
+    #[ApiProperty(identifier: true)]
+    public int $categoryId;
+
+    public bool $enabled;
+
+    public string $name;
+
+    public string $displayName;
+
+    /**
+     * Nested children categories, each with the same shape as this resource.
+     */
+    public array $children;
+}

--- a/tests/Integration/ApiPlatform/CategoryTreeEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CategoryTreeEndpointTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class CategoryTreeEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['category_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get categories tree endpoint' => ['GET', '/categories/trees'];
+    }
+
+    public function testGetCategoriesTree(): void
+    {
+        $tree = $this->getItem('/categories/trees', ['category_read']);
+
+        $this->assertNotEmpty($tree);
+        $this->assertArrayHasKey('categoryId', $tree[0]);
+        $this->assertArrayHasKey('enabled', $tree[0]);
+        $this->assertArrayHasKey('name', $tree[0]);
+        $this->assertArrayHasKey('displayName', $tree[0]);
+        $this->assertArrayHasKey('children', $tree[0]);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Adds a read endpoint exposing the category tree: `GET /categories/trees`. It returns the localized category tree for the current shop and language as a nested collection — each node exposes `categoryId`, `enabled`, `name`, `displayName` and its `children` (same shape, recursively). This is the `GetCategoriesTree` query used by the BO category pickers, previously unexposed. Scope `category_read`.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | Call `GET /categories/trees` with a client granted the `category_read` scope and check the payload is a nested tree where each node exposes `categoryId`, `enabled`, `name`, `displayName` and `children`. Covered by `CategoryTreeEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.