### PR TITLE
Add GetProductSupplierOptions Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductSupplierOptions.php
+++ b/src/ApiPlatform/Resources/Product/ProductSupplierOptions.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Query\GetProductSupplierOptions as GetProductSupplierOptionsQuery;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/products/{productId}/supplier-options',
+            requirements: ['productId' => '\d+'],
+            CQRSQuery: GetProductSupplierOptionsQuery::class,
+            scopes: ['product_read'],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductSupplierOptions
+{
+    #[ApiProperty(identifier: true)]
+    public int $productId;
+
+    public int $defaultSupplierId;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer']])]
+    public array $supplierIds;
+
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'productSupplierId' => ['type' => 'integer'],
+                'productId' => ['type' => 'integer'],
+                'supplierId' => ['type' => 'integer'],
+                'supplierName' => ['type' => 'string'],
+                'reference' => ['type' => 'string'],
+                'priceTaxExcluded' => ['type' => 'string'],
+                'currencyId' => ['type' => 'integer'],
+                'combinationId' => ['type' => 'integer'],
+            ],
+        ],
+    ])]
+    public array $productSuppliers;
+}

--- a/tests/Integration/ApiPlatform/ProductSupplierOptionsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductSupplierOptionsEndpointTest.php
@@ -22,14 +22,45 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\SetSuppliersCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Supplier\Command\UpdateProductSuppliersCommand;
 use Symfony\Component\HttpFoundation\Response;
 
 class ProductSupplierOptionsEndpointTest extends ApiTestCase
 {
+    private const SEEDED_REFERENCE = 'INT-TEST-SUPPLIER-REF';
+    private const SEEDED_PRICE = '12.345';
+    private const SEEDED_CURRENCY_ID = 1;
+
+    private static int $seededProductId;
+    private static int $seededSupplierId;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::createApiClient(['product_read']);
+
+        // A standard (non-combinations) product is required, otherwise the query handler
+        // short-circuits productSuppliers to an empty array (see GetProductSupplierOptionsHandler).
+        self::$seededProductId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . "product` WHERE `product_type` = 'standard' ORDER BY `id_product` ASC"
+        );
+        self::$seededSupplierId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_supplier` FROM `' . _DB_PREFIX_ . 'supplier` ORDER BY `id_supplier` ASC'
+        );
+
+        if (self::$seededProductId === 0 || self::$seededSupplierId === 0) {
+            self::fail('Demo data must ship at least one product and one supplier for this test.');
+        }
+
+        $commandBus = static::createClient()->getContainer()->get('prestashop.core.command_bus');
+        $commandBus->handle(new SetSuppliersCommand(self::$seededProductId, [self::$seededSupplierId]));
+        $commandBus->handle(new UpdateProductSuppliersCommand(self::$seededProductId, [[
+            'supplier_id' => self::$seededSupplierId,
+            'currency_id' => self::SEEDED_CURRENCY_ID,
+            'reference' => self::SEEDED_REFERENCE,
+            'price_tax_excluded' => self::SEEDED_PRICE,
+        ]]));
     }
 
     public static function getProtectedEndpoints(): iterable
@@ -39,20 +70,27 @@ class ProductSupplierOptionsEndpointTest extends ApiTestCase
 
     public function testGetProductSupplierOptions(): void
     {
-        $productId = (int) \Db::getInstance()->getValue(
-            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
-        );
+        $result = $this->getItem('/products/' . self::$seededProductId . '/supplier-options', ['product_read']);
 
-        $result = $this->getItem('/products/' . $productId . '/supplier-options', ['product_read']);
+        $this->assertSame(self::$seededProductId, $result['productId']);
+        $this->assertSame(self::$seededSupplierId, $result['defaultSupplierId']);
+        $this->assertSame([self::$seededSupplierId], $result['supplierIds']);
 
-        $this->assertArrayHasKey('productId', $result);
-        $this->assertSame($productId, $result['productId']);
-        $this->assertArrayHasKey('defaultSupplierId', $result);
-        $this->assertIsInt($result['defaultSupplierId']);
-        $this->assertArrayHasKey('supplierIds', $result);
-        $this->assertIsArray($result['supplierIds']);
-        $this->assertArrayHasKey('productSuppliers', $result);
         $this->assertIsArray($result['productSuppliers']);
+        $this->assertCount(1, $result['productSuppliers']);
+
+        $productSupplier = $result['productSuppliers'][0];
+        $this->assertIsInt($productSupplier['productSupplierId']);
+        $this->assertGreaterThan(0, $productSupplier['productSupplierId']);
+        $this->assertSame(self::$seededProductId, $productSupplier['productId']);
+        $this->assertSame(self::$seededSupplierId, $productSupplier['supplierId']);
+        $this->assertIsString($productSupplier['supplierName']);
+        $this->assertNotSame('', $productSupplier['supplierName']);
+        $this->assertSame(self::SEEDED_REFERENCE, $productSupplier['reference']);
+        $this->assertIsString($productSupplier['priceTaxExcluded']);
+        $this->assertSame((float) self::SEEDED_PRICE, (float) $productSupplier['priceTaxExcluded']);
+        $this->assertSame(self::SEEDED_CURRENCY_ID, $productSupplier['currencyId']);
+        $this->assertSame(0, $productSupplier['combinationId']);
     }
 
     public function testGetUnknownProductReturnsNotFound(): void

--- a/tests/Integration/ApiPlatform/ProductSupplierOptionsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductSupplierOptionsEndpointTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class ProductSupplierOptionsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get product supplier options endpoint' => ['GET', '/products/1/supplier-options'];
+    }
+
+    public function testGetProductSupplierOptions(): void
+    {
+        $productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
+        );
+
+        $result = $this->getItem('/products/' . $productId . '/supplier-options', ['product_read']);
+
+        $this->assertArrayHasKey('productId', $result);
+        $this->assertSame($productId, $result['productId']);
+        $this->assertArrayHasKey('defaultSupplierId', $result);
+        $this->assertIsInt($result['defaultSupplierId']);
+        $this->assertArrayHasKey('supplierIds', $result);
+        $this->assertIsArray($result['supplierIds']);
+        $this->assertArrayHasKey('productSuppliers', $result);
+        $this->assertIsArray($result['productSuppliers']);
+    }
+
+    public function testGetUnknownProductReturnsNotFound(): void
+    {
+        $this->requestApi(
+            'GET',
+            '/products/999999/supplier-options',
+            null,
+            ['product_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `GET /products/{productId}/supplier-options` using `CQRSGet` with `GetProductSupplierOptions`. Response shape: `defaultSupplierId`, `supplierIds[]`, and the `productSuppliers[]` list detailing per-supplier reference/price/currency/combination. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; new `ProductSupplierOptionsEndpointTest` covers scope protection, GET happy path, and unknown-id → 404. |

Endpoint added:
- `GET /products/{productId}/supplier-options` — mono-arg productId, `ProductNotFoundException → 404`.