### PR TITLE
Add order change-currency endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderCurrency.php
+++ b/src/ApiPlatform/Resources/Order/OrderCurrency.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\ChangeOrderCurrencyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/orders/{orderId}/currencies',
+            requirements: ['orderId' => '\d+'],
+            read: false,
+            output: false,
+            CQRSCommand: ChangeOrderCurrencyCommand::class,
+            scopes: [
+                'order_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderCurrency
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    public int $newCurrencyId;
+}

--- a/src/ApiPlatform/Resources/Order/OrderCurrency.php
+++ b/src/ApiPlatform/Resources/Order/OrderCurrency.php
@@ -27,6 +27,7 @@ use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [
@@ -51,5 +52,6 @@ class OrderCurrency
     #[ApiProperty(identifier: true)]
     public int $orderId;
 
+    #[Assert\Positive]
     public int $newCurrencyId;
 }

--- a/tests/Integration/ApiPlatform/OrderCurrencyEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderCurrencyEndpointTest.php
@@ -97,4 +97,46 @@ class OrderCurrencyEndpointTest extends ApiTestCase
         );
         $this->assertSame($newCurrencyId, $currentCurrency);
     }
+
+    public function testChangeOrderCurrencyWithInvalidPayload(): void
+    {
+        $validationErrorsResponse = $this->updateItem(
+            '/orders/' . self::$orderId . '/currencies',
+            ['newCurrencyId' => 0],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+        $this->assertIsArray($validationErrorsResponse);
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'newCurrencyId',
+                'message' => 'This value should be positive.',
+            ],
+        ], $validationErrorsResponse);
+    }
+
+    public function testChangeOrderCurrencyOnValidOrderReturns422(): void
+    {
+        // Flip the order back to valid=1 so the handler refuses the change.
+        \Db::getInstance()->update('orders', ['valid' => 1], '`id_order` = ' . self::$orderId);
+        try {
+            $newCurrencyId = (int) \Db::getInstance()->getValue(
+                'SELECT `id_currency` FROM `' . _DB_PREFIX_ . 'currency`
+                 WHERE `deleted` = 0 AND `active` = 1 AND `id_currency` <> ' . self::$originalCurrencyId . '
+                 ORDER BY `id_currency` ASC'
+            );
+            if ($newCurrencyId === 0) {
+                $this->markTestSkipped('No alternative active currency available in the fixtures.');
+            }
+
+            $this->updateItem(
+                '/orders/' . self::$orderId . '/currencies',
+                ['newCurrencyId' => $newCurrencyId],
+                ['order_write'],
+                Response::HTTP_UNPROCESSABLE_ENTITY
+            );
+        } finally {
+            \Db::getInstance()->update('orders', ['valid' => 0], '`id_order` = ' . self::$orderId);
+        }
+    }
 }

--- a/tests/Integration/ApiPlatform/OrderCurrencyEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderCurrencyEndpointTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderCurrencyEndpointTest extends ApiTestCase
+{
+    private static int $orderId;
+
+    private static int $originalCurrencyId;
+
+    private static int $originalValid;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+
+        self::$orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` DESC'
+        );
+        self::$originalCurrencyId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_currency` FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_order` = ' . self::$orderId
+        );
+        self::$originalValid = (int) \Db::getInstance()->getValue(
+            'SELECT `valid` FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_order` = ' . self::$orderId
+        );
+
+        // The handler refuses to change currency on a "valid" (paid) order — force valid=0.
+        \Db::getInstance()->update(
+            'orders',
+            ['valid' => 0],
+            '`id_order` = ' . self::$orderId
+        );
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        \Db::getInstance()->update(
+            'orders',
+            [
+                'id_currency' => self::$originalCurrencyId,
+                'valid' => self::$originalValid,
+            ],
+            '`id_order` = ' . self::$orderId
+        );
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'change order currency endpoint' => ['PUT', '/orders/1/currencies'];
+    }
+
+    public function testChangeOrderCurrency(): void
+    {
+        $newCurrencyId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_currency` FROM `' . _DB_PREFIX_ . 'currency`
+             WHERE `deleted` = 0 AND `active` = 1 AND `id_currency` <> ' . self::$originalCurrencyId . '
+             ORDER BY `id_currency` ASC'
+        );
+        if ($newCurrencyId === 0) {
+            $this->markTestSkipped('No alternative active currency available in the fixtures.');
+        }
+
+        $this->updateItem(
+            '/orders/' . self::$orderId . '/currencies',
+            ['newCurrencyId' => $newCurrencyId],
+            ['order_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $currentCurrency = (int) \Db::getInstance()->getValue(
+            'SELECT `id_currency` FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_order` = ' . self::$orderId
+        );
+        $this->assertSame($newCurrencyId, $currentCurrency);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `ChangeOrderCurrencyCommand` gap: `PUT /orders/{orderId}/currencies` (scope `order_write`) to change an order's currency (`newCurrencyId`). Only allowed on unpaid orders — the handler rejects a change when the order is valid.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /orders/{id}/currencies` with `{ "newCurrencyId": x }` (client granted `order_write`) changes the currency of an unpaid order. Covered by `OrderCurrencyEndpointTest`.
| Possible impacts? | Changes the order currency and recalculates its totals.