### PR TITLE
Add product bulk-delete endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/BulkDeleteProducts.php
+++ b/src/ApiPlatform/Resources/Product/BulkDeleteProducts.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Command\BulkDeleteProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/products/bulk-delete',
+            CQRSCommand: BulkDeleteProductCommand::class,
+            scopes: [
+                'product_write',
+            ],
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteProducts
+{
+    public array $productIds;
+
+    public const COMMAND_MAPPING = [
+        '[_context][shopConstraint]' => '[shopConstraint]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/ProductBulkDeleteEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductBulkDeleteEndpointTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\Resetter\ProductResetter;
+
+class ProductBulkDeleteEndpointTest extends ApiTestCase
+{
+    private static int $productCounter = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        ProductResetter::resetProducts();
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'bulk delete products endpoint' => ['DELETE', '/products/bulk-delete'];
+    }
+
+    public function testBulkDeleteProducts(): void
+    {
+        $firstProductId = $this->createProduct();
+        $secondProductId = $this->createProduct();
+
+        $this->bulkDeleteItems(
+            '/products/bulk-delete',
+            ['productIds' => [$firstProductId, $secondProductId]],
+            ['product_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        foreach ([$firstProductId, $secondProductId] as $productId) {
+            $this->assertFalse(\Validate::isLoadedObject(new \Product($productId)));
+        }
+    }
+
+    private function createProduct(): int
+    {
+        ++self::$productCounter;
+
+        $product = new \Product();
+        $product->price = 10.0;
+        $product->id_category_default = (int) \Configuration::get('PS_HOME_CATEGORY');
+
+        foreach (\Language::getIDs(false) as $langId) {
+            $product->name[(int) $langId] = 'Test product gap';
+            $product->link_rewrite[(int) $langId] = 'test-product-gap-' . self::$productCounter . '-' . $langId;
+        }
+
+        $product->add();
+        $product->addToCategories([(int) \Configuration::get('PS_HOME_CATEGORY')]);
+
+        return (int) $product->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `BulkDeleteProductCommand` gap: `DELETE /products/bulk-delete` (scope `product_write`), taking a `productIds` array. The shop constraint is taken from the request context. Standalone resource file so it does not collide with the other Product endpoints.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `DELETE /products/bulk-delete` with `{ "productIds": [id1, id2] }` (client granted `product_write`) deletes the given products. Covered by `ProductBulkDeleteEndpointTest`.
| Possible impacts? | None beyond the products targeted by the request.