### PR TITLE
Add Category bulk enable/disable endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Category/BulkToggleCategoriesStatus.php
+++ b/src/ApiPlatform/Resources/Category/BulkToggleCategoriesStatus.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Category;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkDisableCategoriesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\BulkEnableCategoriesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CannotUpdateCategoryStatusException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/categories/bulk-enable',
+            read: false,
+            output: false,
+            CQRSCommand: BulkEnableCategoriesCommand::class,
+            scopes: [
+                'category_write',
+            ],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/categories/bulk-disable',
+            read: false,
+            output: false,
+            CQRSCommand: BulkDisableCategoriesCommand::class,
+            scopes: [
+                'category_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CategoryNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CannotUpdateCategoryStatusException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkToggleCategoriesStatus
+{
+    public array $categoryIds;
+}

--- a/tests/Integration/ApiPlatform/CategoryBulkStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CategoryBulkStatusEndpointTest.php
@@ -37,7 +37,7 @@ class CategoryBulkStatusEndpointTest extends ApiTestCase
     public static function tearDownAfterClass(): void
     {
         $ids = \Db::getInstance()->executeS(
-            "SELECT `id_category` FROM `" . _DB_PREFIX_ . "category` WHERE `id_category` > 1 AND `id_category` IN (SELECT `id_category` FROM `" . _DB_PREFIX_ . "category_lang` WHERE `name` = 'Test category gap')"
+            'SELECT `id_category` FROM `' . _DB_PREFIX_ . 'category` WHERE `id_category` > 1 AND `id_category` IN (SELECT `id_category` FROM `' . _DB_PREFIX_ . "category_lang` WHERE `name` = 'Test category gap')"
         );
         foreach ($ids ?: [] as $row) {
             (new \Category((int) $row['id_category']))->delete();

--- a/tests/Integration/ApiPlatform/CategoryBulkStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CategoryBulkStatusEndpointTest.php
@@ -26,6 +26,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CategoryBulkStatusEndpointTest extends ApiTestCase
 {
+    private static int $categoryCounter = 0;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
@@ -44,7 +46,7 @@ class CategoryBulkStatusEndpointTest extends ApiTestCase
         parent::tearDownAfterClass();
     }
 
-    public function getProtectedEndpoints(): iterable
+    public static function getProtectedEndpoints(): iterable
     {
         yield 'bulk enable categories endpoint' => ['PUT', '/categories/bulk-enable'];
         yield 'bulk disable categories endpoint' => ['PUT', '/categories/bulk-disable'];
@@ -83,8 +85,6 @@ class CategoryBulkStatusEndpointTest extends ApiTestCase
             $this->assertFalse((bool) (new \Category($categoryId))->active);
         }
     }
-
-    private static int $categoryCounter = 0;
 
     private function createCategory(bool $active): int
     {

--- a/tests/Integration/ApiPlatform/CategoryBulkStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CategoryBulkStatusEndpointTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class CategoryBulkStatusEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['category_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $ids = \Db::getInstance()->executeS(
+            "SELECT `id_category` FROM `" . _DB_PREFIX_ . "category` WHERE `id_category` > 1 AND `id_category` IN (SELECT `id_category` FROM `" . _DB_PREFIX_ . "category_lang` WHERE `name` = 'Test category gap')"
+        );
+        foreach ($ids ?: [] as $row) {
+            (new \Category((int) $row['id_category']))->delete();
+        }
+
+        parent::tearDownAfterClass();
+    }
+
+    public function getProtectedEndpoints(): iterable
+    {
+        yield 'bulk enable categories endpoint' => ['PUT', '/categories/bulk-enable'];
+        yield 'bulk disable categories endpoint' => ['PUT', '/categories/bulk-disable'];
+    }
+
+    public function testBulkEnableCategories(): void
+    {
+        $firstId = $this->createCategory(false);
+        $secondId = $this->createCategory(false);
+
+        $this->updateItem(
+            '/categories/bulk-enable',
+            ['categoryIds' => [$firstId, $secondId]],
+            ['category_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        foreach ([$firstId, $secondId] as $categoryId) {
+            $this->assertTrue((bool) (new \Category($categoryId))->active);
+        }
+    }
+
+    public function testBulkDisableCategories(): void
+    {
+        $firstId = $this->createCategory(true);
+        $secondId = $this->createCategory(true);
+
+        $this->updateItem(
+            '/categories/bulk-disable',
+            ['categoryIds' => [$firstId, $secondId]],
+            ['category_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        foreach ([$firstId, $secondId] as $categoryId) {
+            $this->assertFalse((bool) (new \Category($categoryId))->active);
+        }
+    }
+
+    private static int $categoryCounter = 0;
+
+    private function createCategory(bool $active): int
+    {
+        ++self::$categoryCounter;
+
+        $category = new \Category();
+        $category->id_parent = (int) \Configuration::get('PS_HOME_CATEGORY');
+        $category->active = $active;
+
+        foreach (\Language::getIDs(false) as $langId) {
+            $category->name[(int) $langId] = 'Test category gap';
+            $category->link_rewrite[(int) $langId] = 'test-category-gap-' . self::$categoryCounter . '-' . $langId;
+        }
+
+        $category->add();
+
+        return (int) $category->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the two Category status commands not covered by the existing category endpoints: `PUT /categories/bulk-enable` (`BulkEnableCategoriesCommand`) and `PUT /categories/bulk-disable` (`BulkDisableCategoriesCommand`). Both scoped `category_write` and take a `categoryIds` array.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /categories/bulk-enable` and `PUT /categories/bulk-disable` with `{ "categoryIds": [id1, id2] }` (client granted `category_write`) enable/disable the given categories. A missing category returns 404. Covered by `CategoryBulkStatusEndpointTest`.
| Possible impacts? | None beyond the categories targeted by each request.