### PR TITLE
Add SQL request settings read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/SqlRequestSettings/SqlRequestSettingsRead.php
+++ b/src/ApiPlatform/Resources/SqlRequestSettings/SqlRequestSettingsRead.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\SqlRequestSettings;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\SqlManagement\Query\GetSqlRequestSettings;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/sql-request-settings',
+            CQRSQuery: GetSqlRequestSettings::class,
+            scopes: [
+                'sql_management_read',
+            ],
+        ),
+    ],
+)]
+class SqlRequestSettingsRead
+{
+    public string $fileEncoding;
+
+    public string $fileSeparator;
+}

--- a/tests/Integration/ApiPlatform/SqlRequestSettingsReadEndpointTest.php
+++ b/tests/Integration/ApiPlatform/SqlRequestSettingsReadEndpointTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class SqlRequestSettingsReadEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['sql_management_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get sql request settings endpoint' => ['GET', '/sql-request-settings'];
+    }
+
+    public function testGetSqlRequestSettings(): void
+    {
+        $settings = $this->getItem('/sql-request-settings', ['sql_management_read']);
+
+        $this->assertArrayHasKey('fileEncoding', $settings);
+        $this->assertArrayHasKey('fileSeparator', $settings);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetSqlRequestSettings` as `GET /sql-request-settings` (scope `sql_management_read`): returns the file encoding and separator used to export SQL request results. Complements the SQL request settings update endpoint.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /sql-request-settings` (client granted `sql_management_read`) returns `{ fileEncoding, fileSeparator }`. Covered by `SqlRequestSettingsReadEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.