### PR TITLE
Add customer thread reply endpoint

### DIFF
--- a/src/ApiPlatform/Resources/CustomerThread/CustomerThreadReply.php
+++ b/src/ApiPlatform/Resources/CustomerThread/CustomerThreadReply.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CustomerThread;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\ReplyToCustomerThreadCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerServiceException;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerThreadNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/customer-threads/{customerThreadId}/messages',
+            requirements: ['customerThreadId' => '\d+'],
+            read: false,
+            output: false,
+            CQRSCommand: ReplyToCustomerThreadCommand::class,
+            scopes: [
+                'customer_service_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerThreadNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomerServiceException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CustomerThreadReply
+{
+    #[ApiProperty(identifier: true)]
+    public int $customerThreadId;
+
+    public string $replyMessage;
+}

--- a/tests/Integration/ApiPlatform/CustomerThreadReplyEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerThreadReplyEndpointTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class CustomerThreadReplyEndpointTest extends ApiTestCase
+{
+    private static int $originalMailMethod;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['customer_service_write']);
+
+        // Disable real email sending so the reply email succeeds without an SMTP server.
+        self::$originalMailMethod = (int) \Configuration::get('PS_MAIL_METHOD');
+        \Configuration::updateValue('PS_MAIL_METHOD', \Mail::METHOD_DISABLE);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        \Configuration::updateValue('PS_MAIL_METHOD', self::$originalMailMethod);
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'reply to customer thread endpoint' => ['PUT', '/customer-threads/1/messages'];
+    }
+
+    public function testReplyToCustomerThread(): void
+    {
+        $customerThreadId = $this->createCustomerThread();
+
+        $this->updateItem(
+            '/customer-threads/' . $customerThreadId . '/messages',
+            ['replyMessage' => 'Thanks for reaching out, here is our reply.'],
+            ['customer_service_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $messageCount = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'customer_message`
+             WHERE `id_customer_thread` = ' . $customerThreadId
+        );
+        $this->assertSame(1, $messageCount);
+    }
+
+    private function createCustomerThread(): int
+    {
+        $customerId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_customer` FROM `' . _DB_PREFIX_ . 'customer` WHERE `active` = 1 ORDER BY `id_customer` ASC'
+        );
+
+        $customerThread = new \CustomerThread();
+        $customerThread->id_lang = 1;
+        $customerThread->id_contact = 1;
+        $customerThread->id_shop = 1;
+        $customerThread->id_customer = $customerId;
+        $customerThread->email = 'thread-reply@example.com';
+        $customerThread->status = 'open';
+        $customerThread->token = bin2hex(random_bytes(6));
+        $customerThread->add();
+
+        return (int) $customerThread->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `ReplyToCustomerThreadCommand` gap: `PUT /customer-threads/{customerThreadId}/messages` (scope `customer_service_write`) to post a reply to a customer service thread.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /customer-threads/{id}/messages` with `{ "replyMessage": "..." }` (client granted `customer_service_write`) adds a reply message to the thread. Covered by `CustomerThreadReplyEndpointTest` (which disables real mail sending so the assertion does not depend on an SMTP server).
| Possible impacts? | Adds a customer message to the thread and emails the customer.