### PR TITLE
Add employee email read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Employee/EmployeeEmail.php
+++ b/src/ApiPlatform/Resources/Employee/EmployeeEmail.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Employee;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Exception\EmployeeNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Employee\Query\GetEmployeeEmailById;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/employees/{employeeId}/emails',
+            requirements: ['employeeId' => '\d+'],
+            CQRSQuery: GetEmployeeEmailById::class,
+            scopes: [
+                'employee_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        EmployeeNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class EmployeeEmail
+{
+    #[ApiProperty(identifier: true)]
+    public int $employeeId;
+
+    public string $email;
+
+    public const QUERY_MAPPING = [
+        // The query result is a mono-arg Email VO — it collapses to its scalar
+        // string, which we map from the framework's "_queryResult" wrapper key
+        // onto the resource's email property (same pattern as ShowcaseCard).
+        '[_queryResult]' => '[email]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/EmployeeEmailEndpointTest.php
+++ b/tests/Integration/ApiPlatform/EmployeeEmailEndpointTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class EmployeeEmailEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['employee_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get employee email endpoint' => ['GET', '/employees/1/emails'];
+    }
+
+    public function testGetEmployeeEmail(): void
+    {
+        $row = \Db::getInstance()->getRow(
+            'SELECT `id_employee`, `email` FROM `' . _DB_PREFIX_ . 'employee` ORDER BY `id_employee` ASC'
+        );
+        $employeeId = (int) $row['id_employee'];
+        $email = (string) $row['email'];
+
+        $result = $this->getItem('/employees/' . $employeeId . '/emails', ['employee_read']);
+
+        $this->assertArrayHasKey('employeeId', $result);
+        $this->assertSame($employeeId, $result['employeeId']);
+        $this->assertArrayHasKey('email', $result);
+        $this->assertSame($email, $result['email']);
+    }
+
+    public function testGetUnknownEmployeeEmailReturnsNotFound(): void
+    {
+        $this->requestApi('GET', '/employees/9999999/emails', null, ['employee_read'], Response::HTTP_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetEmployeeEmailById` as `GET /employees/{employeeId}/emails` (scope `employee_read`): returns `{ employeeId, email }`. The query result is a mono-arg `Email` VO that collapses to its scalar string, mapped from `_queryResult` to the resource's `email` property (same pattern as `ShowcaseCard`).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /employees/{id}/emails` (client granted `employee_read`) returns `{ employeeId, email }`. A missing employee id returns 404. Covered by `EmployeeEmailEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.