### PR TITLE
Fix AI pre-review being cancelled by unrelated label events

### DIFF
--- a/.github/workflows/ai-prereview.yml
+++ b/.github/workflows/ai-prereview.yml
@@ -5,7 +5,10 @@ on:
     types: [labeled]
 
 concurrency:
-  group: ai-prereview-${{ github.event.pull_request.number }}
+  # Scope the group to the label too: the workflow fires on any `labeled` event but
+  # only does work for `Need AI review`. Keying on the PR number alone let an unrelated
+  # label (e.g. `Waiting for author`) cancel an in-progress review via cancel-in-progress.
+  group: ai-prereview-${{ github.event.pull_request.number }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?      | The `Claude Pre-Review` workflow fires on any `labeled` event but its concurrency group was keyed only on the PR number with `cancel-in-progress: true`. A label added for another reason (e.g. `Waiting for author`, auto-added by the status bot) therefore cancelled an in-progress `Need AI review` run. The cancelling run then skipped all jobs (its label is not `Need AI review`), so the review neither completed nor swapped the label. This scopes the concurrency group to the label name so events for different labels no longer collide.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #321
| How to test?      | Add `Need AI review` to a PR, then add another label (or let the status bot add `Waiting for author`) while the review is running. Before: the review run is cancelled and the label is never swapped to `AI reviewed`. After: the second label gets its own concurrency group and the review completes and swaps the label. Genuine re-triggers of `Need AI review` still cancel the previous run as intended.
| Possible impacts? | CI only (the AI pre-review workflow). No runtime/module code changed.
| Sponsor company?  | @PrestaShopCorp

Observed on PR #314: the `Need AI review` run started, passed the guard and began the Claude review, then was cancelled ~2.5 min in by a `Waiting for author` label added by `ps-jarvis`.
