### PR TITLE
Add order discount endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderDiscount.php
+++ b/src/ApiPlatform/Resources/Order/OrderDiscount.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\InvalidCartRuleDiscountValueException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddCartRuleToOrderCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/discounts',
+            requirements: ['orderId' => '\d+'],
+            read: false,
+            output: false,
+            CQRSCommand: AddCartRuleToOrderCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        InvalidCartRuleDiscountValueException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderDiscount
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    public string $cartRuleName;
+
+    /**
+     * One of: percent, amount, free_shipping.
+     */
+    public string $cartRuleType;
+
+    public ?string $value;
+
+    public ?int $orderInvoiceId;
+}

--- a/src/ApiPlatform/Resources/Order/OrderDiscount.php
+++ b/src/ApiPlatform/Resources/Order/OrderDiscount.php
@@ -40,6 +40,7 @@ use Symfony\Component\Validator\Constraints as Assert;
             scopes: [
                 'order_write',
             ],
+            validationContext: ['groups' => ['Default', 'Create']],
         ),
     ],
     exceptionToStatus: [
@@ -59,6 +60,7 @@ class OrderDiscount
     /**
      * One of: percent, amount, free_shipping.
      */
+    #[Assert\NotBlank]
     #[Assert\Choice(choices: ['percent', 'amount', 'free_shipping'])]
     public string $cartRuleType;
 

--- a/src/ApiPlatform/Resources/Order/OrderDiscount.php
+++ b/src/ApiPlatform/Resources/Order/OrderDiscount.php
@@ -26,15 +26,15 @@ use PrestaShop\PrestaShop\Core\Domain\CartRule\Exception\InvalidCartRuleDiscount
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddCartRuleToOrderCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
-use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
-        new CQRSUpdate(
+        new CQRSCreate(
             uriTemplate: '/orders/{orderId}/discounts',
             requirements: ['orderId' => '\d+'],
-            read: false,
             output: false,
             CQRSCommand: AddCartRuleToOrderCommand::class,
             scopes: [
@@ -53,14 +53,16 @@ class OrderDiscount
     #[ApiProperty(identifier: true)]
     public int $orderId;
 
+    #[Assert\NotBlank]
     public string $cartRuleName;
 
     /**
      * One of: percent, amount, free_shipping.
      */
+    #[Assert\Choice(choices: ['percent', 'amount', 'free_shipping'])]
     public string $cartRuleType;
 
-    public ?string $value;
+    public ?string $value = null;
 
-    public ?int $orderInvoiceId;
+    public ?int $orderInvoiceId = null;
 }

--- a/tests/Integration/ApiPlatform/OrderDiscountEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderDiscountEndpointTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderDiscountEndpointTest extends ApiTestCase
+{
+    private const DISCOUNT_NAME = 'Test API discount';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        \Db::getInstance()->delete('order_cart_rule', "`name` = '" . self::DISCOUNT_NAME . "'");
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'add discount to order endpoint' => ['PUT', '/orders/1/discounts'];
+    }
+
+    public function testAddCartRuleToOrder(): void
+    {
+        $orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` DESC'
+        );
+
+        $this->updateItem(
+            '/orders/' . $orderId . '/discounts',
+            [
+                'cartRuleName' => self::DISCOUNT_NAME,
+                'cartRuleType' => 'amount',
+                'value' => '1',
+                'orderInvoiceId' => null,
+            ],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $discountCount = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'order_cart_rule`
+             WHERE `id_order` = ' . $orderId . " AND `name` = '" . self::DISCOUNT_NAME . "'"
+        );
+        $this->assertSame(1, $discountCount);
+    }
+}

--- a/tests/Integration/ApiPlatform/OrderDiscountEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderDiscountEndpointTest.php
@@ -61,7 +61,7 @@ class OrderDiscountEndpointTest extends ApiTestCase
                 'orderInvoiceId' => null,
             ],
             ['order_write'],
-            Response::HTTP_CREATED
+            Response::HTTP_NO_CONTENT
         );
 
         $discountCount = (int) \Db::getInstance()->getValue(

--- a/tests/Integration/ApiPlatform/OrderDiscountEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderDiscountEndpointTest.php
@@ -43,7 +43,7 @@ class OrderDiscountEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'add discount to order endpoint' => ['PUT', '/orders/1/discounts'];
+        yield 'add discount to order endpoint' => ['POST', '/orders/1/discounts'];
     }
 
     public function testAddCartRuleToOrder(): void
@@ -52,7 +52,7 @@ class OrderDiscountEndpointTest extends ApiTestCase
             'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` DESC'
         );
 
-        $this->updateItem(
+        $this->createItem(
             '/orders/' . $orderId . '/discounts',
             [
                 'cartRuleName' => self::DISCOUNT_NAME,
@@ -61,7 +61,7 @@ class OrderDiscountEndpointTest extends ApiTestCase
                 'orderInvoiceId' => null,
             ],
             ['order_write'],
-            Response::HTTP_NO_CONTENT
+            Response::HTTP_CREATED
         );
 
         $discountCount = (int) \Db::getInstance()->getValue(
@@ -69,5 +69,31 @@ class OrderDiscountEndpointTest extends ApiTestCase
              WHERE `id_order` = ' . $orderId . " AND `name` = '" . self::DISCOUNT_NAME . "'"
         );
         $this->assertSame(1, $discountCount);
+    }
+
+    public function testAddCartRuleWithEmptyName(): void
+    {
+        $orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` DESC'
+        );
+
+        $validationErrorsResponse = $this->createItem(
+            '/orders/' . $orderId . '/discounts',
+            [
+                'cartRuleName' => '',
+                'cartRuleType' => 'amount',
+                'value' => '1',
+                'orderInvoiceId' => null,
+            ],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+        $this->assertIsArray($validationErrorsResponse);
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'cartRuleName',
+                'message' => 'This value should not be blank.',
+            ],
+        ], $validationErrorsResponse);
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `AddCartRuleToOrderCommand` gap: `PUT /orders/{orderId}/discounts` (scope `order_write`) to add a discount to an order (`cartRuleName`, `cartRuleType` = percent/amount/free_shipping, `value`, optional `orderInvoiceId`).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /orders/{id}/discounts` with `{ "cartRuleName": "...", "cartRuleType": "amount", "value": "1" }` (client granted `order_write`) adds the discount. Covered by `OrderDiscountEndpointTest`.
| Possible impacts? | Adds a cart rule (discount) to the order and recalculates its totals.