### PR TITLE
Add Attachment read endpoints to the Admin API

### DIFF
--- a/src/ApiPlatform/Resources/Attachment/AttachmentFile.php
+++ b/src/ApiPlatform/Resources/Attachment/AttachmentFile.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Attachment;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Exception\AttachmentNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Query\GetAttachment;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/attachments/{attachmentId}/files',
+            requirements: ['attachmentId' => '\d+'],
+            CQRSQuery: GetAttachment::class,
+            scopes: [
+                'attachment_read',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        AttachmentNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class AttachmentFile
+{
+    #[ApiProperty(identifier: true)]
+    public int $attachmentId;
+
+    public string $path;
+
+    public string $name;
+}

--- a/src/ApiPlatform/Resources/Attachment/AttachmentInformation.php
+++ b/src/ApiPlatform/Resources/Attachment/AttachmentInformation.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Attachment;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Exception\AttachmentNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Query\GetAttachmentInformation as GetAttachmentInformationQuery;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/attachments/{attachmentId}/information',
+            requirements: ['attachmentId' => '\d+'],
+            CQRSQuery: GetAttachmentInformationQuery::class,
+            scopes: [
+                'attachment_read',
+            ],
+            ApiResourceMapping: self::API_RESOURCE_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        AttachmentNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+    normalizationContext: ['skip_null_values' => false],
+)]
+class AttachmentInformation
+{
+    #[ApiProperty(identifier: true)]
+    public int $attachmentId;
+
+    #[LocalizedValue]
+    public array $names;
+
+    #[LocalizedValue]
+    public array $descriptions;
+
+    public string $fileName;
+
+    public string $mimeType;
+
+    public int $fileSize;
+
+    public const API_RESOURCE_MAPPING = [
+        '[localizedNames]' => '[names]',
+        '[localizedDescriptions]' => '[descriptions]',
+    ];
+}

