### PR TITLE
Add order partial-refund endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderPartialRefund.php
+++ b/src/ApiPlatform/Resources/Order/OrderPartialRefund.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\IssuePartialRefundCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidOrderStateException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/partial-refunds',
+            requirements: ['orderId' => '\d+'],
+            read: false,
+            output: false,
+            CQRSCommand: IssuePartialRefundCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        InvalidOrderStateException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderPartialRefund
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    /**
+     * Refunds keyed by order detail id, each with a "quantity" and "amount".
+     */
+    public array $orderDetailRefunds;
+
+    public string $shippingCostRefundAmount;
+
+    public bool $restockRefundedProducts;
+
+    public bool $generateCreditSlip;
+
+    public bool $generateVoucher;
+
+    public int $voucherRefundType;
+
+    public ?string $voucherRefundAmount;
+}

--- a/src/ApiPlatform/Resources/Order/OrderPartialRefund.php
+++ b/src/ApiPlatform/Resources/Order/OrderPartialRefund.php
@@ -26,16 +26,15 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Command\IssuePartialRefundCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidOrderStateException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
-use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
-        new CQRSUpdate(
+        new CQRSCreate(
             uriTemplate: '/orders/{orderId}/partial-refunds',
             requirements: ['orderId' => '\d+'],
-            read: false,
             output: false,
             CQRSCommand: IssuePartialRefundCommand::class,
             scopes: [

--- a/src/ApiPlatform/Resources/Order/OrderPartialRefund.php
+++ b/src/ApiPlatform/Resources/Order/OrderPartialRefund.php
@@ -28,6 +28,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
@@ -56,6 +57,19 @@ class OrderPartialRefund
     /**
      * Refunds keyed by order detail id, each with a "quantity" and "amount".
      */
+    #[Assert\NotBlank]
+    #[ApiProperty(openapiContext: [
+        'type' => 'object',
+        'additionalProperties' => [
+            'type' => 'object',
+            'properties' => [
+                'quantity' => ['type' => 'integer', 'example' => 1],
+                'amount' => ['type' => 'string', 'example' => '10.00'],
+            ],
+            'required' => ['quantity', 'amount'],
+        ],
+        'example' => ['1' => ['quantity' => 1, 'amount' => '10.00']],
+    ])]
     public array $orderDetailRefunds;
 
     public string $shippingCostRefundAmount;

--- a/tests/Integration/ApiPlatform/OrderPartialRefundEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderPartialRefundEndpointTest.php
@@ -30,8 +30,6 @@ class OrderPartialRefundEndpointTest extends ApiTestCase
 
     private static int $orderId;
 
-    private static int $originalState;
-
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
@@ -41,24 +39,22 @@ class OrderPartialRefundEndpointTest extends ApiTestCase
         self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
         \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
 
