### PR TITLE
Add currency exchange rate read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Currency/ExchangeRate.php
+++ b/src/ApiPlatform/Resources/Currency/ExchangeRate.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Currency;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\ExchangeRateNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Query\GetCurrencyExchangeRate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/currencies/exchange-rates',
+            CQRSQuery: GetCurrencyExchangeRate::class,
+            scopes: [
+                'currency_read',
+            ],
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'isoCode',
+                    required: true,
+                    description: 'Currency ISO code (e.g. EUR, USD)'
+                ),
+            ]),
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        ExchangeRateNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ExchangeRate
+{
+    public DecimalNumber $exchangeRate;
+
+    public const QUERY_MAPPING = [
+        // The query returns an ExchangeRate VO wrapping a DecimalNumber. The framework
+        // wraps a scalar result behind "_queryResult"; here we map it to the exchangeRate
+        // property (the DecimalNumber round-trips as a string, like on CustomerGroup).
+        '[_queryResult]' => '[exchangeRate]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/ExchangeRateEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ExchangeRateEndpointTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class ExchangeRateEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['currency_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get currency exchange rate endpoint' => ['GET', '/currencies/exchange-rates?isoCode=USD'];
+    }
+
+    public function testGetCurrencyExchangeRate(): void
+    {
+        // Use an active non-default currency; the default one has rate 1.
+        $isoCode = (string) \Db::getInstance()->getValue(
+            'SELECT `iso_code` FROM `' . _DB_PREFIX_ . 'currency`
+             WHERE `deleted` = 0 AND `active` = 1 AND `iso_code` <> \'\'
+             ORDER BY `id_currency` ASC'
+        );
+
+        $result = $this->getItem('/currencies/exchange-rates?isoCode=' . urlencode($isoCode), ['currency_read']);
+
+        $this->assertArrayHasKey('exchangeRate', $result);
+        $this->assertNotEmpty($result['exchangeRate']);
+    }
+
+    public function testGetUnknownExchangeRateReturnsNotFound(): void
+    {
+        $this->requestApi(
+            'GET',
+            '/currencies/exchange-rates?isoCode=ZZZ',
+            null,
+            ['currency_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetCurrencyExchangeRate` as `GET /currencies/exchange-rates?isoCode=...` (scope `currency_read`): returns the CLDR exchange rate for a currency ISO code. The handler returns an `ExchangeRate` value object wrapping a `DecimalNumber`; the framework's `_queryResult` wrapper is mapped to the `exchangeRate` property (round-trips as a string, same normalization as `CustomerGroup`'s decimal fields). Uses the CQRSGet + QueryParameter pattern.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /currencies/exchange-rates?isoCode=USD` (client granted `currency_read`) returns `{ exchangeRate }`. An unknown code returns 404. Covered by `ExchangeRateEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.