### PR TITLE
Add order preview read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderPreview.php
+++ b/src/ApiPlatform/Resources/Order/OrderPreview.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSGet(
-            uriTemplate: '/orders/{orderId}/previews',
+            uriTemplate: '/orders/{orderId}/preview',
             requirements: ['orderId' => '\d+'],
             CQRSQuery: GetOrderPreview::class,
             scopes: [

--- a/src/ApiPlatform/Resources/Order/OrderPreview.php
+++ b/src/ApiPlatform/Resources/Order/OrderPreview.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSGet(
-            uriTemplate: '/orders/{orderId}/preview',
+            uriTemplate: '/orders/{orderId}/previews',
             requirements: ['orderId' => '\d+'],
             CQRSQuery: GetOrderPreview::class,
             scopes: [

--- a/src/ApiPlatform/Resources/Order/OrderPreview.php
+++ b/src/ApiPlatform/Resources/Order/OrderPreview.php
@@ -30,13 +30,12 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSGet(
-            uriTemplate: '/orders/{orderId}/previews',
+            uriTemplate: '/orders/{orderId}/preview',
             requirements: ['orderId' => '\d+'],
             CQRSQuery: GetOrderPreview::class,
             scopes: [
                 'order_read',
             ],
-            CQRSQueryMapping: self::QUERY_MAPPING,
         ),
     ],
     exceptionToStatus: [
@@ -48,10 +47,23 @@ class OrderPreview
     #[ApiProperty(identifier: true)]
     public int $orderId;
 
-    public array $invoiceDetails;
-
-    public array $shippingDetails;
-
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'description' => 'Products included in the order',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'id' => ['type' => 'integer'],
+                'name' => ['type' => 'string'],
+                'reference' => ['type' => 'string'],
+                'location' => ['type' => 'string'],
+                'quantity' => ['type' => 'integer'],
+                'unitPrice' => ['type' => 'string'],
+                'totalPrice' => ['type' => 'string'],
+                'totalTax' => ['type' => 'string'],
+            ],
+        ],
+    ])]
     public array $productDetails;
 
     public bool $taxIncluded;
@@ -61,8 +73,4 @@ class OrderPreview
     public string $invoiceAddressFormatted;
 
     public string $shippingAddressFormatted;
-
-    public const QUERY_MAPPING = [
-        '[orderId]' => '[orderId]',
-    ];
 }

--- a/src/ApiPlatform/Resources/Order/OrderPreview.php
+++ b/src/ApiPlatform/Resources/Order/OrderPreview.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Query\GetOrderPreview;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/orders/{orderId}/preview',
+            requirements: ['orderId' => '\d+'],
+            CQRSQuery: GetOrderPreview::class,
+            scopes: [
+                'order_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class OrderPreview
+{
+    #[ApiProperty(identifier: true)]
+    public int $orderId;
+
+    public array $invoiceDetails;
+
+    public array $shippingDetails;
+
+    public array $productDetails;
+
+    public bool $taxIncluded;
+
+    public bool $virtual;
+
+    public string $invoiceAddressFormatted;
+
+    public string $shippingAddressFormatted;
+
+    public const QUERY_MAPPING = [
+        '[orderId]' => '[orderId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
@@ -43,7 +43,7 @@ class OrderPreviewEndpointTest extends ApiTestCase
             'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` ASC'
         );
 
-        $preview = $this->getItem('/orders/' . $orderId . '/preview', ['order_read']);
+        $preview = $this->getItem('/orders/' . $orderId . '/previews', ['order_read']);
 
         $this->assertArrayHasKey('orderId', $preview);
         $this->assertSame($orderId, $preview['orderId']);
@@ -58,6 +58,6 @@ class OrderPreviewEndpointTest extends ApiTestCase
 
     public function testGetNonExistentOrderPreviewReturnsNotFound(): void
     {
-        $this->requestApi('GET', '/orders/999999/preview', null, ['order_read'], Response::HTTP_NOT_FOUND);
+        $this->requestApi('GET', '/orders/999999/previews', null, ['order_read'], Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
@@ -26,15 +26,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class OrderPreviewEndpointTest extends ApiTestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-        self::createApiClient(['order_read']);
-    }
-
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'get order preview endpoint' => ['GET', '/orders/1/previews'];
+        yield 'get order preview endpoint' => ['GET', '/orders/1/preview'];
     }
 
     public function testGetOrderPreview(): void
@@ -43,21 +37,26 @@ class OrderPreviewEndpointTest extends ApiTestCase
             'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` ASC'
         );
 
-        $preview = $this->getItem('/orders/' . $orderId . '/previews', ['order_read']);
+        $preview = $this->getItem('/orders/' . $orderId . '/preview', ['order_read']);
 
-        $this->assertArrayHasKey('orderId', $preview);
         $this->assertSame($orderId, $preview['orderId']);
-        $this->assertArrayHasKey('invoiceDetails', $preview);
-        $this->assertArrayHasKey('shippingDetails', $preview);
-        $this->assertArrayHasKey('productDetails', $preview);
-        $this->assertArrayHasKey('taxIncluded', $preview);
-        $this->assertArrayHasKey('virtual', $preview);
-        $this->assertArrayHasKey('invoiceAddressFormatted', $preview);
-        $this->assertArrayHasKey('shippingAddressFormatted', $preview);
+        $this->assertIsBool($preview['taxIncluded']);
+        $this->assertIsBool($preview['virtual']);
+        $this->assertNotEmpty($preview['invoiceAddressFormatted']);
+        $this->assertNotEmpty($preview['shippingAddressFormatted']);
+        $this->assertIsArray($preview['productDetails']);
+        $this->assertNotEmpty($preview['productDetails']);
+
+        $firstProduct = $preview['productDetails'][0];
+        $this->assertArrayHasKey('id', $firstProduct);
+        $this->assertArrayHasKey('name', $firstProduct);
+        $this->assertArrayHasKey('quantity', $firstProduct);
+        $this->assertArrayHasKey('unitPrice', $firstProduct);
+        $this->assertArrayHasKey('totalPrice', $firstProduct);
     }
 
     public function testGetNonExistentOrderPreviewReturnsNotFound(): void
     {
-        $this->requestApi('GET', '/orders/999999/previews', null, ['order_read'], Response::HTTP_NOT_FOUND);
+        $this->getItem('/orders/999999/preview', ['order_read'], Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
@@ -34,7 +34,7 @@ class OrderPreviewEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'get order preview endpoint' => ['GET', '/orders/1/preview'];
+        yield 'get order preview endpoint' => ['GET', '/orders/1/previews'];
     }
 
     public function testGetOrderPreview(): void

--- a/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
@@ -28,7 +28,7 @@ class OrderPreviewEndpointTest extends ApiTestCase
 {
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'get order preview endpoint' => ['GET', '/orders/1/previews'];
+        yield 'get order preview endpoint' => ['GET', '/orders/1/preview'];
     }
 
     public function testGetOrderPreview(): void
@@ -37,7 +37,7 @@ class OrderPreviewEndpointTest extends ApiTestCase
             'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` ASC'
         );
 
