### PR TITLE
Add order remove-discount endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderDiscountRemoval.php
+++ b/src/ApiPlatform/Resources/Order/OrderDiscountRemoval.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\DeleteCartRuleFromOrderCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/orders/{orderId}/discounts/{orderCartRuleId}',
+            requirements: ['orderId' => '\d+', 'orderCartRuleId' => '\d+'],
+            CQRSCommand: DeleteCartRuleFromOrderCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderDiscountRemoval
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    #[ApiProperty(identifier: true)]
+    public int $orderCartRuleId;
+}

--- a/tests/Integration/ApiPlatform/OrderDiscountRemovalEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderDiscountRemovalEndpointTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderDiscountRemovalEndpointTest extends ApiTestCase
+{
+    private const DISCOUNT_NAME = 'Test API removable discount';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        \Db::getInstance()->delete('order_cart_rule', "`name` = '" . self::DISCOUNT_NAME . "'");
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'remove discount from order endpoint' => ['DELETE', '/orders/1/discounts/1'];
+    }
+
+    public function testDeleteCartRuleFromOrder(): void
+    {
+        $cartRuleId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_cart_rule` FROM `' . _DB_PREFIX_ . 'cart_rule` ORDER BY `id_cart_rule` ASC'
+        );
+        if ($cartRuleId === 0) {
+            $this->markTestSkipped('No cart rule available in the fixtures.');
+        }
+
+        $orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` DESC'
+        );
+
+        \Db::getInstance()->insert('order_cart_rule', [
+            'id_order' => $orderId,
+            'id_cart_rule' => $cartRuleId,
+            'id_order_invoice' => 0,
+            'name' => self::DISCOUNT_NAME,
+            'value' => 1,
+            'value_tax_excl' => 1,
+            'free_shipping' => 0,
+            'deleted' => 0,
+        ]);
+        $orderCartRuleId = (int) \Db::getInstance()->Insert_ID();
+
+        $this->requestApi(
+            'DELETE',
+            '/orders/' . $orderId . '/discounts/' . $orderCartRuleId,
+            null,
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $remaining = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'order_cart_rule`
+             WHERE `id_order_cart_rule` = ' . $orderCartRuleId . ' AND `deleted` = 0'
+        );
+        $this->assertSame(0, $remaining);
+    }
+}

--- a/tests/Integration/ApiPlatform/OrderDiscountRemovalEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderDiscountRemovalEndpointTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
 use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
 
 class OrderDiscountRemovalEndpointTest extends ApiTestCase
 {
@@ -31,13 +32,13 @@ class OrderDiscountRemovalEndpointTest extends ApiTestCase
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['order_cart_rule']);
         self::createApiClient(['order_write']);
     }
 
     public static function tearDownAfterClass(): void
     {
-        \Db::getInstance()->delete('order_cart_rule', "`name` = '" . self::DISCOUNT_NAME . "'");
-
+        DatabaseDump::restoreTables(['order_cart_rule']);
         parent::tearDownAfterClass();
     }
 
@@ -71,12 +72,9 @@ class OrderDiscountRemovalEndpointTest extends ApiTestCase
         ]);
         $orderCartRuleId = (int) \Db::getInstance()->Insert_ID();
 
-        $this->requestApi(
-            'DELETE',
+        $this->deleteItem(
             '/orders/' . $orderId . '/discounts/' . $orderCartRuleId,
-            null,
-            ['order_write'],
-            Response::HTTP_NO_CONTENT
+            ['order_write']
         );
 
         $remaining = (int) \Db::getInstance()->getValue(
@@ -84,5 +82,10 @@ class OrderDiscountRemovalEndpointTest extends ApiTestCase
              WHERE `id_order_cart_rule` = ' . $orderCartRuleId . ' AND `deleted` = 0'
         );
         $this->assertSame(0, $remaining);
+    }
+
+    public function testDeleteFromNonExistentOrderReturns404(): void
+    {
+        $this->deleteItem('/orders/999999/discounts/999999', ['order_write'], Response::HTTP_NOT_FOUND);
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `DeleteCartRuleFromOrderCommand` gap: `DELETE /orders/{orderId}/discounts/{orderCartRuleId}` (scope `order_write`) to remove a discount from an order.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `DELETE /orders/{id}/discounts/{orderCartRuleId}` (client granted `order_write`) removes the order discount. Covered by `OrderDiscountRemovalEndpointTest`.
| Possible impacts? | Removes a cart rule (discount) from the order and recalculates its totals.