### PR TITLE
Add order update-status endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderStatus.php
+++ b/src/ApiPlatform/Resources/Order/OrderStatus.php
@@ -23,7 +23,6 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderStatusCommand;
-use PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
@@ -46,7 +45,6 @@ use Symfony\Component\Validator\Constraints as Assert;
     exceptionToStatus: [
         OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
         OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
-        ChangeOrderStatusException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
     ],
 )]
 class OrderStatus

--- a/src/ApiPlatform/Resources/Order/OrderStatus.php
+++ b/src/ApiPlatform/Resources/Order/OrderStatus.php
@@ -28,6 +28,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
@@ -53,5 +54,6 @@ class OrderStatus
     #[ApiProperty(identifier: true)]
     public int $orderId;
 
+    #[Assert\Positive]
     public int $newOrderStatusId;
 }

--- a/src/ApiPlatform/Resources/Order/OrderStatus.php
+++ b/src/ApiPlatform/Resources/Order/OrderStatus.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\UpdateOrderStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/status',
+            requirements: ['orderId' => '\d+'],
+            read: false,
+            output: false,
+            CQRSCommand: UpdateOrderStatusCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        ChangeOrderStatusException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderStatus
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    public int $newOrderStatusId;
+}

--- a/tests/Integration/ApiPlatform/OrderStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderStatusEndpointTest.php
@@ -41,20 +41,13 @@ class OrderStatusEndpointTest extends ApiTestCase
         self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
         \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
 
-        // Use an order whose current (latest history) state is "logable" and only move it between
-        // logable states, so the transition never adjusts stock.
-        $order = \Db::getInstance()->getRow(
-            'SELECT oh.`id_order`, oh.`id_order_state`
-             FROM `' . _DB_PREFIX_ . 'order_history` oh
-             INNER JOIN `' . _DB_PREFIX_ . 'order_state` os ON os.`id_order_state` = oh.`id_order_state`
-             WHERE os.`logable` = 1
-             AND oh.`id_order_history` = (
-                 SELECT MAX(`id_order_history`) FROM `' . _DB_PREFIX_ . 'order_history` WHERE `id_order` = oh.`id_order`
-             )
-             ORDER BY oh.`id_order` DESC'
+        self::$orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` DESC'
         );
-        self::$orderId = (int) $order['id_order'];
-        self::$originalState = (int) $order['id_order_state'];
+        self::$originalState = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order_state` FROM `' . _DB_PREFIX_ . 'order_history`
+             WHERE `id_order` = ' . self::$orderId . ' ORDER BY `id_order_history` DESC'
+        );
     }
 
     public static function tearDownAfterClass(): void
