### PR TITLE
Add image settings read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/ImageSettings/ImageSettingsRead.php
+++ b/src/ApiPlatform/Resources/ImageSettings/ImageSettingsRead.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\ImageSettings;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\ImageSettings\Query\GetImageSettingsForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/image-settings',
+            CQRSQuery: GetImageSettingsForEditing::class,
+            scopes: [
+                'image_settings_read',
+            ],
+        ),
+    ],
+)]
+class ImageSettingsRead
+{
+    public array $formats;
+
+    public string $baseFormat;
+
+    public int $avifQuality;
+
+    public int $jpegQuality;
+
+    public int $pngQuality;
+
+    public int $webpQuality;
+
+    public int $generationMethod;
+
+    public int $pictureMaxSize;
+
+    public int $pictureMaxWidth;
+
+    public int $pictureMaxHeight;
+}

--- a/tests/Integration/ApiPlatform/ImageSettingsReadEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ImageSettingsReadEndpointTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ImageSettingsReadEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['image_settings_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get image settings endpoint' => ['GET', '/image-settings'];
+    }
+
+    public function testGetImageSettings(): void
+    {
+        $settings = $this->getItem('/image-settings', ['image_settings_read']);
+
+        $this->assertArrayHasKey('formats', $settings);
+        $this->assertArrayHasKey('baseFormat', $settings);
+        $this->assertArrayHasKey('avifQuality', $settings);
+        $this->assertArrayHasKey('jpegQuality', $settings);
+        $this->assertArrayHasKey('pngQuality', $settings);
+        $this->assertArrayHasKey('webpQuality', $settings);
+        $this->assertArrayHasKey('generationMethod', $settings);
+        $this->assertArrayHasKey('pictureMaxSize', $settings);
+        $this->assertArrayHasKey('pictureMaxWidth', $settings);
+        $this->assertArrayHasKey('pictureMaxHeight', $settings);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetImageSettingsForEditing` as `GET /image-settings` (scope `image_settings_read`): returns the accepted `formats`, the `baseFormat`, the per-format qualities (`avifQuality`, `jpegQuality`, `pngQuality`, `webpQuality`), the `generationMethod` and the picture max sizes (`pictureMaxSize`, `pictureMaxWidth`, `pictureMaxHeight`). Complements the image-settings update endpoint.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /image-settings` (client granted `image_settings_read`) returns the image settings payload. Covered by `ImageSettingsReadEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.