### PR TITLE
Add cart add-product endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Cart/CartProduct.php
+++ b/src/ApiPlatform/Resources/Cart/CartProduct.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Cart;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Command\AddProductToCartCommand;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\MinimalQuantityException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/carts/{cartId}/products',
+            requirements: ['cartId' => '\d+'],
+            read: false,
+            output: false,
+            CQRSCommand: AddProductToCartCommand::class,
+            scopes: [
+                'cart_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CartNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CartConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        MinimalQuantityException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CartProduct
+{
+    #[ApiProperty(identifier: true)]
+    public int $cartId;
+
+    public int $productId;
+
+    public int $quantity;
+
+    public ?int $combinationId;
+}

--- a/tests/Integration/ApiPlatform/CartProductEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CartProductEndpointTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class CartProductEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['cart_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'add product to cart endpoint' => ['PUT', '/carts/1/products'];
+    }
+
+    public function testAddProductToCart(): void
+    {
+        $cartId = $this->createCart();
+        $productId = $this->getSimpleInStockProductId();
+
+        $this->updateItem(
+            '/carts/' . $cartId . '/products',
+            ['productId' => $productId, 'quantity' => 2],
+            ['cart_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $quantity = (int) \Db::getInstance()->getValue(
+            'SELECT `quantity` FROM `' . _DB_PREFIX_ . 'cart_product`
+             WHERE `id_cart` = ' . $cartId . ' AND `id_product` = ' . $productId
+        );
+        $this->assertSame(2, $quantity);
+    }
+
+    private function createCart(): int
+    {
+        $cart = new \Cart();
+        $cart->id_currency = (int) \Configuration::get('PS_CURRENCY_DEFAULT');
+        $cart->id_lang = (int) \Configuration::get('PS_LANG_DEFAULT');
+        $cart->id_shop = 1;
+        $cart->add();
+
+        return (int) $cart->id;
+    }
+
+    private function getSimpleInStockProductId(): int
+    {
+        return (int) \Db::getInstance()->getValue(
+            'SELECT sa.`id_product` FROM `' . _DB_PREFIX_ . 'stock_available` sa
+             INNER JOIN `' . _DB_PREFIX_ . 'product` p ON p.`id_product` = sa.`id_product`
+             WHERE sa.`quantity` > 0 AND sa.`id_product_attribute` = 0 AND p.`active` = 1
+             AND sa.`id_product` NOT IN (SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product_attribute`)
+             ORDER BY sa.`id_product` ASC'
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `AddProductToCartCommand` gap: `PUT /carts/{cartId}/products` (scope `cart_write`) to add a product (optionally a specific combination) with a quantity to a cart.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /carts/{id}/products` with `{ "productId": x, "quantity": 2 }` (client granted `cart_write`) adds the product to the cart. A missing cart/product returns 404. Covered by `CartProductEndpointTest`.
| Possible impacts? | None beyond the cart targeted by the request.