### PR TITLE
Add customer address-information endpoint to the Admin API

### DIFF
--- a/src/ApiPlatform/Resources/Customer/CustomerAddressInformation.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerAddressInformation.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerByEmailNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForAddressCreation;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/customers/address-informations',
+            CQRSQuery: GetCustomerForAddressCreation::class,
+            scopes: [
+                'customer_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'email',
+                    required: true,
+                    description: 'Email of the customer whose information is fetched to pre-fill an address (matches the first customer found for that email)'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    [
+                        'name' => 'email',
+                        'in' => 'query',
+                        'required' => true,
+                        'schema' => [
+                            'type' => 'string',
+                        ],
+                        'description' => 'Email of the customer whose information is fetched to pre-fill an address',
+                    ],
+                ],
+            ],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        CustomerByEmailNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CustomerAddressInformation
+{
+    #[ApiProperty(identifier: true, openapiContext: ['type' => 'integer', 'example' => 1])]
+    public int $customerId;
+
+    public string $firstName;
+
+    public string $lastName;
+
+    public ?string $company;
+
+    public const QUERY_MAPPING = [
+        '[email]' => '[customerEmail]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/CustomerAddressInformationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerAddressInformationEndpointTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CustomerAddressInformationEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['customer', 'customer_group']);
+        self::createApiClient(['customer_read', 'customer_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['customer', 'customer_group']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get address information endpoint' => [
+            'GET',
+            '/customers/address-informations?email=customer.address@example.com',
+        ];
+    }
+
+    public function testGetCustomerAddressInformation(): void
+    {
+        $created = $this->createItem(
+            '/customers',
+            [
+                'firstName' => 'Alice',
+                'lastName' => 'Martin',
+                'email' => 'customer.address@example.com',
+                'password' => 'TestPassword123!',
+                'defaultGroupId' => 3,
+                'groupIds' => [3],
+                'enabled' => true,
+                'partnerOffersSubscribed' => false,
+                'guest' => false,
+            ],
+            ['customer_write']
+        );
+        $customerId = $created['customerId'];
+
+        $response = $this->getItem(
+            '/customers/address-informations?email=customer.address@example.com',
+            ['customer_read']
+        );
+
+        $this->assertEquals(
+            [
+                'customerId' => $customerId,
+                'firstName' => 'Alice',
+                'lastName' => 'Martin',
+                'company' => null,
+            ],
+            $response
+        );
+    }
+
+    public function testGetAddressInformationForUnknownEmailReturnsNotFound(): void
+    {
+        $this->getItem(
+            '/customers/address-informations?email=does.not.exist@example.com',
+            ['customer_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?      | Exposes the `GetCustomerForAddressCreation` query in the Admin API: `GET /customers/address-informations?email=...`, under the `customer_read` scope. It looks a customer up by email and returns the identity fields used to pre-fill an address form (`customerId`, `firstName`, `lastName`, `company`), mirroring the legacy address-creation autocomplete.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#41986
| How to test?      | Run `CustomerAddressInformationEndpointTest`. `testGetCustomerAddressInformation` creates a customer and fetches `/customers/address-informations?email=<email>`, asserting the full response; `testGetAddressInformationForUnknownEmailReturnsNotFound` asserts the 404 mapping for an unknown email.
| Possible impacts? | New read endpoint only; no change to existing operations.
| Sponsor company?  | @PrestaShopCorp

Notes:
- The lookup key (email) is passed as a **query parameter**, not a path segment: an email in the path collides with API Platform's optional `.{_format}` suffix (the `.com` TLD would be parsed as a format) and needs awkward escaping of `@`/`.`. The `QueryProvider` merges query-string filters into the CQRS query construction, so `email` maps cleanly to the `GetCustomerForAddressCreation` constructor via `CQRSQueryMapping`.
- Modelled as a single-item `CQRSGet` (not a collection): the query returns one `AddressCreationCustomerInformation` DTO and throws when no customer matches. Since the URI template has no variable, API Platform resolves the operation with empty `uriVariables`; the `customerId` identifier is only used for the response contract.
- Only `CustomerByEmailNotFoundException → 404` is mapped. The generic `CustomerException` the handler can raise on a DB failure is intentionally left unmapped so it surfaces as a 500 rather than being masked as a 4xx.
- This covers one of the two endpoints listed in the issue. The `GetRequiredFieldsForCustomer` read endpoint is handled separately: it shares the `/customers/required-fields` resource introduced by #237 (the write side) and requires a small core change first (the CQRS serializer only wraps scalar query results under `_queryResult`, not list results).
