### PR TITLE
Add shop logos read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Shop/ShopLogos.php
+++ b/src/ApiPlatform/Resources/Shop/ShopLogos.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Shop;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Shop\Query\GetLogosPaths;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/shops/logos',
+            CQRSQuery: GetLogosPaths::class,
+            scopes: [
+                'shop_read',
+            ],
+        ),
+    ],
+)]
+class ShopLogos
+{
+    public string $headerLogoPath;
+
+    public string $mailLogoPath;
+
+    public string $invoiceLogoPath;
+
+    public string $faviconPath;
+}

--- a/tests/Integration/ApiPlatform/ShopLogosEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ShopLogosEndpointTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ShopLogosEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['shop_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get shop logos endpoint' => ['GET', '/shops/logos'];
+    }
+
+    public function testGetShopLogos(): void
+    {
+        $logos = $this->getItem('/shops/logos', ['shop_read']);
+
+        $this->assertArrayHasKey('headerLogoPath', $logos);
+        $this->assertArrayHasKey('mailLogoPath', $logos);
+        $this->assertArrayHasKey('invoiceLogoPath', $logos);
+        $this->assertArrayHasKey('faviconPath', $logos);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetLogosPaths` as `GET /shops/logos` (scope `shop_read`): returns the paths of the header, mail, invoice logos and favicon.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /shops/logos` (client granted `shop_read`) returns `{ headerLogoPath, mailLogoPath, invoiceLogoPath, faviconPath }`. Covered by `ShopLogosEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.