-        $preview = $this->getItem('/orders/' . $orderId . '/previews', ['order_read']);
+        $preview = $this->getItem('/orders/' . $orderId . '/preview', ['order_read']);
 
         $this->assertSame($orderId, $preview['orderId']);
         $this->assertIsBool($preview['taxIncluded']);
@@ -57,6 +57,6 @@ class OrderPreviewEndpointTest extends ApiTestCase
 
     public function testGetNonExistentOrderPreviewReturnsNotFound(): void
     {
-        $this->getItem('/orders/999999/previews', ['order_read'], Response::HTTP_NOT_FOUND);
+        $this->getItem('/orders/999999/preview', ['order_read'], Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class OrderPreviewEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get order preview endpoint' => ['GET', '/orders/1/preview'];
+    }
+
+    public function testGetOrderPreview(): void
+    {
+        $orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` ASC'
+        );
+
+        $preview = $this->getItem('/orders/' . $orderId . '/preview', ['order_read']);
+
+        $this->assertArrayHasKey('orderId', $preview);
+        $this->assertSame($orderId, $preview['orderId']);
+        $this->assertArrayHasKey('invoiceDetails', $preview);
+        $this->assertArrayHasKey('shippingDetails', $preview);
+        $this->assertArrayHasKey('productDetails', $preview);
+        $this->assertArrayHasKey('taxIncluded', $preview);
+        $this->assertArrayHasKey('virtual', $preview);
+        $this->assertArrayHasKey('invoiceAddressFormatted', $preview);
+        $this->assertArrayHasKey('shippingAddressFormatted', $preview);
+    }
+
+    public function testGetNonExistentOrderPreviewReturnsNotFound(): void
+    {
+        $this->requestApi('GET', '/orders/999999/preview', null, ['order_read'], Response::HTTP_NOT_FOUND);
+    }
+}

--- a/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderPreviewEndpointTest.php
@@ -28,7 +28,7 @@ class OrderPreviewEndpointTest extends ApiTestCase
 {
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'get order preview endpoint' => ['GET', '/orders/1/preview'];
+        yield 'get order preview endpoint' => ['GET', '/orders/1/previews'];
     }
 
     public function testGetOrderPreview(): void
@@ -37,7 +37,7 @@ class OrderPreviewEndpointTest extends ApiTestCase
             'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` ASC'
         );
 
-        $preview = $this->getItem('/orders/' . $orderId . '/preview', ['order_read']);
+        $preview = $this->getItem('/orders/' . $orderId . '/previews', ['order_read']);
 
         $this->assertSame($orderId, $preview['orderId']);
         $this->assertIsBool($preview['taxIncluded']);
@@ -57,6 +57,6 @@ class OrderPreviewEndpointTest extends ApiTestCase
 
     public function testGetNonExistentOrderPreviewReturnsNotFound(): void
     {
-        $this->getItem('/orders/999999/preview', ['order_read'], Response::HTTP_NOT_FOUND);
+        $this->getItem('/orders/999999/previews', ['order_read'], Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Rector/ApiResourceUriTemplateRector.php
+++ b/tests/Rector/ApiResourceUriTemplateRector.php
@@ -111,6 +111,7 @@ final class ApiResourceUriTemplateRector extends AbstractRector
         'install',
         'delete',
         'cover',
+        'preview',
         'disable',
         'enable',
         'search',

--- a/tests/Unit/Rector/Fixture/ApiResourceUriTemplateRector/skip_preview_keyword.php.inc
+++ b/tests/Unit/Rector/Fixture/ApiResourceUriTemplateRector/skip_preview_keyword.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiResource;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/orders/{orderId}/preview',
+        ),
+    ]
+)]
+class OrderPreview
+{
+}
+
+?>


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetOrderPreview` as `GET /orders/{orderId}/preview` (scope `order_read`): returns the invoice and shipping details, product details, tax/virtual flags and the formatted addresses of an order. Lightweight alternative to the full `/details` endpoint.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /orders/{id}/preview` (client granted `order_read`) returns `{ orderId, invoiceDetails, shippingDetails, productDetails, taxIncluded, virtual, invoiceAddressFormatted, shippingAddressFormatted }`. A non-existent id returns 404. Covered by `OrderPreviewEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.