### PR TITLE
Add GetShopProductImages Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ShopProductImages.php
+++ b/src/ApiPlatform/Resources/Product/ShopProductImages.php
@@ -43,7 +43,6 @@ use Symfony\Component\HttpFoundation\Response;
 )]
 class ShopProductImages
 {
-    #[ApiProperty(identifier: true)]
     public int $shopId;
 
     #[ApiProperty(openapiContext: [

--- a/src/ApiPlatform/Resources/Product/ShopProductImages.php
+++ b/src/ApiPlatform/Resources/Product/ShopProductImages.php
@@ -24,10 +24,8 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
-use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Query\GetShopProductImages as GetShopProductImagesQuery;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
-use Symfony\Component\HttpFoundation\Response;
 
 #[ApiResource(
     operations: [
@@ -36,9 +34,6 @@ use Symfony\Component\HttpFoundation\Response;
             CQRSQuery: GetShopProductImagesQuery::class,
             scopes: ['product_read'],
         ),
-    ],
-    exceptionToStatus: [
-        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
     ],
 )]
 class ShopProductImages

--- a/src/ApiPlatform/Resources/Product/ShopProductImages.php
+++ b/src/ApiPlatform/Resources/Product/ShopProductImages.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\Query\GetShopProductImages as GetShopProductImagesQuery;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/products/{productId}/shop-images',
+            CQRSQuery: GetShopProductImagesQuery::class,
+            scopes: ['product_read'],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ShopProductImages
+{
+    #[ApiProperty(identifier: true)]
+    public int $shopId;
+
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'imageId' => ['type' => 'integer'],
+                'cover' => ['type' => 'boolean'],
+            ],
+        ],
+    ])]
+    public array $productImages;
+}

--- a/tests/Integration/ApiPlatform/ShopProductImagesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ShopProductImagesEndpointTest.php
@@ -38,7 +38,7 @@ class ShopProductImagesEndpointTest extends ApiTestCase
     public function testListShopProductImages(): void
     {
         $productId = (int) \Db::getInstance()->getValue(
-            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'image_shop` ORDER BY `id_product` ASC LIMIT 1'
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'image_shop` ORDER BY `id_product` ASC'
         );
         $this->assertGreaterThan(0, $productId, 'Fixture data must contain at least one product with images.');
 

--- a/tests/Integration/ApiPlatform/ShopProductImagesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ShopProductImagesEndpointTest.php
@@ -22,8 +22,6 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
-use Symfony\Component\HttpFoundation\Response;
-
 class ShopProductImagesEndpointTest extends ApiTestCase
 {
     public static function setUpBeforeClass(): void
@@ -43,7 +41,7 @@ class ShopProductImagesEndpointTest extends ApiTestCase
             'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
         );
 
-        $result = $this->listItems('/products/' . $productId . '/shop-images', ['product_read']);
+        $result = $this->getItem('/products/' . $productId . '/shop-images', ['product_read']);
 
         $this->assertIsArray($result);
         foreach ($result as $row) {
@@ -52,16 +50,5 @@ class ShopProductImagesEndpointTest extends ApiTestCase
             $this->assertArrayHasKey('productImages', $row);
             $this->assertIsArray($row['productImages']);
         }
-    }
-
-    public function testListUnknownProductReturnsNotFound(): void
-    {
-        $this->requestApi(
-            'GET',
-            '/products/999999/shop-images',
-            null,
-            ['product_read'],
-            Response::HTTP_NOT_FOUND
-        );
     }
 }

--- a/tests/Integration/ApiPlatform/ShopProductImagesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ShopProductImagesEndpointTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class ShopProductImagesEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list shop product images endpoint' => ['GET', '/products/1/shop-images'];
+    }
+
+    public function testListShopProductImages(): void
+    {
+        $productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
+        );
+
+        $result = $this->listItems('/products/' . $productId . '/shop-images', ['product_read']);
+
+        $this->assertIsArray($result);
+        foreach ($result as $row) {
+            $this->assertArrayHasKey('shopId', $row);
+            $this->assertIsInt($row['shopId']);
+            $this->assertArrayHasKey('productImages', $row);
+            $this->assertIsArray($row['productImages']);
+        }
+    }
+
+    public function testListUnknownProductReturnsNotFound(): void
+    {
+        $this->requestApi(
+            'GET',
+            '/products/999999/shop-images',
+            null,
+            ['product_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}

--- a/tests/Integration/ApiPlatform/ShopProductImagesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ShopProductImagesEndpointTest.php
@@ -38,17 +38,49 @@ class ShopProductImagesEndpointTest extends ApiTestCase
     public function testListShopProductImages(): void
     {
         $productId = (int) \Db::getInstance()->getValue(
-            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'image_shop` ORDER BY `id_product` ASC LIMIT 1'
         );
+        $this->assertGreaterThan(0, $productId, 'Fixture data must contain at least one product with images.');
+
+        $expectedByShop = [];
+        $rows = \Db::getInstance()->executeS(
+            'SELECT `id_shop`, `id_image`, `cover` FROM `' . _DB_PREFIX_ . 'image_shop`'
+            . ' WHERE `id_product` = ' . $productId
+            . ' ORDER BY `id_shop` ASC, `id_image` ASC'
+        );
+        foreach ($rows as $row) {
+            $shopId = (int) $row['id_shop'];
+            $expectedByShop[$shopId][] = [
+                'imageId' => (int) $row['id_image'],
+                'cover' => null !== $row['cover'] && (bool) $row['cover'],
+            ];
+        }
 
         $result = $this->getItem('/products/' . $productId . '/shop-images', ['product_read']);
 
         $this->assertIsArray($result);
-        foreach ($result as $row) {
-            $this->assertArrayHasKey('shopId', $row);
-            $this->assertIsInt($row['shopId']);
-            $this->assertArrayHasKey('productImages', $row);
-            $this->assertIsArray($row['productImages']);
+        $this->assertCount(count($expectedByShop), $result);
+
+        $actualByShop = [];
+        foreach ($result as $entry) {
+            $this->assertArrayHasKey('shopId', $entry);
+            $this->assertIsInt($entry['shopId']);
+            $this->assertArrayHasKey('productImages', $entry);
+            $this->assertIsArray($entry['productImages']);
+
+            $images = [];
+            foreach ($entry['productImages'] as $image) {
+                $this->assertArrayHasKey('imageId', $image);
+                $this->assertIsInt($image['imageId']);
+                $this->assertArrayHasKey('cover', $image);
+                $this->assertIsBool($image['cover']);
+                $images[] = ['imageId' => $image['imageId'], 'cover' => $image['cover']];
+            }
+            usort($images, static fn ($a, $b) => $a['imageId'] <=> $b['imageId']);
+            $actualByShop[$entry['shopId']] = $images;
         }
+        ksort($actualByShop);
+
+        $this->assertSame($expectedByShop, $actualByShop);
     }
 }


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `GET /products/{productId}/shop-images` using `CQRSGetCollection` with `GetShopProductImages`. Returns per-shop image associations: each element = `{shopId, productImages: [{imageId, cover}, ...]}`. Complements the existing `GET /products/{productId}/images` (`ProductImageList`, single-shop) with the multi-shop view. Unknown product id returns `200 []` (no exception), matching the underlying all-shops query. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; `ShopProductImagesEndpointTest` covers scope protection and the list happy path, asserting the exact per-shop `{imageId, cover}` grouping against the fixture data (`image_shop` table). |