### PR TITLE
Add cart send-to-customer endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Cart/CartEmail.php
+++ b/src/ApiPlatform/Resources/Cart/CartEmail.php
@@ -18,6 +18,8 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Cart;
 
 use ApiPlatform\Metadata\ApiProperty;

--- a/src/ApiPlatform/Resources/Cart/CartEmail.php
+++ b/src/ApiPlatform/Resources/Cart/CartEmail.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Cart;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Command\SendCartToCustomerCommand;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartException;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/carts/{cartId}/emails',
+            requirements: ['cartId' => '\d+'],
+            read: false,
+            output: false,
+            allowEmptyBody: true,
+            CQRSCommand: SendCartToCustomerCommand::class,
+            scopes: [
+                'cart_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CartNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CartException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CartEmail
+{
+    #[ApiProperty(identifier: true)]
+    public int $cartId;
+}

--- a/tests/Integration/ApiPlatform/CartEmailEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CartEmailEndpointTest.php
@@ -63,6 +63,21 @@ class CartEmailEndpointTest extends ApiTestCase
         );
     }
 
+    public function testSendUnknownCartReturnsNotFound(): void
+    {
+        $unknownCartId = 1 + (int) \Db::getInstance()->getValue(
+            'SELECT MAX(`id_cart`) FROM `' . _DB_PREFIX_ . 'cart`'
+        );
+
+        $this->requestApi(
+            'PUT',
+            '/carts/' . $unknownCartId . '/emails',
+            null,
+            ['cart_write'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+
     private function createCustomerCart(): int
     {
         $customerId = (int) \Db::getInstance()->getValue(
@@ -76,6 +91,20 @@ class CartEmailEndpointTest extends ApiTestCase
         $cart->id_shop = 1;
         $cart->add();
 
+        // A cart with a product is more representative of a real "send to customer" case.
+        $cart->updateQty(1, $this->getSimpleInStockProductId());
+
         return (int) $cart->id;
+    }
+
+    private function getSimpleInStockProductId(): int
+    {
+        return (int) \Db::getInstance()->getValue(
+            'SELECT sa.`id_product` FROM `' . _DB_PREFIX_ . 'stock_available` sa
+             INNER JOIN `' . _DB_PREFIX_ . 'product` p ON p.`id_product` = sa.`id_product`
+             WHERE sa.`quantity` > 0 AND sa.`id_product_attribute` = 0 AND p.`active` = 1
+             AND sa.`id_product` NOT IN (SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product_attribute`)
+             ORDER BY sa.`id_product` ASC'
+        );
     }
 }

--- a/tests/Integration/ApiPlatform/CartEmailEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CartEmailEndpointTest.php
@@ -68,6 +68,9 @@ class CartEmailEndpointTest extends ApiTestCase
         );
     }
 
+    // Note: the CartException => 422 mapping is not exercised here. The only way the handler
+    // raises a generic CartException is a mail-send failure or a cart whose customer no longer
+    // exists — states that cannot be reliably set up through this endpoint in an integration test.
     public function testSendUnknownCartReturnsNotFound(): void
     {
         $unknownCartId = 1 + (int) \Db::getInstance()->getValue(

--- a/tests/Integration/ApiPlatform/CartEmailEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CartEmailEndpointTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class CartEmailEndpointTest extends ApiTestCase
+{
+    private static int $originalMailMethod;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['cart_write']);
+
+        // Disable real email sending so Mail::send() succeeds without an SMTP server.
+        self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
+        \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        \Configuration::updateValue('PS_MAIL_METHOD', self::$originalMailMethod);
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'send cart to customer endpoint' => ['PUT', '/carts/1/emails'];
+    }
+
+    public function testSendCartToCustomer(): void
+    {
+        $cartId = $this->createCustomerCart();
+
+        $this->requestApi(
+            'PUT',
+            '/carts/' . $cartId . '/emails',
+            null,
+            ['cart_write'],
+            Response::HTTP_NO_CONTENT
+        );
+    }
+
+    private function createCustomerCart(): int
+    {
+        $customerId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_customer` FROM `' . _DB_PREFIX_ . 'customer` WHERE `active` = 1 ORDER BY `id_customer` ASC'
+        );
+
+        $cart = new \Cart();
+        $cart->id_customer = $customerId;
+        $cart->id_currency = (int) \Configuration::get('PS_CURRENCY_DEFAULT');
+        $cart->id_lang = (int) \Configuration::get('PS_LANG_DEFAULT');
+        $cart->id_shop = 1;
+        $cart->add();
+
+        return (int) $cart->id;
+    }
+}

--- a/tests/Integration/ApiPlatform/CartEmailEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CartEmailEndpointTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
 use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
 
 class CartEmailEndpointTest extends ApiTestCase
 {
@@ -33,6 +34,8 @@ class CartEmailEndpointTest extends ApiTestCase
         parent::setUpBeforeClass();
         self::createApiClient(['cart_write']);
 
+        DatabaseDump::restoreTables(['cart', 'cart_product']);
+
         // Disable real email sending so Mail::send() succeeds without an SMTP server.
         self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
         \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
@@ -41,6 +44,8 @@ class CartEmailEndpointTest extends ApiTestCase
     public static function tearDownAfterClass(): void
     {
         \Configuration::updateValue('PS_MAIL_METHOD', self::$originalMailMethod);
+
+        DatabaseDump::restoreTables(['cart', 'cart_product']);
 
         parent::tearDownAfterClass();
     }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `SendCartToCustomerCommand` gap: `PUT /carts/{cartId}/emails` (scope `cart_write`) to send the cart to its customer by email.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Related ticket?     | Related to PrestaShop/PrestaShop#39630
| Fixed ticket?     | fixed https://github.com/PrestaShop/PrestaShop/issues/41969
| How to test?      | `PUT /carts/{id}/emails` (client granted `cart_write`) emails the cart to the customer. Covered by `CartEmailEndpointTest` (which disables real mail sending so the assertion does not depend on an SMTP server).
| Possible impacts? | Sends an email to the cart customer.