### PR TITLE
Add GET operation to the Customer required-fields endpoint

### DIFF
--- a/config/admin/services.yml
+++ b/config/admin/services.yml
@@ -59,8 +59,9 @@ services:
       $decorated: '@.inner'
 
   # Filters Admin API operations whose minVersion/maxVersion extra properties don't match the running core
-  # version. On PrestaShop >= 9.2 the equivalent core decorator exists and is injected as an optional
-  # reference: when present this module decorator is a pure pass-through.
+  # version. On PrestaShop >= 9.2 the equivalent core decorator class exists (checked via class_exists, NOT
+  # injected as a service which would create a circular reference in the decoration chain): when detected
+  # this module decorator is a pure pass-through.
   # Note: module resources must declare the gating via extraProperties (['minVersion' => 'x.y.z']), NOT via
   # the named constructor arguments which only exist in the core operation classes since PrestaShop 9.2.
   # @deprecated remove together with the class once the module requires PrestaShop >= 9.2.
@@ -68,4 +69,3 @@ services:
     decorates: api_platform.metadata.resource.metadata_collection_factory
     arguments:
       $decorated: '@.inner'
-      $coreVersionDecorator: '@?PrestaShopBundle\ApiPlatform\Metadata\Resource\Factory\CoreVersionCompatibilityMetadataCollectionFactoryDecorator'

--- a/src/ApiPlatform/Metadata/Resource/Factory/CoreVersionCompatibilityMetadataCollectionFactoryDecorator.php
+++ b/src/ApiPlatform/Metadata/Resource/Factory/CoreVersionCompatibilityMetadataCollectionFactoryDecorator.php
@@ -56,9 +56,6 @@ class CoreVersionCompatibilityMetadataCollectionFactoryDecorator implements Reso
     public function __construct(
         private readonly ResourceMetadataCollectionFactoryInterface $decorated,
         private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
-        // The core twin decorator is injected as an optional reference: it is non-null on PrestaShop >= 9.2
-        // where the core already filters, in which case this decorator is a pure pass-through
-        private readonly ?ResourceMetadataCollectionFactoryInterface $coreVersionDecorator = null,
     ) {
     }
 
@@ -67,8 +64,10 @@ class CoreVersionCompatibilityMetadataCollectionFactoryDecorator implements Reso
         // We call the original method since we only want to alter the result of this method.
         $resourceMetadataCollection = $this->decorated->create($resourceClass);
 
