### PR TITLE
Add product attribute groups read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductAttributeGroupList.php
+++ b/src/ApiPlatform/Resources/Product/ProductAttributeGroupList.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Query\GetProductAttributeGroups;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/products/{productId}/attribute-groups',
+            CQRSQuery: GetProductAttributeGroups::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][shopConstraint]' => '[shopConstraint]',
+            ],
+        ),
+    ],
+)]
+class ProductAttributeGroupList
+{
+    public int $attributeGroupId;
+
+    #[LocalizedValue]
+    public array $localizedNames;
+
+    #[LocalizedValue]
+    public array $localizedPublicNames;
+
+    public string $groupType;
+
+    /**
+     * True when the group represents color swatches.
+     * Property name follows the Rector rule that strips the `is` prefix.
+     */
+    public bool $colorGroup;
+
+    public int $position;
+
+    public ?array $attributes;
+}

--- a/src/ApiPlatform/Resources/Product/ProductAttributeGroupList.php
+++ b/src/ApiPlatform/Resources/Product/ProductAttributeGroupList.php
@@ -18,12 +18,17 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
 
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Product\AttributeGroup\Query\GetProductAttributeGroups;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
 use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
 
 #[ApiResource(
     operations: [
@@ -36,7 +41,16 @@ use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
             CQRSQueryMapping: [
                 '[_context][shopConstraint]' => '[shopConstraint]',
             ],
+            ApiResourceMapping: [
+                '[localizedNames]' => '[names]',
+                '[localizedPublicNames]' => '[publicNames]',
+                '[isColorGroup]' => '[colorGroup]',
+                '[groupType]' => '[type]',
+            ],
         ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
     ],
 )]
 class ProductAttributeGroupList
@@ -44,20 +58,35 @@ class ProductAttributeGroupList
     public int $attributeGroupId;
 
     #[LocalizedValue]
-    public array $localizedNames;
+    public array $names;
 
     #[LocalizedValue]
-    public array $localizedPublicNames;
+    public array $publicNames;
 
-    public string $groupType;
+    public string $type;
 
-    /**
-     * True when the group represents color swatches.
-     * Property name follows the Rector rule that strips the `is` prefix.
-     */
     public bool $colorGroup;
 
     public int $position;
 
+    #[ApiProperty(
+        openapiContext: [
+            'type' => 'array',
+            'description' => 'Attributes belonging to the group. Nested `localizedNames` are keyed by language id.',
+            'items' => [
+                'type' => 'object',
+                'properties' => [
+                    'attributeId' => ['type' => 'integer'],
+                    'position' => ['type' => 'integer'],
+                    'color' => ['type' => 'string'],
+                    'localizedNames' => [
+                        'type' => 'object',
+                        'additionalProperties' => ['type' => 'string'],
+                    ],
+                    'textureFilePath' => ['type' => 'string', 'nullable' => true],
+                ],
+            ],
+        ]
+    )]
     public ?array $attributes;
 }

--- a/tests/Integration/ApiPlatform/ProductAttributeGroupListEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductAttributeGroupListEndpointTest.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use Symfony\Component\HttpFoundation\Response;
+
 class ProductAttributeGroupListEndpointTest extends ApiTestCase
 {
     public static function setUpBeforeClass(): void
@@ -45,11 +47,24 @@ class ProductAttributeGroupListEndpointTest extends ApiTestCase
         $result = $this->getItem('/products/' . $productId . '/attribute-groups', ['product_read']);
 
         $this->assertNotEmpty($result);
-        $this->assertArrayHasKey('attributeGroupId', $result[0]);
-        $this->assertArrayHasKey('localizedNames', $result[0]);
-        $this->assertArrayHasKey('groupType', $result[0]);
-        $this->assertArrayHasKey('colorGroup', $result[0]);
-        $this->assertArrayHasKey('position', $result[0]);
-        $this->assertArrayHasKey('attributes', $result[0]);
+        $first = $result[0];
+        $this->assertArrayHasKey('attributeGroupId', $first);
+        $this->assertIsInt($first['attributeGroupId']);
+        $this->assertArrayHasKey('names', $first);
+        $this->assertIsArray($first['names']);
+        $this->assertArrayHasKey('publicNames', $first);
+        $this->assertIsArray($first['publicNames']);
+        $this->assertArrayHasKey('type', $first);
+        $this->assertIsString($first['type']);
+        $this->assertArrayHasKey('colorGroup', $first);
+        $this->assertIsBool($first['colorGroup']);
+        $this->assertArrayHasKey('position', $first);
+        $this->assertIsInt($first['position']);
+        $this->assertArrayHasKey('attributes', $first);
+    }
+
+    public function testGetAttributeGroupsForNonExistentProduct(): void
+    {
+        $this->getItem('/products/99999999/attribute-groups', ['product_read'], Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Integration/ApiPlatform/ProductAttributeGroupListEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductAttributeGroupListEndpointTest.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ProductAttributeGroupListEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list product attribute groups endpoint' => ['GET', '/products/1/attribute-groups'];
+    }
+
+    public function testListProductAttributeGroups(): void
+    {
+        // Pick a demo product that actually has combinations (and therefore attribute groups).
+        $productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product_attribute` ORDER BY `id_product` ASC'
+        );
+
+        $result = $this->getItem('/products/' . $productId . '/attribute-groups', ['product_read']);
+
+        $this->assertNotEmpty($result);
+        $this->assertArrayHasKey('attributeGroupId', $result[0]);
+        $this->assertArrayHasKey('localizedNames', $result[0]);
+        $this->assertArrayHasKey('groupType', $result[0]);
+        $this->assertArrayHasKey('colorGroup', $result[0]);
+        $this->assertArrayHasKey('position', $result[0]);
+        $this->assertArrayHasKey('attributes', $result[0]);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetProductAttributeGroups` as `GET /products/{productId}/attribute-groups` (scope `product_read`): returns the attribute groups (with their nested attributes) associated with a product's combinations.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /products/{id}/attribute-groups` (client granted `product_read`) returns the product's attribute groups (with nested attributes). Covered by `ProductAttributeGroupListEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.