### PR TITLE
Add database tables read + table fields read endpoints

### DIFF
--- a/src/ApiPlatform/Resources/SqlRequest/DatabaseTableFields.php
+++ b/src/ApiPlatform/Resources/SqlRequest/DatabaseTableFields.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SqlRequest;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Exception\SqlManagementConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetDatabaseTableFieldsList;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/sql-requests/database-tables/{tableName}/fields',
+            requirements: ['tableName' => '[A-Za-z0-9_-]+'],
+            CQRSQuery: GetDatabaseTableFieldsList::class,
+            scopes: [
+                'sql_management_read',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        SqlManagementConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class DatabaseTableFields
+{
+    #[ApiProperty(identifier: true)]
+    public string $tableName;
+
+    /**
+     * @var array<int, array{name: string, type: string}>
+     */
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+                'type' => ['type' => 'string'],
+            ],
+        ],
+    ])]
+    public array $fields;
+}

--- a/src/ApiPlatform/Resources/SqlRequest/DatabaseTables.php
+++ b/src/ApiPlatform/Resources/SqlRequest/DatabaseTables.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SqlRequest;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetDatabaseTablesList;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/sql-requests/database-tables',
+            CQRSQuery: GetDatabaseTablesList::class,
+            scopes: [
+                'sql_management_read',
+            ],
+        ),
+    ],
+)]
+class DatabaseTables
+{
+    /**
+     * @var string[]
+     */
+    public array $tables;
+}

--- a/tests/Integration/ApiPlatform/DatabaseTablesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/DatabaseTablesEndpointTest.php
@@ -33,13 +33,36 @@ class DatabaseTablesEndpointTest extends ApiTestCase
     public static function getProtectedEndpoints(): iterable
     {
         yield 'get database tables endpoint' => ['GET', '/sql-requests/database-tables'];
+        yield 'get database table fields endpoint' => ['GET', '/sql-requests/database-tables/' . _DB_PREFIX_ . 'product/fields'];
     }
 
-    public function testGetDatabaseTables(): void
+    public function testGetDatabaseTables(): string
     {
         $result = $this->getItem('/sql-requests/database-tables', ['sql_management_read']);
 
         $this->assertArrayHasKey('tables', $result);
         $this->assertNotEmpty($result['tables']);
+
+        return $result['tables'][0];
+    }
+
+    /**
+     * @depends testGetDatabaseTables
+     */
+    public function testGetDatabaseTableFields(string $tableName): void
+    {
+        $result = $this->getItem('/sql-requests/database-tables/' . $tableName . '/fields', ['sql_management_read']);
+
+        $this->assertArrayHasKey('tableName', $result);
+        $this->assertSame($tableName, $result['tableName']);
+        $this->assertArrayHasKey('fields', $result);
+        $this->assertNotEmpty($result['fields']);
+
+        foreach ($result['fields'] as $field) {
+            $this->assertArrayHasKey('name', $field);
+            $this->assertArrayHasKey('type', $field);
+            $this->assertIsString($field['name']);
+            $this->assertIsString($field['type']);
+        }
     }
 }

--- a/tests/Integration/ApiPlatform/DatabaseTablesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/DatabaseTablesEndpointTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class DatabaseTablesEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['sql_management_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get database tables endpoint' => ['GET', '/sql-requests/database-tables'];
+    }
+
+    public function testGetDatabaseTables(): void
+    {
+        $result = $this->getItem('/sql-requests/database-tables', ['sql_management_read']);
+
+        $this->assertArrayHasKey('tables', $result);
+        $this->assertNotEmpty($result['tables']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?      | Exposes two `SqlManagement` read queries as Admin API endpoints under a common `SqlRequest\DatabaseTables*` resource pair:<br>• `GET /sql-requests/database-tables` (`GetDatabaseTablesList`) — returns the list of database table names available for a SQL request.<br>• `GET /sql-requests/database-tables/{tableName}/fields` (`GetDatabaseTableFieldsList`) — returns the columns (`name` + `type`) of the given table. `SqlManagementConstraintException` is mapped to 422.<br>Both operations require scope `sql_management_read`.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | With a client granted `sql_management_read`:<br>1. `GET /sql-requests/database-tables` → `{ tables: [...] }`<br>2. `GET /sql-requests/database-tables/{tableName}/fields` (using any table name from step 1) → `{ tableName, fields: [{ name, type }, ...] }`<br>Covered end-to-end by `DatabaseTablesEndpointTest` (chained `@depends` so the fields test uses a real table returned by the list endpoint).
| Possible impacts? | None — read-only endpoints on a new resource.