-        // The core decorator already handles the filtering on PrestaShop >= 9.2
-        if (null !== $this->coreVersionDecorator) {
+        // The core twin decorator exists on PrestaShop >= 9.2 and already handles the filtering, so this
+        // decorator is a pure pass-through. The check relies on class_exists instead of injecting the core
+        // service, which would create a circular reference in the decoration chain.
+        if (class_exists(\PrestaShopBundle\ApiPlatform\Metadata\Resource\Factory\CoreVersionCompatibilityMetadataCollectionFactoryDecorator::class)) {
             return $resourceMetadataCollection;
         }
 

--- a/src/ApiPlatform/Resources/Customer/CustomerRequiredFields.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerRequiredFields.php
@@ -27,11 +27,19 @@ use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Command\SetRequiredFieldsForCustomerCommand;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\CannotSetRequiredFieldsForCustomerException;
 use PrestaShop\PrestaShop\Core\Domain\Customer\Exception\InvalidCustomerRequiredFieldsException;
+use PrestaShop\PrestaShop\Core\Domain\Customer\Query\GetRequiredFieldsForCustomer;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
 use Symfony\Component\HttpFoundation\Response;
 
 #[ApiResource(
     operations: [
+        new CQRSGet(
+            uriTemplate: '/customers/required-fields',
+            CQRSQuery: GetRequiredFieldsForCustomer::class,
+            scopes: ['customer_read'],
+            CQRSQueryMapping: ['[_queryResult]' => '[requiredFields]'],
+        ),
         new CQRSUpdate(
             uriTemplate: '/customers/required-fields',
             output: false,

--- a/src/ApiPlatform/Resources/Customer/CustomerRequiredFields.php
+++ b/src/ApiPlatform/Resources/Customer/CustomerRequiredFields.php
@@ -36,6 +36,9 @@ use Symfony\Component\HttpFoundation\Response;
     operations: [
         new CQRSGet(
             uriTemplate: '/customers/required-fields',
+            extraProperties: [
+                'minVersion' => '9.2.0',
+            ],
             CQRSQuery: GetRequiredFieldsForCustomer::class,
             scopes: ['customer_read'],
             CQRSQueryMapping: ['[_queryResult]' => '[requiredFields]'],

--- a/tests/Integration/ApiPlatform/CoreVersionCompatibilityDecoratorTest.php
+++ b/tests/Integration/ApiPlatform/CoreVersionCompatibilityDecoratorTest.php
@@ -64,6 +64,10 @@ class CoreVersionCompatibilityDecoratorTest extends TestCase
 
     public function testIncompatibleOperationsAreFiltered(): void
     {
+        if ($this->coreDecoratorClassExists()) {
+            $this->markTestSkipped('On PrestaShop >= 9.2 the module decorator is a pure pass-through, filtering is covered by testPassThroughWhenCoreDecoratorClassExists');
+        }
+
         $decorator = new CoreVersionCompatibilityMetadataCollectionFactoryDecorator(
             $this->buildDecoratedFactory(),
             new DisabledFeatureFlagStateChecker(),
@@ -72,15 +76,18 @@ class CoreVersionCompatibilityDecoratorTest extends TestCase
         $this->assertEquals(self::EXPECTED_KEPT_OPERATIONS, $this->getOperationNames($decorator->create('resourceClass')));
     }
 
-    public function testPassThroughWhenCoreDecoratorIsPresent(): void
+    public function testPassThroughWhenCoreDecoratorClassExists(): void
     {
-        // When the core twin decorator is detected (PrestaShop >= 9.2) the module decorator filters nothing,
-        // the core is responsible for the filtering
-        $coreDecorator = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        // When the core twin decorator class exists (PrestaShop >= 9.2) the module decorator filters nothing,
+        // the core is responsible for the filtering. The detection relies on class_exists, so this case can
+        // only be exercised when the CI matrix runs against a core version that ships the class.
+        if (!$this->coreDecoratorClassExists()) {
+            $this->markTestSkipped('The core twin decorator class only exists on PrestaShop >= 9.2, filtering is covered by testIncompatibleOperationsAreFiltered');
+        }
+
         $decorator = new CoreVersionCompatibilityMetadataCollectionFactoryDecorator(
             $this->buildDecoratedFactory(),
             new DisabledFeatureFlagStateChecker(),
-            $coreDecorator,
         );
 
         $this->assertEquals(self::ALL_OPERATIONS, $this->getOperationNames($decorator->create('resourceClass')));
@@ -97,6 +104,11 @@ class CoreVersionCompatibilityDecoratorTest extends TestCase
         );
 
         $this->assertEquals(self::ALL_OPERATIONS, $this->getOperationNames($decorator->create('resourceClass')));
+    }
+
+    private function coreDecoratorClassExists(): bool
+    {
+        return class_exists(\PrestaShopBundle\ApiPlatform\Metadata\Resource\Factory\CoreVersionCompatibilityMetadataCollectionFactoryDecorator::class);
     }
 
     private function buildDecoratedFactory(): ResourceMetadataCollectionFactoryInterface

--- a/tests/Integration/ApiPlatform/CustomerRequiredFieldsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerRequiredFieldsEndpointTest.php
@@ -32,7 +32,7 @@ class CustomerRequiredFieldsEndpointTest extends ApiTestCase
     {
         parent::setUpBeforeClass();
         DatabaseDump::restoreTables(['required_field']);
-        self::createApiClient(['customer_write']);
+        self::createApiClient(['customer_read', 'customer_write']);
     }
 
     public static function tearDownAfterClass(): void
@@ -43,6 +43,11 @@ class CustomerRequiredFieldsEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
+        yield 'get required fields endpoint' => [
+            'GET',
+            '/customers/required-fields',
+        ];
+
         yield 'set required fields endpoint' => [
             'PUT',
             '/customers/required-fields',
@@ -64,6 +69,22 @@ class CustomerRequiredFieldsEndpointTest extends ApiTestCase
         $fieldNames = array_column($storedFields ?: [], 'field_name');
 
         $this->assertContains('newsletter', $fieldNames);
+    }
+
+    public function testGetCustomerRequiredFields(): void
+    {
+        // Set a known state through the write endpoint, then read it back through the GET endpoint.
+        $this->updateItem(
+            '/customers/required-fields',
+            ['requiredFields' => ['newsletter']],
+            ['customer_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $requiredFields = $this->getItem('/customers/required-fields', ['customer_read']);
+
+        $this->assertArrayHasKey('requiredFields', $requiredFields);
+        $this->assertContains('newsletter', $requiredFields['requiredFields']);
     }
 
     public function testSetInvalidCustomerRequiredFieldIsRejected(): void

--- a/tests/Integration/ApiPlatform/CustomerRequiredFieldsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerRequiredFieldsEndpointTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use PrestaShop\PrestaShop\Core\Version;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Resources\DatabaseDump;
 
@@ -43,15 +44,26 @@ class CustomerRequiredFieldsEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'get required fields endpoint' => [
-            'GET',
-            '/customers/required-fields',
-        ];
+        // GET endpoint only works for 9.2+
+        if (version_compare(Version::VERSION, '9.2.0', '>=')) {
+            yield 'get required fields endpoint' => [
+                'GET',
+                '/customers/required-fields',
+            ];
+        }
 
         yield 'set required fields endpoint' => [
             'PUT',
             '/customers/required-fields',
         ];
+    }
+
+    public function testGetCustomerRequiredFields(): void
+    {
+        $this->markTestSkippedByMinVersion('9.2.0');
+        $requiredFields = $this->getItem('/customers/required-fields', ['customer_read']);
+        // By default, there is no required filed
+        $this->assertEquals([], $requiredFields['requiredFields']);
     }
 
     public function testSetCustomerRequiredFields(): void
@@ -63,28 +75,19 @@ class CustomerRequiredFieldsEndpointTest extends ApiTestCase
             Response::HTTP_NO_CONTENT
         );
 
-        $storedFields = \Db::getInstance()->executeS(
-            'SELECT `field_name` FROM `' . _DB_PREFIX_ . "required_field` WHERE `object_name` = 'Customer'"
-        );
-        $fieldNames = array_column($storedFields ?: [], 'field_name');
+        // GET endpoint only works for 9.2+
+        if (version_compare(Version::VERSION, '9.2.0', '>=')) {
+            $requiredFields = $this->getItem('/customers/required-fields', ['customer_read']);
+            $this->assertEquals(['newsletter'], $requiredFields['requiredFields']);
+        } else {
+            // Test manually from the DB
+            $storedFields = \Db::getInstance()->executeS(
+                'SELECT `field_name` FROM `' . _DB_PREFIX_ . "required_field` WHERE `object_name` = 'Customer'"
+            );
+            $fieldNames = array_column($storedFields ?: [], 'field_name');
 
-        $this->assertContains('newsletter', $fieldNames);
-    }
-
-    public function testGetCustomerRequiredFields(): void
-    {
-        // Set a known state through the write endpoint, then read it back through the GET endpoint.
-        $this->updateItem(
-            '/customers/required-fields',
-            ['requiredFields' => ['newsletter']],
-            ['customer_write'],
-            Response::HTTP_NO_CONTENT
-        );
-
-        $requiredFields = $this->getItem('/customers/required-fields', ['customer_read']);
-
-        $this->assertArrayHasKey('requiredFields', $requiredFields);
-        $this->assertContains('newsletter', $requiredFields['requiredFields']);
+            $this->assertContains('newsletter', $fieldNames);
+        }
     }
 
     public function testSetInvalidCustomerRequiredFieldIsRejected(): void


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds the read counterpart of the Customer required-fields endpoint: a `GET /customers/required-fields` operation (scope `customer_read`) on the existing `CustomerRequiredFields` resource. It exposes `GetRequiredFieldsForCustomer`, whose query returns a plain `string[]`, mapped onto the resource via `CQRSQueryMapping: ['[_queryResult]' => '[requiredFields]']`.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#41986
| Sponsor company   | @PrestaShopCorp

> [!WARNING]
> **Draft — depends on a core change.** Mapping a bare list query result requires PrestaShop/PrestaShop#42011 (wrap plain list results under `_queryResult`). CI here stays red until that PR is merged into core. This will be marked ready for review once #42011 lands.

Complements the write-side endpoint (`PUT`, #237). The existing test class gains a GET read-back test and the `GET` route is added to the protected-endpoints check; the client is granted `customer_read` alongside `customer_write`.
