### PR TITLE
Add category update-position endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Category/CategoryPosition.php
+++ b/src/ApiPlatform/Resources/Category/CategoryPosition.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Category;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\UpdateCategoryPositionCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/categories/{categoryId}/positions',
+            requirements: ['categoryId' => '\d+'],
+            read: false,
+            output: false,
+            CQRSCommand: UpdateCategoryPositionCommand::class,
+            scopes: [
+                'category_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CategoryNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CategoryException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CategoryPosition
+{
+    #[ApiProperty(identifier: true)]
+    public int $categoryId;
+
+    public int $parentCategoryId;
+
+    /**
+     * Direction of the move (0 = up / 1 = down).
+     */
+    public int $way;
+
+    /**
+     * List of positions in the parent category, each entry looks like "<index>_<parentCategoryId>_<categoryId>".
+     */
+    public array $positions;
+
+    public bool $foundFirst;
+}

--- a/tests/Integration/ApiPlatform/CategoryPositionEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CategoryPositionEndpointTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class CategoryPositionEndpointTest extends ApiTestCase
+{
+    private static int $counter = 0;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['category_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $ids = \Db::getInstance()->executeS(
+            'SELECT `id_category` FROM `' . _DB_PREFIX_ . 'category_lang` WHERE `name` = \'Test category position\''
+        );
+        foreach ($ids ?: [] as $row) {
+            (new \Category((int) $row['id_category']))->delete();
+        }
+
+        parent::tearDownAfterClass();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'update category position endpoint' => ['PUT', '/categories/1/positions'];
+    }
+
+    public function testUpdateCategoryPosition(): void
+    {
+        $parentCategoryId = (int) \Configuration::get('PS_HOME_CATEGORY');
+        $firstCategoryId = $this->createCategory($parentCategoryId);
+        $secondCategoryId = $this->createCategory($parentCategoryId);
+
+        // Format: "<index>_<parentId>_<categoryId>". Sending the second category as the FIRST entry
+        // (with index 0) tells the handler its target position is 0 — i.e. move it up.
+        $positions = [
+            '0_' . $parentCategoryId . '_' . $secondCategoryId,
+            '1_' . $parentCategoryId . '_' . $firstCategoryId,
+        ];
+
+        $this->updateItem(
+            '/categories/' . $secondCategoryId . '/positions',
+            [
+                'parentCategoryId' => $parentCategoryId,
+                'way' => 0,
+                'positions' => $positions,
+                'foundFirst' => true,
+            ],
+            ['category_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $this->assertSame(
+            0,
+            (int) \Db::getInstance()->getValue(
+                'SELECT `position` FROM `' . _DB_PREFIX_ . 'category` WHERE `id_category` = ' . $secondCategoryId
+            )
+        );
+    }
+
+    private function createCategory(int $parentCategoryId): int
+    {
+        ++self::$counter;
+
+        $category = new \Category();
+        $category->id_parent = $parentCategoryId;
+        $category->active = true;
+
+        foreach (\Language::getIDs(false) as $langId) {
+            $category->name[(int) $langId] = 'Test category position';
+            $category->link_rewrite[(int) $langId] = 'test-category-position-' . self::$counter . '-' . $langId;
+        }
+
+        $category->add();
+
+        return (int) $category->id;
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Fills the `UpdateCategoryPositionCommand` gap: `PUT /categories/{categoryId}/positions` (scope `category_write`) to reorder a category within its parent (`parentCategoryId`, `way`, `positions` list in `"<index>_<parentId>_<categoryId>"` format, `foundFirst` bool).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `PUT /categories/{id}/positions` with a positions payload (client granted `category_write`) reorders the category. Covered by `CategoryPositionEndpointTest`.
| Possible impacts? | Reorders categories within their parent.