### PR TITLE
Add GetLanguageForEditing Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Language/Language.php
+++ b/src/ApiPlatform/Resources/Language/Language.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Language;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Language\Exception\LanguageNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Language\Query\GetLanguageForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/languages/{languageId}',
+            requirements: ['languageId' => '\d+'],
+            CQRSQuery: GetLanguageForEditing::class,
+            scopes: ['language_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        LanguageNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class Language
+{
+    #[ApiProperty(identifier: true)]
+    public int $languageId;
+
+    public string $name;
+
+    public string $isoCode;
+
+    public string $tagIETF;
+
+    public string $locale;
+
+    public string $shortDateFormat;
+
+    public string $fullDateFormat;
+
+    public bool $rtl;
+
+    public bool $enabled;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer']])]
+    public array $shopIds;
+
+    public const QUERY_MAPPING = [
+        '[shopAssociation]' => '[shopIds]',
+        '[active]' => '[enabled]',
+    ];
+}

--- a/src/ApiPlatform/Resources/Language/LanguageForEditing.php
+++ b/src/ApiPlatform/Resources/Language/LanguageForEditing.php
@@ -43,7 +43,7 @@ use Symfony\Component\HttpFoundation\Response;
         LanguageNotFoundException::class => Response::HTTP_NOT_FOUND,
     ],
 )]
-class Language
+class LanguageForEditing
 {
     #[ApiProperty(identifier: true)]
     public int $languageId;

--- a/src/ApiPlatform/Resources/Language/LanguageForEditing.php
+++ b/src/ApiPlatform/Resources/Language/LanguageForEditing.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSGet(
-            uriTemplate: '/languages/{languageId}',
+            uriTemplate: '/languages/{languageId}/details',
             requirements: ['languageId' => '\d+'],
             CQRSQuery: GetLanguageForEditing::class,
             scopes: ['language_read'],

--- a/tests/Integration/ApiPlatform/LanguageEndpointTest.php
+++ b/tests/Integration/ApiPlatform/LanguageEndpointTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class LanguageEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['language_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get language endpoint' => ['GET', '/languages/1'];
+    }
+
+    public function testGetLanguage(): void
+    {
+        $result = $this->getItem('/languages/1', ['language_read']);
+
+        $this->assertArrayHasKey('languageId', $result);
+        $this->assertSame(1, $result['languageId']);
+        $this->assertArrayHasKey('name', $result);
+        $this->assertIsString($result['name']);
+        $this->assertArrayHasKey('isoCode', $result);
+        $this->assertIsString($result['isoCode']);
+        $this->assertArrayHasKey('tagIETF', $result);
+        $this->assertIsString($result['tagIETF']);
+        $this->assertArrayHasKey('locale', $result);
+        $this->assertIsString($result['locale']);
+        $this->assertArrayHasKey('shortDateFormat', $result);
+        $this->assertIsString($result['shortDateFormat']);
+        $this->assertArrayHasKey('fullDateFormat', $result);
+        $this->assertIsString($result['fullDateFormat']);
+        $this->assertArrayHasKey('rtl', $result);
+        $this->assertIsBool($result['rtl']);
+        $this->assertArrayHasKey('enabled', $result);
+        $this->assertIsBool($result['enabled']);
+        $this->assertArrayHasKey('shopIds', $result);
+        $this->assertIsArray($result['shopIds']);
+    }
+
+    public function testGetUnknownLanguageReturnsNotFound(): void
+    {
+        $this->requestApi(
+            'GET',
+            '/languages/999999',
+            null,
+            ['language_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}

--- a/tests/Integration/ApiPlatform/LanguageEndpointTest.php
+++ b/tests/Integration/ApiPlatform/LanguageEndpointTest.php
@@ -34,12 +34,12 @@ class LanguageEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'get language endpoint' => ['GET', '/languages/1'];
+        yield 'get language endpoint' => ['GET', '/languages/1/details'];
     }
 
     public function testGetLanguage(): void
     {
-        $result = $this->getItem('/languages/1', ['language_read']);
+        $result = $this->getItem('/languages/1/details', ['language_read']);
 
         $this->assertArrayHasKey('languageId', $result);
         $this->assertSame(1, $result['languageId']);
@@ -67,7 +67,7 @@ class LanguageEndpointTest extends ApiTestCase
     {
         $this->requestApi(
             'GET',
-            '/languages/999999',
+            '/languages/999999/details',
             null,
             ['language_read'],
             Response::HTTP_NOT_FOUND


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds \`GET /languages/{languageId}\` using \`CQRSGet\` with \`GetLanguageForEditing\` — a mono-argument Query returning the editable Language shape. Includes integration tests (scope protection, happy path with type assertions on all 10 fields, unknown-id → 404). |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run \`composer phpunit-integration\`; new \`LanguageEndpointTest\` covers scope protection, GET happy path, unknown-id 404. |

Endpoint added:
- \`GET /languages/{languageId}\` — CQRS mapping \`shopAssociation → shopIds\`, \`active → enabled\`; \`is\`-prefix and boolean-field Rector conventions applied.

Note: PR #178 previously bundled Language read + write; it was closed. This scope-limited GET picks up the read half only, following the pattern of the recently landed simple read endpoints.