### PR TITLE
Bootstrap CI for 9.2.x

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         php: ${{ fromJSON(needs.workflow_matrix_generator.outputs.dynamic_matrix) }}
-        prestashop_version: ['develop', '9.0.3', '9.1.x']
+        prestashop_version: ['develop', '9.2.x', '9.0.3', '9.1.x']
         exclude:
           # 9.0.3 doesn't support PHP 8.5
           - php: '8.5'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -129,7 +129,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
           matrix:
-              presta_version: ['9.0.3', '9.1.x', 'develop']
+              presta_version: ['9.0.3', '9.1.x', 'develop', '9.2.x']
           fail-fast: false
       env:
           PHPRC: ${{ github.workspace }}/${{ github.event.repository.name }}/.phpstan-php-ini


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | Add the new version branch `9.2.x` (opened for 9.2.0) to this repository's CI matrices / branch lists.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Review the diff: `9.2.x` is added wherever active version branches are enumerated.
| UI Tests          | N/A
| Fixed issue or discussion? | N/A
| Related PRs       | Companion PRs opened by the same "Version-branch bootstrap" run.
| Sponsor company   | N/A

> 🤖 Opened automatically by the **Version-branch bootstrap** workflow. Idempotent: re-running updates this PR; if it was closed, a new one is created.