### PR TITLE
Add customer address-creation info read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Customer/AddressCreationCustomerInfo.php
+++ b/src/ApiPlatform/Resources/Customer/AddressCreationCustomerInfo.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
+
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerByEmailNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForAddressCreation;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/customers/address-creation-info',
+            CQRSQuery: GetCustomerForAddressCreation::class,
+            scopes: [
+                'customer_read',
+            ],
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'customerEmail',
+                    required: true,
+                    description: 'Customer email address'
+                ),
+            ]),
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerByEmailNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class AddressCreationCustomerInfo
+{
+    public int $customerId;
+
+    public string $firstName;
+
+    public string $lastName;
+
+    public ?string $company;
+}

--- a/src/ApiPlatform/Resources/Customer/AddressCreationCustomerInfo.php
+++ b/src/ApiPlatform/Resources/Customer/AddressCreationCustomerInfo.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Customer;
 
+use ApiPlatform\Metadata\ApiResource;
 use ApiPlatform\Metadata\Parameters;
 use ApiPlatform\Metadata\QueryParameter;
-use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CustomerByEmailNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetCustomerForAddressCreation;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
@@ -33,7 +33,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSGet(
-            uriTemplate: '/customers/address-creation-info',
+            uriTemplate: '/customers/address-creation-infos',
             CQRSQuery: GetCustomerForAddressCreation::class,
             scopes: [
                 'customer_read',

--- a/tests/Integration/ApiPlatform/AddressCreationCustomerInfoEndpointTest.php
+++ b/tests/Integration/ApiPlatform/AddressCreationCustomerInfoEndpointTest.php
@@ -34,7 +34,7 @@ class AddressCreationCustomerInfoEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'get customer address-creation info endpoint' => ['GET', '/customers/address-creation-info?customerEmail=foo@example.com'];
+        yield 'get customer address-creation info endpoint' => ['GET', '/customers/address-creation-infos?customerEmail=foo@example.com'];
     }
 
     public function testGetCustomerForAddressCreation(): void
@@ -45,7 +45,7 @@ class AddressCreationCustomerInfoEndpointTest extends ApiTestCase
         );
 
         $result = $this->getItem(
-            '/customers/address-creation-info?customerEmail=' . urlencode((string) $row['email']),
+            '/customers/address-creation-infos?customerEmail=' . urlencode((string) $row['email']),
             ['customer_read']
         );
 
@@ -60,7 +60,7 @@ class AddressCreationCustomerInfoEndpointTest extends ApiTestCase
     {
         $this->requestApi(
             'GET',
-            '/customers/address-creation-info?customerEmail=' . urlencode('nobody-' . uniqid() . '@example.invalid'),
+            '/customers/address-creation-infos?customerEmail=' . urlencode('nobody-' . uniqid() . '@example.invalid'),
             null,
             ['customer_read'],
             Response::HTTP_NOT_FOUND

--- a/tests/Integration/ApiPlatform/AddressCreationCustomerInfoEndpointTest.php
+++ b/tests/Integration/ApiPlatform/AddressCreationCustomerInfoEndpointTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class AddressCreationCustomerInfoEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['customer_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get customer address-creation info endpoint' => ['GET', '/customers/address-creation-info?customerEmail=foo@example.com'];
+    }
+
+    public function testGetCustomerForAddressCreation(): void
+    {
+        $row = \Db::getInstance()->getRow(
+            'SELECT `id_customer`, `firstname`, `lastname`, `email`
+             FROM `' . _DB_PREFIX_ . 'customer` WHERE `active` = 1 ORDER BY `id_customer` ASC'
+        );
+
+        $result = $this->getItem(
+            '/customers/address-creation-info?customerEmail=' . urlencode((string) $row['email']),
+            ['customer_read']
+        );
+
+        $this->assertArrayHasKey('customerId', $result);
+        $this->assertSame((int) $row['id_customer'], $result['customerId']);
+        $this->assertSame((string) $row['firstname'], $result['firstName']);
+        $this->assertSame((string) $row['lastname'], $result['lastName']);
+        $this->assertArrayHasKey('company', $result);
+    }
+
+    public function testGetForUnknownEmailReturnsNotFound(): void
+    {
+        $this->requestApi(
+            'GET',
+            '/customers/address-creation-info?customerEmail=' . urlencode('nobody-' . uniqid() . '@example.invalid'),
+            null,
+            ['customer_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetCustomerForAddressCreation` as `GET /customers/address-creation-info?customerEmail=...` (scope `customer_read`): returns the minimal customer info the address-creation BO flow needs (`customerId`, `firstName`, `lastName`, `company`). The email is passed as a required query parameter (`QueryParameter`), same pattern as `FoundProduct`'s `phrase` — but here combined with `CQRSGet` (single object result) rather than `CQRSGetCollection`.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /customers/address-creation-info?customerEmail=<email>` (client granted `customer_read`) returns `{ customerId, firstName, lastName, company }`. An unknown email returns 404. Covered by `AddressCreationCustomerInfoEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.