@@ -73,11 +66,12 @@ class OrderStatusEndpointTest extends ApiTestCase
 
     public function testUpdateOrderStatus(): void
     {
-        $newStateId = (int) \Db::getInstance()->getValue(
-            'SELECT `id_order_state` FROM `' . _DB_PREFIX_ . 'order_state`
-             WHERE `deleted` = 0 AND `logable` = 1 AND `id_order_state` <> ' . self::$originalState . '
-             ORDER BY `id_order_state` ASC'
-        );
+        // "Processing in progress" / "Payment accepted" are both logable, non-error states,
+        // so moving between them (or from the current state) never adjusts stock.
+        $newStateId = (int) \Configuration::get('PS_OS_PREPARATION');
+        if ($newStateId === 0 || $newStateId === self::$originalState) {
+            $newStateId = (int) \Configuration::get('PS_OS_PAYMENT');
+        }
 
         $this->updateItem(
             '/orders/' . self::$orderId . '/status',

--- a/tests/Integration/ApiPlatform/OrderStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderStatusEndpointTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderStatusEndpointTest extends ApiTestCase
+{
+    private static int $originalMailMethod;
+
+    private static int $orderId;
+
+    private static int $originalState;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+
+        // Disable real email sending so the status-change email succeeds without an SMTP server.
+        self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
+        \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
+
+        // Use an order whose current state is "logable" and only move it between logable states,
+        // so the transition never adjusts stock.
+        self::$orderId = (int) \Db::getInstance()->getValue(
+            'SELECT o.`id_order` FROM `' . _DB_PREFIX_ . 'orders` o
+             INNER JOIN `' . _DB_PREFIX_ . 'order_state` os ON os.`id_order_state` = o.`current_state`
+             WHERE os.`logable` = 1 ORDER BY o.`id_order` DESC'
+        );
+        self::$originalState = (int) (new \Order(self::$orderId))->getCurrentState();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        // Restore the order state (while mail is still disabled), then restore the mail method.
+        (new \Order(self::$orderId))->setCurrentState(self::$originalState);
+        \Configuration::updateValue('PS_MAIL_METHOD', self::$originalMailMethod);
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'update order status endpoint' => ['PUT', '/orders/1/status'];
+    }
+
+    public function testUpdateOrderStatus(): void
+    {
+        $newStateId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order_state` FROM `' . _DB_PREFIX_ . 'order_state`
+             WHERE `deleted` = 0 AND `logable` = 1 AND `id_order_state` <> ' . self::$originalState . '
+             ORDER BY `id_order_state` ASC'
+        );
+
+        $this->updateItem(
+            '/orders/' . self::$orderId . '/status',
+            ['newOrderStatusId' => $newStateId],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $this->assertSame($newStateId, (int) (new \Order(self::$orderId))->getCurrentState());
+    }
+}

--- a/tests/Integration/ApiPlatform/OrderStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderStatusEndpointTest.php
@@ -82,4 +82,21 @@ class OrderStatusEndpointTest extends ApiTestCase
 
         $this->assertSame($newStateId, (int) (new \Order(self::$orderId))->getCurrentState());
     }
+
+    public function testUpdateOrderStatusWithInvalidPayload(): void
+    {
+        $validationErrorsResponse = $this->updateItem(
+            '/orders/' . self::$orderId . '/status',
+            ['newOrderStatusId' => 0],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+        $this->assertIsArray($validationErrorsResponse);
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'newOrderStatusId',
+                'message' => 'This value should be positive.',
+            ],
+        ], $validationErrorsResponse);
+    }
 }

--- a/tests/Integration/ApiPlatform/OrderStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderStatusEndpointTest.php
@@ -41,14 +41,20 @@ class OrderStatusEndpointTest extends ApiTestCase
         self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
         \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
 
-        // Use an order whose current state is "logable" and only move it between logable states,
-        // so the transition never adjusts stock.
-        self::$orderId = (int) \Db::getInstance()->getValue(
-            'SELECT o.`id_order` FROM `' . _DB_PREFIX_ . 'orders` o
-             INNER JOIN `' . _DB_PREFIX_ . 'order_state` os ON os.`id_order_state` = o.`current_state`
-             WHERE os.`logable` = 1 ORDER BY o.`id_order` DESC'
+        // Use an order whose current (latest history) state is "logable" and only move it between
+        // logable states, so the transition never adjusts stock.
+        $order = \Db::getInstance()->getRow(
+            'SELECT oh.`id_order`, oh.`id_order_state`
+             FROM `' . _DB_PREFIX_ . 'order_history` oh
+             INNER JOIN `' . _DB_PREFIX_ . 'order_state` os ON os.`id_order_state` = oh.`id_order_state`
+             WHERE os.`logable` = 1
+             AND oh.`id_order_history` = (
+                 SELECT MAX(`id_order_history`) FROM `' . _DB_PREFIX_ . 'order_history` WHERE `id_order` = oh.`id_order`
+             )
+             ORDER BY oh.`id_order` DESC'
         );
-        self::$originalState = (int) (new \Order(self::$orderId))->getCurrentState();
+        self::$orderId = (int) $order['id_order'];
+        self::$originalState = (int) $order['id_order_state'];
     }
 
     public static function tearDownAfterClass(): void


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `UpdateOrderStatusCommand` gap: `PUT /orders/{orderId}/status` (scope `order_write`) to change an order's current status (`newOrderStatusId`).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /orders/{id}/status` with `{ "newOrderStatusId": x }` (client granted `order_write`) changes the order status. Covered by `OrderStatusEndpointTest` (which disables real mail sending so the assertion does not depend on an SMTP server).
| Possible impacts? | Changes the order status (and sends the associated status email).