### PR TITLE
Add cart process-order-email endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Cart/CartProcessOrderEmail.php
+++ b/src/ApiPlatform/Resources/Cart/CartProcessOrderEmail.php
@@ -22,6 +22,7 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Cart;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\SendProcessOrderEmailCommand;
@@ -47,6 +48,7 @@ use Symfony\Component\HttpFoundation\Response;
     exceptionToStatus: [
         CartNotFoundException::class => Response::HTTP_NOT_FOUND,
         CustomerNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CartConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
         OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
         OrderEmailSendException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
     ],

--- a/src/ApiPlatform/Resources/Cart/CartProcessOrderEmail.php
+++ b/src/ApiPlatform/Resources/Cart/CartProcessOrderEmail.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Cart;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\SendProcessOrderEmailCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderEmailSendException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/carts/{cartId}/process-order-emails',
+            requirements: ['cartId' => '\d+'],
+            read: false,
+            output: false,
+            allowEmptyBody: true,
+            CQRSCommand: SendProcessOrderEmailCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CartNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomerNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        OrderEmailSendException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CartProcessOrderEmail
+{
+    #[ApiProperty(identifier: true)]
+    public int $cartId;
+}

--- a/tests/Integration/ApiPlatform/CartProcessOrderEmailEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CartProcessOrderEmailEndpointTest.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class CartProcessOrderEmailEndpointTest extends ApiTestCase
+{
+    private static int $originalMailMethod;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+
+        // Disable real email sending so Mail::send() succeeds without an SMTP server.
+        self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
+        \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        \Configuration::updateValue('PS_MAIL_METHOD', self::$originalMailMethod);
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'send process order email endpoint' => ['PUT', '/carts/1/process-order-emails'];
+    }
+
+    public function testSendProcessOrderEmail(): void
+    {
+        $cartId = $this->createCustomerCart();
+
+        $this->requestApi(
+            'PUT',
+            '/carts/' . $cartId . '/process-order-emails',
+            null,
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+    }
+
+    private function createCustomerCart(): int
+    {
+        $customerId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_customer` FROM `' . _DB_PREFIX_ . 'customer` WHERE `active` = 1 ORDER BY `id_customer` ASC'
+        );
+
+        $cart = new \Cart();
+        $cart->id_customer = $customerId;
+        $cart->id_currency = (int) \Configuration::get('PS_CURRENCY_DEFAULT');
+        $cart->id_lang = (int) \Configuration::get('PS_LANG_DEFAULT');
+        $cart->id_shop = 1;
+        $cart->add();
+
+        return (int) $cart->id;
+    }
+}

--- a/tests/Integration/ApiPlatform/CartProcessOrderEmailEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CartProcessOrderEmailEndpointTest.php
@@ -63,6 +63,19 @@ class CartProcessOrderEmailEndpointTest extends ApiTestCase
         );
     }
 
+    public function testSendProcessOrderEmailWithInvalidCartIdReturns422(): void
+    {
+        // cartId=0 passes the URI \d+ requirement but new CartId(0) throws
+        // CartConstraintException — must surface as 422, not 500.
+        $this->requestApi(
+            'PUT',
+            '/carts/0/process-order-emails',
+            null,
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+    }
+
     private function createCustomerCart(): int
     {
         $customerId = (int) \Db::getInstance()->getValue(


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `SendProcessOrderEmailCommand` gap: `PUT /carts/{cartId}/process-order-emails` (scope `order_write`) to send the process-order email to the cart's customer.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /carts/{id}/process-order-emails` (client granted `order_write`) emails the customer. Covered by `CartProcessOrderEmailEndpointTest` (which disables real mail sending so the assertion does not depend on an SMTP server).
| Possible impacts? | Sends the process-order email to the cart customer.