### PR TITLE
Add regenerate-thumbnails endpoint

### DIFF
--- a/src/ApiPlatform/Resources/ImageType/RegenerateThumbnails.php
+++ b/src/ApiPlatform/Resources/ImageType/RegenerateThumbnails.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\ImageType;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Command\RegenerateThumbnailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\ImageTypeNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Exception\RegenerateThumbnailsException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/image-types/regenerate-thumbnails',
+            read: false,
+            output: false,
+            CQRSCommand: RegenerateThumbnailsCommand::class,
+            scopes: [
+                'image_type_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ImageTypeNotFoundException::class => Response::HTTP_NOT_FOUND,
+        RegenerateThumbnailsException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class RegenerateThumbnails
+{
+    /**
+     * Image domain to regenerate: all, categories, manufacturers, suppliers, products, stores.
+     */
+    public string $image;
+
+    /**
+     * Restrict to a single image type id, or 0 to regenerate every image type of the domain.
+     */
+    public int $imageTypeId;
+
+    public bool $erasePreviousImages;
+}

--- a/tests/Integration/ApiPlatform/RegenerateThumbnailsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/RegenerateThumbnailsEndpointTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class RegenerateThumbnailsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['image_type_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'regenerate thumbnails endpoint' => ['PUT', '/image-types/regenerate-thumbnails'];
+    }
+
+    public function testRegenerateThumbnails(): void
+    {
+        // Regenerate the supplier thumbnails (a small image domain) for every image
+        // type, without erasing the existing images.
+        $this->updateItem(
+            '/image-types/regenerate-thumbnails',
+            [
+                'image' => 'suppliers',
+                'imageTypeId' => 0,
+                'erasePreviousImages' => false,
+            ],
+            ['image_type_write'],
+            Response::HTTP_NO_CONTENT
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Adds `PUT /image-types/regenerate-thumbnails` (`RegenerateThumbnailsCommand`, scope `image_type_write`): regenerate the thumbnails of an image domain (`all`, `categories`, `manufacturers`, `suppliers`, `products`, `stores`) for a single image type (`imageTypeId`) or all of them (`0`), optionally erasing previous images.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /image-types/regenerate-thumbnails` with `{ "image": "suppliers", "imageTypeId": 0, "erasePreviousImages": false }` (client granted `image_type_write`) returns 204. Covered by `RegenerateThumbnailsEndpointTest`.
| Possible impacts? | Regenerates thumbnail images on disk for the selected domain.