### PR TITLE
Add order bulk-update-status endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/BulkOrderStatus.php
+++ b/src/ApiPlatform/Resources/Order/BulkOrderStatus.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\BulkChangeOrderStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/bulk-update-status',
+            read: false,
+            output: false,
+            CQRSCommand: BulkChangeOrderStatusCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        ChangeOrderStatusException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkOrderStatus
+{
+    public array $orderIds;
+
+    public int $newOrderStatusId;
+}

--- a/src/ApiPlatform/Resources/Order/BulkOrderStatus.php
+++ b/src/ApiPlatform/Resources/Order/BulkOrderStatus.php
@@ -18,8 +18,11 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
 
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\BulkChangeOrderStatusCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\ChangeOrderStatusException;
@@ -49,6 +52,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 class BulkOrderStatus
 {
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer']])]
     #[Assert\NotBlank]
     #[Assert\All([new Assert\Positive()])]
     public array $orderIds;

--- a/src/ApiPlatform/Resources/Order/BulkOrderStatus.php
+++ b/src/ApiPlatform/Resources/Order/BulkOrderStatus.php
@@ -27,6 +27,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
@@ -48,7 +49,10 @@ use Symfony\Component\HttpFoundation\Response;
 )]
 class BulkOrderStatus
 {
+    #[Assert\NotBlank]
+    #[Assert\All([new Assert\Positive()])]
     public array $orderIds;
 
+    #[Assert\Positive]
     public int $newOrderStatusId;
 }

--- a/tests/Integration/ApiPlatform/BulkOrderStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/BulkOrderStatusEndpointTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class BulkOrderStatusEndpointTest extends ApiTestCase
+{
+    private static int $originalMailMethod;
+
+    /** @var array<int, int> orderId => original state id */
+    private static array $originalStates = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+
+        // Disable real email sending so the status-change emails succeed without an SMTP server.
+        self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
+        \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
+
+        // Put two orders in a known logable, non-error state so the bulk change moves them to a
+        // different logable state (never touching stock, never hitting "already assigned").
+        $orders = \Db::getInstance()->executeS(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` DESC LIMIT 2'
+        );
+        foreach ($orders ?: [] as $order) {
+            $orderId = (int) $order['id_order'];
+            self::$originalStates[$orderId] = (int) \Db::getInstance()->getValue(
+                'SELECT `id_order_state` FROM `' . _DB_PREFIX_ . 'order_history`
+                 WHERE `id_order` = ' . $orderId . ' ORDER BY `id_order_history` DESC'
+            );
+            (new \Order($orderId))->setCurrentState((int) \Configuration::get('PS_OS_PAYMENT'));
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        foreach (self::$originalStates as $orderId => $originalState) {
+            (new \Order($orderId))->setCurrentState($originalState);
+        }
+        \Configuration::updateValue('PS_MAIL_METHOD', self::$originalMailMethod);
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'bulk update order status endpoint' => ['PUT', '/orders/bulk-update-status'];
+    }
+
+    public function testBulkChangeOrderStatus(): void
+    {
+        $newStateId = (int) \Configuration::get('PS_OS_PREPARATION');
+        $orderIds = array_keys(self::$originalStates);
+
+        $this->updateItem(
+            '/orders/bulk-update-status',
+            ['orderIds' => $orderIds, 'newOrderStatusId' => $newStateId],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        foreach ($orderIds as $orderId) {
+            $this->assertSame($newStateId, (int) (new \Order($orderId))->getCurrentState());
+        }
+    }
+}

--- a/tests/Integration/ApiPlatform/BulkOrderStatusEndpointTest.php
+++ b/tests/Integration/ApiPlatform/BulkOrderStatusEndpointTest.php
@@ -86,4 +86,38 @@ class BulkOrderStatusEndpointTest extends ApiTestCase
             $this->assertSame($newStateId, (int) (new \Order($orderId))->getCurrentState());
         }
     }
+
+    public function testBulkChangeOrderStatusWithEmptyOrderIds(): void
+    {
+        $validationErrorsResponse = $this->updateItem(
+            '/orders/bulk-update-status',
+            ['orderIds' => [], 'newOrderStatusId' => (int) \Configuration::get('PS_OS_PREPARATION')],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+        $this->assertIsArray($validationErrorsResponse);
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'orderIds',
+                'message' => 'This value should not be blank.',
+            ],
+        ], $validationErrorsResponse);
+    }
+
+    public function testBulkChangeOrderStatusWithInvalidStatusId(): void
+    {
+        $validationErrorsResponse = $this->updateItem(
+            '/orders/bulk-update-status',
+            ['orderIds' => array_keys(self::$originalStates), 'newOrderStatusId' => 0],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+        $this->assertIsArray($validationErrorsResponse);
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'newOrderStatusId',
+                'message' => 'This value should be positive.',
+            ],
+        ], $validationErrorsResponse);
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `BulkChangeOrderStatusCommand` gap: `PUT /orders/bulk-update-status` (scope `order_write`) to change the status of several orders at once (`orderIds`, `newOrderStatusId`).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /orders/bulk-update-status` with `{ "orderIds": [id1, id2], "newOrderStatusId": x }` (client granted `order_write`) changes all the given orders' status. Covered by `BulkOrderStatusEndpointTest` (which disables real mail sending so the assertion does not depend on an SMTP server).
| Possible impacts? | Changes the status (and sends the status emails) of the given orders.