### PR TITLE
Add API client generate-secret endpoint

### DIFF
--- a/src/ApiPlatform/Resources/ApiClient/GenerateApiClientSecret.php
+++ b/src/ApiPlatform/Resources/ApiClient/GenerateApiClientSecret.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\ApiClient;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\GenerateApiClientSecretCommand;
+use PrestaShop\PrestaShop\Core\Domain\ApiClient\Exception\ApiClientNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/api-clients/{apiClientId}/secrets',
+            requirements: ['apiClientId' => '\d+'],
+            read: false,
+            allowEmptyBody: true,
+            CQRSCommand: GenerateApiClientSecretCommand::class,
+            scopes: [
+                'api_client_write',
+            ],
+            ApiResourceMapping: self::RESOURCE_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        ApiClientNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class GenerateApiClientSecret
+{
+    #[ApiProperty(identifier: true)]
+    public int $apiClientId;
+
+    public string $secret;
+
+    public const RESOURCE_MAPPING = [
+        // The command returns the generated secret as a scalar, wrapped as _commandResult by the core.
+        '[_commandResult]' => '[secret]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/GenerateApiClientSecretEndpointTest.php
+++ b/tests/Integration/ApiPlatform/GenerateApiClientSecretEndpointTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class GenerateApiClientSecretEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['api_client_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'generate api client secret endpoint' => ['PUT', '/api-clients/1/secrets'];
+    }
+
+    public function testGenerateApiClientSecret(): void
+    {
+        $apiClientId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_api_client` FROM `' . _DB_PREFIX_ . 'api_client` ORDER BY `id_api_client` DESC'
+        );
+
+        $response = $this->updateItem(
+            '/api-clients/' . $apiClientId . '/secrets',
+            [],
+            ['api_client_write'],
+            Response::HTTP_OK
+        );
+
+        $this->assertArrayHasKey('secret', $response);
+        $this->assertNotEmpty($response['secret']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GenerateApiClientSecretCommand` as `PUT /api-clients/{apiClientId}/secrets` (scope `api_client_write`): regenerate the API client secret and return the new plaintext secret. The command returns a scalar string, mapped to the resource via `ApiResourceMapping ['[_commandResult]' => '[secret]']`.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /api-clients/{id}/secrets` (client granted `api_client_write`) returns `{ apiClientId, secret }` with the new secret. Covered by `GenerateApiClientSecretEndpointTest`.
| Possible impacts? | Regenerates (and returns) the API client secret.

> **Draft — depends on core PR PrestaShop/PrestaShop#41964.** `GenerateApiClientSecretCommand` returns a scalar (the secret string); the core `CommandProcessor` currently throws an `array_merge` TypeError for scalar command results. #41964 wraps them as `_commandResult` (mirroring `_queryResult`). This endpoint turns green once #41964 is released.