### PR TITLE
Add order resend-email endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderEmail.php
+++ b/src/ApiPlatform/Resources/Order/OrderEmail.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\ResendOrderEmailCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderEmailSendException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/emails',
+            requirements: ['orderId' => '\d+'],
+            read: false,
+            output: false,
+            CQRSCommand: ResendOrderEmailCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        OrderEmailSendException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderEmail
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    public int $orderStatusId;
+
+    public int $orderHistoryId;
+}

--- a/src/ApiPlatform/Resources/Order/OrderEmail.php
+++ b/src/ApiPlatform/Resources/Order/OrderEmail.php
@@ -28,6 +28,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
@@ -53,7 +54,9 @@ class OrderEmail
     #[ApiProperty(identifier: true)]
     public int $orderId;
 
+    #[Assert\Positive]
     public int $orderStatusId;
 
+    #[Assert\Positive]
     public int $orderHistoryId;
 }

--- a/tests/Integration/ApiPlatform/OrderEmailEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderEmailEndpointTest.php
@@ -67,4 +67,32 @@ class OrderEmailEndpointTest extends ApiTestCase
             Response::HTTP_NO_CONTENT
         );
     }
+
+    public function testResendOrderEmailWithInvalidPayload(): void
+    {
+        $history = \Db::getInstance()->getRow(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'order_history` ORDER BY `id_order_history` ASC'
+        );
+
+        $validationErrorsResponse = $this->updateItem(
+            '/orders/' . (int) $history['id_order'] . '/emails',
+            [
+                'orderStatusId' => 0,
+                'orderHistoryId' => 0,
+            ],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+        $this->assertIsArray($validationErrorsResponse);
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'orderStatusId',
+                'message' => 'This value should be positive.',
+            ],
+            [
+                'propertyPath' => 'orderHistoryId',
+                'message' => 'This value should be positive.',
+            ],
+        ], $validationErrorsResponse);
+    }
 }

--- a/tests/Integration/ApiPlatform/OrderEmailEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderEmailEndpointTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderEmailEndpointTest extends ApiTestCase
+{
+    private static int $originalMailMethod;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+
+        // Disable real email sending so OrderHistory::sendEmail() succeeds without an SMTP server.
+        self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
+        \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        \Configuration::updateValue('PS_MAIL_METHOD', self::$originalMailMethod);
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'resend order email endpoint' => ['PUT', '/orders/1/emails'];
+    }
+
+    public function testResendOrderEmail(): void
+    {
+        $history = \Db::getInstance()->getRow(
+            'SELECT `id_order`, `id_order_history`, `id_order_state`
+             FROM `' . _DB_PREFIX_ . 'order_history` ORDER BY `id_order_history` ASC'
+        );
+
+        $this->updateItem(
+            '/orders/' . (int) $history['id_order'] . '/emails',
+            [
+                'orderStatusId' => (int) $history['id_order_state'],
+                'orderHistoryId' => (int) $history['id_order_history'],
+            ],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `ResendOrderEmailCommand` gap: `PUT /orders/{orderId}/emails` (scope `order_write`) to resend the customer email of an order status history entry (`orderStatusId`, `orderHistoryId`).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /orders/{id}/emails` with `{ "orderStatusId": x, "orderHistoryId": y }` (client granted `order_write`) resends the status email. Covered by `OrderEmailEndpointTest` (which disables real mail sending so the assertion does not depend on an SMTP server).
| Possible impacts? | Resends an order status email to the customer.