### PR TITLE
Add product specific prices read endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductSpecificPrices.php
+++ b/src/ApiPlatform/Resources/Product/ProductSpecificPrices.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\SpecificPrice\Query\GetSpecificPriceList;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/specific-prices',
+            requirements: ['productId' => '\d+'],
+            CQRSQuery: GetSpecificPriceList::class,
+            scopes: [
+                'specific_price_read',
+            ],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+)]
+class ProductSpecificPrices
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    public array $specificPrices;
+
+    public int $totalSpecificPricesCount;
+
+    public const QUERY_MAPPING = [
+        '[_context][langId]' => '[languageId]',
+        '[productId]' => '[productId]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/ProductSpecificPricesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductSpecificPricesEndpointTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ProductSpecificPricesEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['specific_price_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list product specific prices endpoint' => ['GET', '/products/1/specific-prices'];
+    }
+
+    public function testListProductSpecificPrices(): void
+    {
+        $productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` WHERE `active` = 1 ORDER BY `id_product` ASC'
+        );
+
+        $result = $this->getItem('/products/' . $productId . '/specific-prices', ['specific_price_read']);
+
+        $this->assertArrayHasKey('productId', $result);
+        $this->assertSame($productId, $result['productId']);
+        $this->assertArrayHasKey('specificPrices', $result);
+        $this->assertIsArray($result['specificPrices']);
+        $this->assertArrayHasKey('totalSpecificPricesCount', $result);
+        $this->assertIsInt($result['totalSpecificPricesCount']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------------
| Branch?           | dev
| Description?       | Exposes `GetSpecificPriceList` as `GET /products/{productId}/specific-prices` (scope `specific_price_read`): returns the specific prices applied to a product (`specificPrices`) along with the total count (`totalSpecificPricesCount`).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630
| How to test?      | `GET /products/{id}/specific-prices` (client granted `specific_price_read`) returns `{ productId, specificPrices, totalSpecificPricesCount }`. Covered by `ProductSpecificPricesEndpointTest`.
| Possible impacts? | None — read-only endpoint on a new resource.