### PR TITLE
Add GetCreditSlipIdsByDateRange Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/CreditSlip/CreditSlipIdList.php
+++ b/src/ApiPlatform/Resources/CreditSlip/CreditSlipIdList.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CreditSlip;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\CreditSlip\Exception\CreditSlipNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\CreditSlip\Query\GetCreditSlipIdsByDateRange;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/credit-slips/ids',
+            CQRSQuery: GetCreditSlipIdsByDateRange::class,
+            scopes: ['credit_slip_read'],
+            CQRSQueryMapping: [
+                '[@index][creditSlipId]' => '[creditSlipIds][@index]',
+            ],
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'dateTimeFrom',
+                    required: true,
+                    description: 'Start date (Y-m-d)'
+                ),
+                new QueryParameter(
+                    key: 'dateTimeTo',
+                    required: true,
+                    description: 'End date (Y-m-d)'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    ['name' => 'dateTimeFrom', 'in' => 'query', 'required' => true, 'schema' => ['type' => 'string', 'format' => 'date']],
+                    ['name' => 'dateTimeTo', 'in' => 'query', 'required' => true, 'schema' => ['type' => 'string', 'format' => 'date']],
+                ],
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CreditSlipNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CreditSlipIdList
+{
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'description' => 'List of credit slip IDs in the date range',
+        'items' => ['type' => 'integer'],
+    ])]
+    public array $creditSlipIds;
+}

--- a/tests/Integration/ApiPlatform/CreditSlipIdListEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CreditSlipIdListEndpointTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class CreditSlipIdListEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['credit_slip_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list credit slip ids endpoint' => ['GET', '/credit-slips/ids?dateTimeFrom=2000-01-01&dateTimeTo=2099-12-31'];
+    }
+
+    public function testEmptyRangeReturnsNotFound(): void
+    {
+        // The domain query throws CreditSlipNotFoundException on empty
+        // date ranges; that maps to a 404 response.
+        $this->requestApi(
+            'GET',
+            '/credit-slips/ids?dateTimeFrom=1900-01-01&dateTimeTo=1900-01-02',
+            null,
+            ['credit_slip_read'],
+            Response::HTTP_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `GET /credit-slips/ids?dateTimeFrom=…&dateTimeTo=…` using `CQRSGet` with `GetCreditSlipIdsByDateRange`. Returns `{creditSlipIds: [int, ...]}` for the requested inclusive range. **Note:** the underlying core query throws `CreditSlipNotFoundException` on empty results (rather than returning an empty list). That behavior is preserved and mapped to HTTP 404. A follow-up core change could later switch to empty-list semantics for a nicer UX. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; new `CreditSlipIdListEndpointTest` covers scope protection and the empty-range-→-404 path. |

Uses the `CombinationIdList` pattern (`[@index][<vo-ctor-param>]` → `[fieldName][@index]`) to flatten the array-of-VO result into a plain int array.