### PR TITLE
Add product catalog price rules read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductCatalogPriceRules.php
+++ b/src/ApiPlatform/Resources/Product/ProductCatalogPriceRules.php
@@ -48,7 +48,7 @@ class ProductCatalogPriceRules
     public int $totalCount;
 
     public const QUERY_MAPPING = [
-        '[_context][langId]' => '[languageId]',
+        '[_context][langId]' => '[langId]',
         '[productId]' => '[productId]',
     ];
 }

--- a/src/ApiPlatform/Resources/Product/ProductCatalogPriceRules.php
+++ b/src/ApiPlatform/Resources/Product/ProductCatalogPriceRules.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CatalogPriceRule\Query\GetCatalogPriceRuleListForProduct;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/catalog-price-rules',
+            requirements: ['productId' => '\d+'],
+            CQRSQuery: GetCatalogPriceRuleListForProduct::class,
+            scopes: [
+                'catalog_price_rule_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+)]
+class ProductCatalogPriceRules
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    public array $catalogPriceRules;
+
+    public int $totalCount;
+
+    public const QUERY_MAPPING = [
+        '[_context][langId]' => '[languageId]',
+        '[productId]' => '[productId]',
+    ];
+}

--- a/src/ApiPlatform/Resources/Product/ProductCatalogPriceRules.php
+++ b/src/ApiPlatform/Resources/Product/ProductCatalogPriceRules.php
@@ -18,6 +18,8 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
 
 use ApiPlatform\Metadata\ApiProperty;
@@ -43,6 +45,27 @@ class ProductCatalogPriceRules
     #[ApiProperty(identifier: true)]
     public int $productId;
 
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'catalogPriceRuleId' => ['type' => 'integer'],
+                'catalogPriceRuleName' => ['type' => 'string'],
+                'fromQuantity' => ['type' => 'integer'],
+                'reductionType' => ['type' => 'string'],
+                'reduction' => ['type' => 'string'],
+                'taxIncluded' => ['type' => 'boolean'],
+                'dateStart' => ['type' => 'string', 'format' => 'date-time'],
+                'dateEnd' => ['type' => 'string', 'format' => 'date-time'],
+                'shopName' => ['type' => 'string', 'nullable' => true],
+                'currencyName' => ['type' => 'string', 'nullable' => true],
+                'countryName' => ['type' => 'string', 'nullable' => true],
+                'groupName' => ['type' => 'string', 'nullable' => true],
+                'currencyIso' => ['type' => 'string', 'nullable' => true],
+            ],
+        ],
+    ])]
     public array $catalogPriceRules;
 
     public int $totalCount;

--- a/tests/Integration/ApiPlatform/ProductCatalogPriceRulesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductCatalogPriceRulesEndpointTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ProductCatalogPriceRulesEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['catalog_price_rule_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list product catalog price rules endpoint' => ['GET', '/products/1/catalog-price-rules'];
+    }
+
+    public function testListProductCatalogPriceRules(): void
+    {
+        $productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` WHERE `active` = 1 ORDER BY `id_product` ASC'
+        );
+
+        $result = $this->getItem('/products/' . $productId . '/catalog-price-rules', ['catalog_price_rule_read']);
+
+        $this->assertArrayHasKey('productId', $result);
+        $this->assertSame($productId, $result['productId']);
+        $this->assertArrayHasKey('catalogPriceRules', $result);
+        $this->assertArrayHasKey('totalCount', $result);
+    }
+}

--- a/tests/Integration/ApiPlatform/ProductCatalogPriceRulesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductCatalogPriceRulesEndpointTest.php
@@ -24,12 +24,6 @@ namespace PsApiResourcesTest\Integration\ApiPlatform;
 
 class ProductCatalogPriceRulesEndpointTest extends ApiTestCase
 {
-    public static function setUpBeforeClass(): void
-    {
-        parent::setUpBeforeClass();
-        self::createApiClient(['catalog_price_rule_read']);
-    }
-
     public static function getProtectedEndpoints(): iterable
     {
         yield 'list product catalog price rules endpoint' => ['GET', '/products/1/catalog-price-rules'];
@@ -46,6 +40,9 @@ class ProductCatalogPriceRulesEndpointTest extends ApiTestCase
         $this->assertArrayHasKey('productId', $result);
         $this->assertSame($productId, $result['productId']);
         $this->assertArrayHasKey('catalogPriceRules', $result);
+        $this->assertIsArray($result['catalogPriceRules']);
         $this->assertArrayHasKey('totalCount', $result);
+        $this->assertIsInt($result['totalCount']);
+        $this->assertSame(count($result['catalogPriceRules']), $result['totalCount']);
     }
 }


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetCatalogPriceRuleListForProduct` as `GET /products/{productId}/catalog-price-rules` (scope `catalog_price_rule_read`): returns the catalog price rules that apply to a product with the total count.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /products/{id}/catalog-price-rules` (client granted `catalog_price_rule_read`) returns `{ productId, catalogPriceRules, totalCount }`. Covered by `ProductCatalogPriceRulesEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.