### PR TITLE
Add virtual product file delete endpoint

### DIFF
--- a/src/ApiPlatform/Resources/VirtualProductFile/VirtualProductFile.php
+++ b/src/ApiPlatform/Resources/VirtualProductFile/VirtualProductFile.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\VirtualProductFile;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Command\DeleteVirtualProductFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\VirtualProductFileNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/virtual-product-files/{virtualProductFileId}',
+            requirements: ['virtualProductFileId' => '\d+'],
+            CQRSCommand: DeleteVirtualProductFileCommand::class,
+            scopes: [
+                'product_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        VirtualProductFileNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class VirtualProductFile
+{
+    #[ApiProperty(identifier: true)]
+    public int $virtualProductFileId;
+}

--- a/tests/Integration/ApiPlatform/VirtualProductFileEndpointTest.php
+++ b/tests/Integration/ApiPlatform/VirtualProductFileEndpointTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class VirtualProductFileEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'delete virtual product file endpoint' => ['DELETE', '/virtual-product-files/1'];
+    }
+
+    public function testDeleteVirtualProductFile(): void
+    {
+        $productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
+        );
+
+        $download = new \ProductDownload();
+        $download->id_product = $productId;
+        $download->filename = sha1(uniqid('vpf', true));
+        $download->display_filename = 'test-file';
+        $download->active = true;
+        $download->add();
+        $virtualProductFileId = (int) $download->id;
+
+        $this->requestApi(
+            'DELETE',
+            '/virtual-product-files/' . $virtualProductFileId,
+            null,
+            ['product_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $this->assertFalse(\Validate::isLoadedObject(new \ProductDownload($virtualProductFileId)));
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `DeleteVirtualProductFileCommand` gap: `DELETE /virtual-product-files/{virtualProductFileId}` (scope `product_write`), deleting a product's downloadable virtual file record.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `DELETE /virtual-product-files/{id}` (client granted `product_write`) removes the virtual product file. A missing id returns 404. Covered by `VirtualProductFileEndpointTest`.
| Possible impacts? | None beyond the virtual product file record targeted by the request.