### PR TITLE
Add reference currency read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Currency/ReferenceCurrency.php
+++ b/src/ApiPlatform/Resources/Currency/ReferenceCurrency.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Currency;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Query\GetReferenceCurrency;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/currencies/references',
+            CQRSQuery: GetReferenceCurrency::class,
+            scopes: [
+                'currency_read',
+            ],
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'isoCode',
+                    required: true,
+                    description: 'Currency ISO code (e.g. EUR, USD)'
+                ),
+            ]),
+        ),
+    ],
+    exceptionToStatus: [
+        CurrencyNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ReferenceCurrency
+{
+    public string $isoCode;
+
+    public string $numericIsoCode;
+
+    public array $names;
+
+    public array $symbols;
+
+    public array $patterns;
+
+    public int $precision;
+}

--- a/tests/Integration/ApiPlatform/ReferenceCurrencyEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ReferenceCurrencyEndpointTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class ReferenceCurrencyEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['currency_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get reference currency endpoint' => ['GET', '/currencies/references?isoCode=EUR'];
+    }
+
+    public function testGetReferenceCurrency(): void
+    {
+        $result = $this->getItem('/currencies/references?isoCode=EUR', ['currency_read']);
+
+        $this->assertArrayHasKey('isoCode', $result);
+        $this->assertSame('EUR', $result['isoCode']);
+        $this->assertArrayHasKey('numericIsoCode', $result);
+        $this->assertIsString($result['numericIsoCode']);
+        $this->assertArrayHasKey('names', $result);
+        $this->assertIsArray($result['names']);
+        $this->assertArrayHasKey('symbols', $result);
+        $this->assertArrayHasKey('patterns', $result);
+        $this->assertArrayHasKey('precision', $result);
+        $this->assertIsInt($result['precision']);
+    }
+
+    public function testGetUnknownReferenceCurrencyReturnsNotFound(): void
+    {
+        $this->requestApi(
+            'GET',
+            '/currencies/references?isoCode=ZZZ',
+            null,
+            ['currency_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetReferenceCurrency` as `GET /currencies/references?isoCode=...` (scope `currency_read`): returns the CLDR reference-data snapshot for a currency ISO code — `isoCode`, `numericIsoCode`, localized `names`, `symbols`, `patterns`, `precision`. Uses the CQRSGet + QueryParameter pattern for a mono-arg string query.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /currencies/references?isoCode=EUR` (client granted `currency_read`) returns the reference-currency payload. An unknown code returns 404. Covered by `ReferenceCurrencyEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.