--- a/src/ApiPlatform/Resources/Attachment/FoundAttachment.php
+++ b/src/ApiPlatform/Resources/Attachment/FoundAttachment.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Attachment;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Exception\EmptySearchException;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Exception\EmptySearchInputException;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Query\SearchAttachment;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/attachments/search',
+            CQRSQuery: SearchAttachment::class,
+            scopes: [
+                'attachment_read',
+            ],
+            CQRSQueryMapping: [
+                '[phrase]' => '[searchPhrase]',
+            ],
+            ApiResourceMapping: self::API_RESOURCE_MAPPING,
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'phrase',
+                    required: true,
+                    description: 'Search phrase to find attachments by name'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    [
+                        'name' => 'phrase',
+                        'in' => 'query',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                        'description' => 'Search phrase to find attachments by name',
+                    ],
+                ],
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        EmptySearchInputException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        EmptySearchException::class => Response::HTTP_NOT_FOUND,
+    ],
+    normalizationContext: ['skip_null_values' => false],
+)]
+class FoundAttachment
+{
+    #[ApiProperty(identifier: true)]
+    public int $attachmentId;
+
+    #[LocalizedValue]
+    public array $names;
+
+    #[LocalizedValue]
+    public array $descriptions;
+
+    public string $fileName;
+
+    public string $mimeType;
+
+    public int $fileSize;
+
+    public const API_RESOURCE_MAPPING = [
+        '[localizedNames]' => '[names]',
+        '[localizedDescriptions]' => '[descriptions]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/AttachmentReadEndpointTest.php
+++ b/tests/Integration/ApiPlatform/AttachmentReadEndpointTest.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\Context\LanguageContextBuilder;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\Command\AddAttachmentCommand;
+use PrestaShop\PrestaShop\Core\Domain\Attachment\ValueObject\AttachmentId;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+use Tests\Resources\DummyFileUploader;
+
+/**
+ * Covers the read-only Attachment endpoints wiring the SearchAttachment,
+ * GetAttachment and GetAttachmentInformation CQRS queries. The CRUD endpoints
+ * (GET/POST/PATCH/DELETE) are handled by a separate resource (see PR #295) and
+ * are intentionally not tested here.
+ */
+class AttachmentReadEndpointTest extends ApiTestCase
+{
+    private const SEARCHABLE_NAME = 'ApiResourceAttachment';
+
+    private static int $attachmentId;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::resetTables();
+        self::createApiClient(['attachment_read']);
+
+        self::$attachmentId = self::createAttachment(self::SEARCHABLE_NAME, 'test_text_file.txt');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        self::resetTables();
+    }
+
+    protected static function resetTables(): void
+    {
+        DatabaseDump::restoreTables([
+            'attachment',
+            'attachment_lang',
+        ]);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'search endpoint' => [
+            'GET',
+            '/attachments/search?phrase=test',
+        ];
+
+        yield 'get file endpoint' => [
+            'GET',
+            '/attachments/1/files',
+        ];
+
+        yield 'get information endpoint' => [
+            'GET',
+            '/attachments/1/information',
+        ];
+    }
+
+    public function testSearchAttachments(): void
+    {
+        $defaultLocale = self::getDefaultLocale();
+
+        $searchResults = $this->getItem('/attachments/search?phrase=' . self::SEARCHABLE_NAME, ['attachment_read']);
+
+        $this->assertIsArray($searchResults);
+        $this->assertNotEmpty($searchResults);
+
+        $found = false;
+        foreach ($searchResults as $result) {
+            $this->assertArrayHasKey('attachmentId', $result);
+            $this->assertArrayHasKey('names', $result);
+            $this->assertArrayHasKey('fileName', $result);
+            if ((int) $result['attachmentId'] === self::$attachmentId) {
+                $found = true;
+                $this->assertSame(self::SEARCHABLE_NAME, $result['names'][$defaultLocale]);
+                $this->assertSame('test_text_file.txt', $result['fileName']);
+            }
+        }
+
+        $this->assertTrue($found, 'The seeded attachment should be returned by the search.');
+    }
+
+    public function testSearchAttachmentsWithNoResults(): void
+    {
+        $this->getItem('/attachments/search?phrase=nonexistentattachment999', ['attachment_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testSearchAttachmentsWithEmptyPhrase(): void
+    {
+        $this->getItem('/attachments/search?phrase=', ['attachment_read'], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+
+    public function testGetAttachmentFile(): void
+    {
+        $attachmentFile = $this->getItem('/attachments/' . self::$attachmentId . '/files', ['attachment_read']);
+
+        $this->assertEquals(self::$attachmentId, $attachmentFile['attachmentId']);
+        $this->assertSame('test_text_file.txt', $attachmentFile['name']);
+        $this->assertNotEmpty($attachmentFile['path']);
+        $this->assertFileExists($attachmentFile['path']);
+    }
+
+    public function testGetNotFoundAttachmentFile(): void
+    {
+        $this->getItem('/attachments/999999/files', ['attachment_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testGetAttachmentInformation(): void
+    {
+        $defaultLocale = self::getDefaultLocale();
+
+        $information = $this->getItem('/attachments/' . self::$attachmentId . '/information', ['attachment_read']);
+
+        $this->assertEquals(self::$attachmentId, $information['attachmentId']);
+        $this->assertSame(self::SEARCHABLE_NAME, $information['names'][$defaultLocale]);
+        $this->assertArrayHasKey('descriptions', $information);
+        $this->assertSame('test_text_file.txt', $information['fileName']);
+        $this->assertSame('text/plain', $information['mimeType']);
+        $this->assertGreaterThan(0, $information['fileSize']);
+    }
+
+    public function testGetNotFoundAttachmentInformation(): void
+    {
+        $this->getItem('/attachments/999999/information', ['attachment_read'], Response::HTTP_NOT_FOUND);
+    }
+
+    private static function createAttachment(string $name, string $dummyFileName): int
+    {
+        $defaultLangId = (int) \Configuration::get('PS_LANG_DEFAULT');
+
+        $container = static::createClient()->getContainer();
+
+        // The AddAttachmentCommand validates the localized names against the default language,
+        // which requires the language context to be built. Outside of an HTTP request it must
+        // be defined explicitly.
+        /** @var LanguageContextBuilder $languageContextBuilder */
+        $languageContextBuilder = $container->get('test_language_context_builder');
+        $languageContextBuilder->setLanguageId($defaultLangId);
+        $languageContextBuilder->setDefaultLanguageId($defaultLangId);
+
+        $sourceFile = DummyFileUploader::upload($dummyFileName);
+
+        $command = new AddAttachmentCommand(
+            [$defaultLangId => $name],
+            [$defaultLangId => 'Description of ' . $name]
+        );
+        $command->setFileInformation(
+            $sourceFile,
+            (int) filesize($sourceFile),
+            (string) mime_content_type($sourceFile),
+            $dummyFileName
+        );
+
+        /** @var AttachmentId $attachmentId */
+        $attachmentId = $container->get('prestashop.core.command_bus')->handle($command);
+        $attachmentId = $attachmentId->getValue();
+
+        // The core file uploader relies on move_uploaded_file(), which is a no-op outside a
+        // real HTTP upload, so the physical file is never stored. Copy it to the location
+        // GetAttachment reads from so the /files endpoint can be exercised.
+        $attachment = new \Attachment($attachmentId);
+        copy(DummyFileUploader::getDummyFilePath($dummyFileName), _PS_DOWNLOAD_DIR_ . $attachment->file);
+
+        return $attachmentId;
+    }
+
+    private static function getDefaultLocale(): string
+    {
+        $defaultLangId = (int) \Configuration::get('PS_LANG_DEFAULT');
+
+        return (new \Language($defaultLangId))->getLocale();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds the **read-only** Attachment endpoints that are missing from the Admin API, wiring already existing core CQRS queries (no core change required):<br><br>• `GET /attachments/search?phrase=` → `SearchAttachment` (collection of matching attachments)<br>• `GET /attachments/{attachmentId}/files` → `GetAttachment` (file path + original name)<br>• `GET /attachments/{attachmentId}/information` → `GetAttachmentInformation` (localized names & descriptions, file name, mime type, file size)<br><br>All use the `attachment_read` scope. Localized fields are exposed as locale-keyed maps through `#[LocalizedValue]`.<br><br>Behaviour inherited from the core `SearchAttachment` handler: an empty `phrase` returns `422`, a search with no match returns `404`.
| Type?             | new feature
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Contributes to https://github.com/PrestaShop/PrestaShop/issues/41946
| Sponsor company   | @PrestaShopCorp
| How to test?      | - Run the module integration tests (`AttachmentReadEndpointTest`).<br>- Or from Swagger UI, create an API client with the `attachment_read` scope, then:<br>&nbsp;&nbsp;• `GET /attachments/search?phrase=<name>`<br>&nbsp;&nbsp;• `GET /attachments/{attachmentId}/files`<br>&nbsp;&nbsp;• `GET /attachments/{attachmentId}/information`

### Scope within the Attachment domain

This PR covers the read queries that no other PR handles, in dedicated resource classes (`FoundAttachment`, `AttachmentFile`, `AttachmentInformation`), so it does **not** collide with the CRUD Attachment resource. For the full domain (tracked in PrestaShop/PrestaShop#39630):

| Query / Command | Where |
| --- | --- |
| `SearchAttachment` | **this PR** |
| `GetAttachment` | **this PR** |
| `GetAttachmentInformation` | **this PR** — exposed at `GET /attachments/{attachmentId}/information` (distinct from #295's edit GET; returns `mimeType` + `fileSize` which the for-editing result does not, and needs no core change) |
| `GetAttachmentForEditing` + Add/Edit/Delete/Bulk (CRUD) | #295 (needs core PrestaShop/PrestaShop#41889 for the scalar-id constructors used by `PATCH`, and to expose the id in the for-editing result) |

Unlike #295, this PR requires no core modification.

### Related
- #295 — full Attachment CRUD (`GET/POST/PATCH/DELETE`, list, bulk)
- PrestaShop/PrestaShop#41889 — core companion to #295 (scalar ids + id exposure in the for-editing CQRS)
- PrestaShop/PrestaShop#39630 — Admin API endpoints tracking (Attachment domain)