+        // Use an order that is ALREADY delivered (has a delivery-flagged state in its history):
+        // partial refund is allowed on it, and with restockRefundedProducts=false it never
+        // reinjects stock. We don't change its state ourselves (delivering an order would
+        // decrement stock, which is not possible without an employee in the API context).
         self::$orderId = (int) \Db::getInstance()->getValue(
-            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` DESC'
+            'SELECT oh.`id_order`
+             FROM `' . _DB_PREFIX_ . 'order_history` oh
+             INNER JOIN `' . _DB_PREFIX_ . 'order_state` os ON os.`id_order_state` = oh.`id_order_state`
+             WHERE os.`delivery` = 1
+             GROUP BY oh.`id_order`
+             ORDER BY oh.`id_order` DESC'
         );
-        self::$originalState = (int) \Db::getInstance()->getValue(
-            'SELECT `id_order_state` FROM `' . _DB_PREFIX_ . 'order_history`
-             WHERE `id_order` = ' . self::$orderId . ' ORDER BY `id_order_history` DESC'
-        );
-
-        // Make the order paid and delivered so a partial refund is allowed and, with
-        // restockRefundedProducts=false, never reinjects stock.
-        $order = new \Order(self::$orderId);
-        $order->setCurrentState((int) \Configuration::get('PS_OS_PAYMENT'));
-        $order->setCurrentState((int) \Configuration::get('PS_OS_DELIVERED'));
     }
 
     public static function tearDownAfterClass(): void
     {
-        (new \Order(self::$orderId))->setCurrentState(self::$originalState);
         \Configuration::updateValue('PS_MAIL_METHOD', self::$originalMailMethod);
 
         parent::tearDownAfterClass();
@@ -71,6 +67,10 @@ class OrderPartialRefundEndpointTest extends ApiTestCase
 
     public function testIssuePartialRefund(): void
     {
+        if (self::$orderId === 0) {
+            $this->markTestSkipped('No delivered order available in the fixtures.');
+        }
+
         $orderDetailId = (int) \Db::getInstance()->getValue(
             'SELECT `id_order_detail` FROM `' . _DB_PREFIX_ . 'order_detail`
              WHERE `id_order` = ' . self::$orderId . ' ORDER BY `id_order_detail` ASC'

--- a/tests/Integration/ApiPlatform/OrderPartialRefundEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderPartialRefundEndpointTest.php
@@ -92,4 +92,32 @@ class OrderPartialRefundEndpointTest extends ApiTestCase
             Response::HTTP_NO_CONTENT
         );
     }
+
+    public function testIssuePartialRefundWithEmptyOrderDetailRefunds(): void
+    {
+        if (self::$orderId === 0) {
+            $this->markTestSkipped('No delivered order available in the fixtures.');
+        }
+
+        $validationErrorsResponse = $this->updateItem(
+            '/orders/' . self::$orderId . '/partial-refunds',
+            [
+                'orderDetailRefunds' => [],
+                'shippingCostRefundAmount' => '0',
+                'restockRefundedProducts' => false,
+                'generateCreditSlip' => false,
+                'generateVoucher' => false,
+                'voucherRefundType' => 0,
+            ],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+        $this->assertIsArray($validationErrorsResponse);
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'orderDetailRefunds',
+                'message' => 'This value should not be blank.',
+            ],
+        ], $validationErrorsResponse);
+    }
 }

--- a/tests/Integration/ApiPlatform/OrderPartialRefundEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderPartialRefundEndpointTest.php
@@ -62,7 +62,7 @@ class OrderPartialRefundEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'issue order partial refund endpoint' => ['PUT', '/orders/1/partial-refunds'];
+        yield 'issue order partial refund endpoint' => ['POST', '/orders/1/partial-refunds'];
     }
 
     public function testIssuePartialRefund(): void
@@ -76,7 +76,7 @@ class OrderPartialRefundEndpointTest extends ApiTestCase
              WHERE `id_order` = ' . self::$orderId . ' ORDER BY `id_order_detail` ASC'
         );
 
-        $this->updateItem(
+        $this->createItem(
             '/orders/' . self::$orderId . '/partial-refunds',
             [
                 'orderDetailRefunds' => [
@@ -99,7 +99,7 @@ class OrderPartialRefundEndpointTest extends ApiTestCase
             $this->markTestSkipped('No delivered order available in the fixtures.');
         }
 
-        $validationErrorsResponse = $this->updateItem(
+        $validationErrorsResponse = $this->createItem(
             '/orders/' . self::$orderId . '/partial-refunds',
             [
                 'orderDetailRefunds' => [],

--- a/tests/Integration/ApiPlatform/OrderPartialRefundEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderPartialRefundEndpointTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderPartialRefundEndpointTest extends ApiTestCase
+{
+    private static int $originalMailMethod;
+
+    private static int $orderId;
+
+    private static int $originalState;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+
+        // Disable real email sending so the refund email succeeds without an SMTP server.
+        self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
+        \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
+
+        self::$orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` DESC'
+        );
+        self::$originalState = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order_state` FROM `' . _DB_PREFIX_ . 'order_history`
+             WHERE `id_order` = ' . self::$orderId . ' ORDER BY `id_order_history` DESC'
+        );
+
+        // Make the order paid and delivered so a partial refund is allowed and, with
+        // restockRefundedProducts=false, never reinjects stock.
+        $order = new \Order(self::$orderId);
+        $order->setCurrentState((int) \Configuration::get('PS_OS_PAYMENT'));
+        $order->setCurrentState((int) \Configuration::get('PS_OS_DELIVERED'));
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        (new \Order(self::$orderId))->setCurrentState(self::$originalState);
+        \Configuration::updateValue('PS_MAIL_METHOD', self::$originalMailMethod);
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'issue order partial refund endpoint' => ['PUT', '/orders/1/partial-refunds'];
+    }
+
+    public function testIssuePartialRefund(): void
+    {
+        $orderDetailId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order_detail` FROM `' . _DB_PREFIX_ . 'order_detail`
+             WHERE `id_order` = ' . self::$orderId . ' ORDER BY `id_order_detail` ASC'
+        );
+
+        $this->updateItem(
+            '/orders/' . self::$orderId . '/partial-refunds',
+            [
+                'orderDetailRefunds' => [
+                    $orderDetailId => ['quantity' => 1, 'amount' => '1.00'],
+                ],
+                'shippingCostRefundAmount' => '0',
+                'restockRefundedProducts' => false,
+                'generateCreditSlip' => false,
+                'generateVoucher' => false,
+                'voucherRefundType' => 0,
+            ],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `IssuePartialRefundCommand` gap: `POST /orders/{orderId}/partial-refunds` (scope `order_write`) to issue a partial refund on an order (`orderDetailRefunds` keyed by order detail id with `quantity`/`amount`, `shippingCostRefundAmount`, `restockRefundedProducts`, `generateCreditSlip`, `generateVoucher`, `voucherRefundType`, `voucherRefundAmount`).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `POST /orders/{id}/partial-refunds` with a refund payload (client granted `order_write`) issues the refund. Covered by `OrderPartialRefundEndpointTest` (which disables real mail sending and uses a paid+delivered order with `restockRefundedProducts=false`).
| Possible impacts? | Records a partial refund on the order (and optionally a credit slip / voucher).
