### PR TITLE
Bump GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,12 +34,12 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout Module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           path: ps_apiresources
 
       - name: Checkout PrestaShop repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           repository: PrestaShop/PrestaShop

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: PHP syntax checker 8.1
               uses: prestashop/github-action-php-lint/8.1@master
@@ -38,10 +38,10 @@ jobs:
                 php-version: '8.1'
 
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Cache dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                 path: vendor
                 key: php-${{ hashFiles('composer.lock') }}
@@ -62,10 +62,10 @@ jobs:
             php-version: '8.1'
 
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
 
         - name: Cache dependencies
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
             path: vendor
             key: php-${{ hashFiles('composer.lock') }}
@@ -86,10 +86,10 @@ jobs:
             php-version: '8.1'
 
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
 
         - name: Cache dependencies
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
             path: vendor
             key: php-${{ hashFiles('composer.lock') }}
@@ -110,10 +110,10 @@ jobs:
             php-version: '8.1'
 
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v5
 
         - name: Cache dependencies
-          uses: actions/cache@v3
+          uses: actions/cache@v4
           with:
             path: vendor
             key: php-${{ hashFiles('composer.lock') }}
@@ -135,7 +135,7 @@ jobs:
           PHPRC: ${{ github.workspace }}/${{ github.event.repository.name }}/.phpstan-php-ini
       steps:
           - name: Checkout repository
-            uses: actions/checkout@v4
+            uses: actions/checkout@v5
             with:
                 path: ${{ github.event.repository.name }}
 


### PR DESCRIPTION
## Summary

GitHub Actions runners have deprecated the Node.js 20 runtime (see [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Every recent CI run on this repo now surfaces the following warning on all PHP jobs:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v3, actions/checkout@v3, actions/checkout@v4.

This PR bumps the affected actions to their current Node.js 24 majors:

- `actions/checkout@v3` / `actions/checkout@v4` → `actions/checkout@v5`
- `actions/cache@v3` → `actions/cache@v4`

Files touched:
- `.github/workflows/php.yml`
- `.github/workflows/integration.yml`

`ai-prereview.yml` already pins `actions/checkout@v6` and needs no change.

## Test plan

- [ ] CI on this PR is green with no more Node.js 20 deprecation notices.