### PR TITLE
Add GetProductIsEnabled Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductIsEnabled.php
+++ b/src/ApiPlatform/Resources/Product/ProductIsEnabled.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Query\GetProductIsEnabled;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/is-enabled',
+            requirements: ['productId' => '\d+'],
+            CQRSQuery: GetProductIsEnabled::class,
+            CQRSQueryMapping: [
+                '[_queryResult]' => '[enabled]',
+            ],
+            scopes: ['product_read'],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductIsEnabled
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    public bool $enabled;
+}

--- a/src/ApiPlatform/Resources/Product/ProductIsEnabled.php
+++ b/src/ApiPlatform/Resources/Product/ProductIsEnabled.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSGet(
-            uriTemplate: '/products/{productId}/is-enabled',
+            uriTemplate: '/products/{productId}/enable-status',
             requirements: ['productId' => '\d+'],
             CQRSQuery: GetProductIsEnabled::class,
             CQRSQueryMapping: [

--- a/src/ApiPlatform/Resources/Product/ProductIsEnabled.php
+++ b/src/ApiPlatform/Resources/Product/ProductIsEnabled.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[ApiResource(
     operations: [
         new CQRSGet(
-            uriTemplate: '/products/{productId}/enable-status',
+            uriTemplate: '/products/{productId}/status',
             requirements: ['productId' => '\d+'],
             CQRSQuery: GetProductIsEnabled::class,
             CQRSQueryMapping: [

--- a/tests/Integration/ApiPlatform/ProductIsEnabledEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductIsEnabledEndpointTest.php
@@ -34,7 +34,7 @@ class ProductIsEnabledEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'get product is-enabled endpoint' => ['GET', '/products/1/is-enabled'];
+        yield 'get product is-enabled endpoint' => ['GET', '/products/1/enable-status'];
     }
 
     public function testGetProductIsEnabled(): void
@@ -43,7 +43,7 @@ class ProductIsEnabledEndpointTest extends ApiTestCase
             'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
         );
 
-        $result = $this->getItem('/products/' . $productId . '/is-enabled', ['product_read']);
+        $result = $this->getItem('/products/' . $productId . '/enable-status', ['product_read']);
 
         $this->assertArrayHasKey('productId', $result);
         $this->assertSame($productId, $result['productId']);
@@ -55,7 +55,7 @@ class ProductIsEnabledEndpointTest extends ApiTestCase
     {
         $this->requestApi(
             'GET',
-            '/products/999999/is-enabled',
+            '/products/999999/enable-status',
             null,
             ['product_read'],
             Response::HTTP_NOT_FOUND

--- a/tests/Integration/ApiPlatform/ProductIsEnabledEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductIsEnabledEndpointTest.php
@@ -34,7 +34,7 @@ class ProductIsEnabledEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'get product is-enabled endpoint' => ['GET', '/products/1/enable-status'];
+        yield 'get product is-enabled endpoint' => ['GET', '/products/1/status'];
     }
 
     public function testGetProductIsEnabled(): void
@@ -43,7 +43,7 @@ class ProductIsEnabledEndpointTest extends ApiTestCase
             'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
         );
 
-        $result = $this->getItem('/products/' . $productId . '/enable-status', ['product_read']);
+        $result = $this->getItem('/products/' . $productId . '/status', ['product_read']);
 
         $this->assertArrayHasKey('productId', $result);
         $this->assertSame($productId, $result['productId']);
@@ -55,7 +55,7 @@ class ProductIsEnabledEndpointTest extends ApiTestCase
     {
         $this->requestApi(
             'GET',
-            '/products/999999/enable-status',
+            '/products/999999/status',
             null,
             ['product_read'],
             Response::HTTP_NOT_FOUND

--- a/tests/Integration/ApiPlatform/ProductIsEnabledEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductIsEnabledEndpointTest.php
@@ -48,17 +48,11 @@ class ProductIsEnabledEndpointTest extends ApiTestCase
         $this->assertArrayHasKey('productId', $result);
         $this->assertSame($productId, $result['productId']);
         $this->assertArrayHasKey('enabled', $result);
-        $this->assertIsBool($result['enabled']);
+        $this->assertTrue($result['enabled']);
     }
 
     public function testGetUnknownProductReturnsNotFound(): void
     {
-        $this->requestApi(
-            'GET',
-            '/products/999999/status',
-            null,
-            ['product_read'],
-            Response::HTTP_NOT_FOUND
-        );
+        $this->getItem('/products/999999/status', ['product_read'], Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Integration/ApiPlatform/ProductIsEnabledEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductIsEnabledEndpointTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class ProductIsEnabledEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get product is-enabled endpoint' => ['GET', '/products/1/is-enabled'];
+    }
+
+    public function testGetProductIsEnabled(): void
+    {
+        $productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
+        );
+
+        $result = $this->getItem('/products/' . $productId . '/is-enabled', ['product_read']);
+
+        $this->assertArrayHasKey('productId', $result);
+        $this->assertSame($productId, $result['productId']);
+        $this->assertArrayHasKey('enabled', $result);
+        $this->assertIsBool($result['enabled']);
+    }
+
+    public function testGetUnknownProductReturnsNotFound(): void
+    {
+        $this->requestApi(
+            'GET',
+            '/products/999999/is-enabled',
+            null,
+            ['product_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `GET /products/{productId}/status` using `CQRSGet` with `GetProductIsEnabled`. The bool return is exposed via the `[_queryResult]` scalar-wrap mapping as `{enabled: bool}`. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; new `ProductIsEnabledEndpointTest` covers scope protection, GET happy path, and unknown-id → 404. |

Endpoint added:
- `GET /products/{productId}/status` — bool scalar-wrapped, `ProductNotFoundException → 404`.

Same scalar-wrap pattern as `GetShowcaseCardIsClosed` on `ShowcaseCard` (`[_queryResult]` → property).