### PR TITLE
Add address required-fields update endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Address/SetAddressRequiredFields.php
+++ b/src/ApiPlatform/Resources/Address/SetAddressRequiredFields.php
@@ -46,8 +46,6 @@ use Symfony\Component\HttpFoundation\Response;
 )]
 class SetAddressRequiredFields
 {
-    /**
-     * @var string[] Allowed values: company, address2, postcode, other, phone, phone_mobile, vat_number, dni
-     */
+    // Allowed values: company, address2, postcode, other, phone, phone_mobile, vat_number, dni.
     public array $requiredFields;
 }

--- a/src/ApiPlatform/Resources/Address/SetAddressRequiredFields.php
+++ b/src/ApiPlatform/Resources/Address/SetAddressRequiredFields.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Address;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Address\Command\SetRequiredFieldsForAddressCommand;
+use PrestaShop\PrestaShop\Core\Domain\Address\Exception\AddressConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Address\Exception\CannotSetRequiredFieldsForAddressException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/addresses/required-fields',
+            read: false,
+            output: false,
+            CQRSCommand: SetRequiredFieldsForAddressCommand::class,
+            scopes: [
+                'address_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        AddressConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CannotSetRequiredFieldsForAddressException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class SetAddressRequiredFields
+{
+    /**
+     * @var string[] Allowed values: company, address2, postcode, other, phone, phone_mobile, vat_number, dni
+     */
+    public array $requiredFields;
+}

--- a/tests/Integration/ApiPlatform/AddressRequiredFieldsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/AddressRequiredFieldsEndpointTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class AddressRequiredFieldsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['address_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        \Db::getInstance()->delete('required_field', "`object_name` = 'CustomerAddress'");
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'set address required fields endpoint' => ['PUT', '/addresses/required-fields'];
+    }
+
+    public function testSetAddressRequiredFields(): void
+    {
+        $this->updateItem(
+            '/addresses/required-fields',
+            ['requiredFields' => ['company', 'phone']],
+            ['address_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $storedFields = \Db::getInstance()->executeS(
+            "SELECT `field_name` FROM `" . _DB_PREFIX_ . "required_field` WHERE `object_name` = 'CustomerAddress'"
+        );
+        $fieldNames = array_column($storedFields ?: [], 'field_name');
+
+        $this->assertContains('company', $fieldNames);
+        $this->assertContains('phone', $fieldNames);
+    }
+
+    public function testSetInvalidAddressRequiredFieldIsRejected(): void
+    {
+        $this->updateItem(
+            '/addresses/required-fields',
+            ['requiredFields' => ['not_a_valid_field']],
+            ['address_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+    }
+}

--- a/tests/Integration/ApiPlatform/AddressRequiredFieldsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/AddressRequiredFieldsEndpointTest.php
@@ -54,7 +54,7 @@ class AddressRequiredFieldsEndpointTest extends ApiTestCase
         );
 
         $storedFields = \Db::getInstance()->executeS(
-            "SELECT `field_name` FROM `" . _DB_PREFIX_ . "required_field` WHERE `object_name` = 'CustomerAddress'"
+            'SELECT `field_name` FROM `' . _DB_PREFIX_ . "required_field` WHERE `object_name` = 'CustomerAddress'"
         );
         $fieldNames = array_column($storedFields ?: [], 'field_name');
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Adds `PUT /addresses/required-fields` (`SetRequiredFieldsForAddressCommand`, scope `address_write`): defines which optional address fields become required (allowed: company, address2, postcode, other, phone, phone_mobile, vat_number, dni). Complements the address required-fields read endpoint. Standalone resource file.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /addresses/required-fields` with `{ "requiredFields": ["company", "phone"] }` (client granted `address_write`) makes those fields required. An unknown field name returns 422. Covered by `AddressRequiredFieldsEndpointTest`.
| Possible impacts? | Updates the address required-field configuration.