### PR TITLE
Add order shipping-details update endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderShippingDetails.php
+++ b/src/ApiPlatform/Resources/Order/OrderShippingDetails.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderShippingDetailsCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/shipping-details',
+            requirements: ['orderId' => '\d+'],
+            read: false,
+            output: false,
+            CQRSCommand: UpdateOrderShippingDetailsCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class OrderShippingDetails
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    public int $currentOrderCarrierId;
+
+    public int $newCarrierId;
+
+    public ?string $trackingNumber;
+}

--- a/tests/Integration/ApiPlatform/OrderShippingDetailsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderShippingDetailsEndpointTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderShippingDetailsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'update order shipping details endpoint' => ['PUT', '/orders/1/shipping-details'];
+    }
+
+    public function testUpdateOrderShippingDetails(): void
+    {
+        // Reuse an existing order carrier row. We send back the same carrier and
+        // tracking number so the command runs without changing the carrier (no
+        // shipping-cost recalculation) and without sending the "in transit" email
+        // (only sent when the tracking number actually changes) - neither of which
+        // is available in the test environment.
+        $orderCarrier = \Db::getInstance()->getRow(
+            'SELECT `id_order`, `id_order_carrier`, `id_carrier`, `tracking_number`
+             FROM `' . _DB_PREFIX_ . 'order_carrier` ORDER BY `id_order_carrier` ASC'
+        );
+
+        $orderId = (int) $orderCarrier['id_order'];
+        $orderCarrierId = (int) $orderCarrier['id_order_carrier'];
+        $trackingNumber = (string) $orderCarrier['tracking_number'];
+
+        $this->updateItem(
+            '/orders/' . $orderId . '/shipping-details',
+            [
+                'currentOrderCarrierId' => $orderCarrierId,
+                'newCarrierId' => (int) $orderCarrier['id_carrier'],
+                'trackingNumber' => $trackingNumber,
+            ],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $reloaded = new \OrderCarrier($orderCarrierId);
+        $this->assertSame($trackingNumber, (string) $reloaded->tracking_number);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `UpdateOrderShippingDetailsCommand` gap: `PUT /orders/{orderId}/shipping-details` (scope `order_write`) to change an order's carrier and/or tracking number (`currentOrderCarrierId`, `newCarrierId`, `trackingNumber`). The "in transit" customer email is only sent by the core handler when the tracking number actually changes.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /orders/{id}/shipping-details` with `{ "currentOrderCarrierId": x, "newCarrierId": y, "trackingNumber": "..." }` (client granted `order_write`) updates the order carrier/tracking. Covered by `OrderShippingDetailsEndpointTest`.
| Possible impacts? | Recalculates the order shipping cost when the carrier changes; sends the in-transit email when the tracking number changes.