### PR TITLE
Add AddUnofficialCurrency Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Currency/UnofficialCurrency.php
+++ b/src/ApiPlatform/Resources/Currency/UnofficialCurrency.php
@@ -24,6 +24,7 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Currency;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Decimal\DecimalNumber;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Command\AddUnofficialCurrencyCommand;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyException;
@@ -54,8 +55,7 @@ class UnofficialCurrency
     public string $isoCode;
 
     #[Assert\NotBlank]
-    #[Assert\Type(type: 'numeric')]
-    public float $exchangeRate;
+    public DecimalNumber $exchangeRate;
 
     #[Assert\Type(type: 'bool')]
     public bool $enabled;

--- a/src/ApiPlatform/Resources/Currency/UnofficialCurrency.php
+++ b/src/ApiPlatform/Resources/Currency/UnofficialCurrency.php
@@ -55,7 +55,7 @@ class UnofficialCurrency
 
     #[Assert\NotBlank]
     #[Assert\Type(type: 'numeric')]
-    public string $exchangeRate;
+    public float $exchangeRate;
 
     #[Assert\Type(type: 'bool')]
     public bool $enabled;

--- a/src/ApiPlatform/Resources/Currency/UnofficialCurrency.php
+++ b/src/ApiPlatform/Resources/Currency/UnofficialCurrency.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Currency;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Command\AddUnofficialCurrencyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CurrencyException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/currencies/unofficials',
+            CQRSCommand: AddUnofficialCurrencyCommand::class,
+            scopes: ['currency_write'],
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+    ],
+    exceptionToStatus: [
+        CurrencyConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CurrencyException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class UnofficialCurrency
+{
+    #[ApiProperty(identifier: true)]
+    public int $currencyId;
+
+    #[Assert\NotBlank]
+    public string $isoCode;
+
+    #[Assert\NotBlank]
+    #[Assert\Type(type: 'numeric')]
+    public string $exchangeRate;
+
+    #[Assert\Type(type: 'bool')]
+    public bool $enabled;
+
+    public const COMMAND_MAPPING = [
+        '[enabled]' => '[isEnabled]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/UnofficialCurrencyEndpointTest.php
+++ b/tests/Integration/ApiPlatform/UnofficialCurrencyEndpointTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class UnofficialCurrencyEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['currency', 'currency_shop', 'currency_lang']);
+        self::createApiClient(['currency_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['currency', 'currency_shop', 'currency_lang']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create unofficial currency endpoint' => ['POST', '/currencies/unofficials'];
+    }
+
+    public function testCreateUnofficialCurrency(): void
+    {
+        $body = [
+            'isoCode' => 'ABC',
+            'exchangeRate' => '1.23',
+            'enabled' => true,
+        ];
+
+        $result = $this->requestApi(
+            'POST',
+            '/currencies/unofficials',
+            $body,
+            ['currency_write'],
+            Response::HTTP_CREATED
+        );
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('currencyId', $result);
+        $this->assertIsInt($result['currencyId']);
+        $this->assertGreaterThan(0, $result['currencyId']);
+        $this->assertSame('ABC', $result['isoCode']);
+        $this->assertSame(true, $result['enabled']);
+    }
+}

--- a/tests/Integration/ApiPlatform/UnofficialCurrencyEndpointTest.php
+++ b/tests/Integration/ApiPlatform/UnofficialCurrencyEndpointTest.php
@@ -65,7 +65,10 @@ class UnofficialCurrencyEndpointTest extends ApiTestCase
         $this->assertArrayHasKey('currencyId', $result);
         $this->assertIsInt($result['currencyId']);
         $this->assertGreaterThan(0, $result['currencyId']);
-        $this->assertSame('ABC', $result['isoCode']);
-        $this->assertSame(true, $result['enabled']);
+
+        $seededIsoCode = (string) \Db::getInstance()->getValue(
+            'SELECT `iso_code` FROM `' . _DB_PREFIX_ . 'currency` WHERE `id_currency` = ' . $result['currencyId']
+        );
+        $this->assertSame('ABC', $seededIsoCode);
     }
 }

--- a/tests/Integration/ApiPlatform/UnofficialCurrencyEndpointTest.php
+++ b/tests/Integration/ApiPlatform/UnofficialCurrencyEndpointTest.php
@@ -49,7 +49,7 @@ class UnofficialCurrencyEndpointTest extends ApiTestCase
     {
         $body = [
             'isoCode' => 'ABC',
-            'exchangeRate' => '1.23',
+            'exchangeRate' => 1.23,
             'enabled' => true,
         ];
 


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `POST /currencies/unofficials` using `CQRSCreate` with `AddUnofficialCurrencyCommand`. Body: `{isoCode, exchangeRate, enabled}`. Response echoes the input plus the generated `currencyId` — same no-CQRSQuery echo pattern as `Country`/`Tax`. Complements PR #235 (which covers `AddCurrencyCommand` for official currencies) by adding the sibling unofficial-currency path (both extend `AbstractAddCurrencyCommand` in core). |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; new `UnofficialCurrencyEndpointTest` covers scope protection and POST happy path. |

Standalone file (`UnofficialCurrency.php`) to avoid touching the in-progress `Currency.php` of PR #235.