### PR TITLE
Add WebserviceKey delete + bulk-delete Admin API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/WebserviceKey/BulkWebserviceKeys.php
+++ b/src/ApiPlatform/Resources/WebserviceKey/BulkWebserviceKeys.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\WebserviceKey;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Webservice\Command\BulkDeleteWebserviceKeyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceKeyNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/webservice-keys/bulk-delete',
+            CQRSCommand: BulkDeleteWebserviceKeyCommand::class,
+            scopes: ['webservice_key_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        WebserviceKeyNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkWebserviceKeys
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $webserviceKeyIds;
+}

--- a/src/ApiPlatform/Resources/WebserviceKey/WebserviceKey.php
+++ b/src/ApiPlatform/Resources/WebserviceKey/WebserviceKey.php
@@ -25,11 +25,13 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\WebserviceKey;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Command\AddWebserviceKeyCommand;
+use PrestaShop\PrestaShop\Core\Domain\Webservice\Command\DeleteWebserviceKeyCommand;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Command\EditWebserviceKeyCommand;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Exception\WebserviceKeyNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Webservice\Query\GetWebserviceKeyForEditing;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use PrestaShopBundle\Form\Admin\Type\FormattedTextareaType;
@@ -66,6 +68,12 @@ use Symfony\Component\Validator\Constraints as Assert;
                 '[enabled]' => '[status]',
             ],
             CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/webservice-keys/{webserviceKeyId}',
+            requirements: ['webserviceKeyId' => '\d+'],
+            CQRSCommand: DeleteWebserviceKeyCommand::class,
+            scopes: ['webservice_key_write'],
         ),
     ],
     normalizationContext: ['skip_null_values' => false],

--- a/tests/Integration/ApiPlatform/WebserviceKeyDeleteEndpointTest.php
+++ b/tests/Integration/ApiPlatform/WebserviceKeyDeleteEndpointTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class WebserviceKeyDeleteEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['webservice_key_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['webservice_account', 'webservice_account_shop', 'webservice_permission']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'delete endpoint' => ['DELETE', '/webservice-keys/999999'];
+        yield 'bulk delete endpoint' => ['DELETE', '/webservice-keys/bulk-delete'];
+    }
+
+    public function testDeleteWebserviceKey(): void
+    {
+        $seededId = $this->seedWebserviceKey('a' . str_repeat('0', 31));
+
+        $this->requestApi(
+            'DELETE',
+            '/webservice-keys/' . $seededId,
+            null,
+            ['webservice_key_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $stillThere = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'webservice_account` WHERE `id_webservice_account` = ' . $seededId
+        );
+        $this->assertSame(0, $stillThere);
+    }
+
+    public function testBulkDeleteWebserviceKeys(): void
+    {
+        $id1 = $this->seedWebserviceKey('b' . str_repeat('0', 31));
+        $id2 = $this->seedWebserviceKey('c' . str_repeat('0', 31));
+
+        $this->requestApi(
+            'DELETE',
+            '/webservice-keys/bulk-delete',
+            ['webserviceKeyIds' => [$id1, $id2]],
+            ['webservice_key_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $stillThere = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'webservice_account` WHERE `id_webservice_account` IN (' . $id1 . ', ' . $id2 . ')'
+        );
+        $this->assertSame(0, $stillThere);
+    }
+
+    private function seedWebserviceKey(string $key): int
+    {
+        \Db::getInstance()->insert('webservice_account', [
+            'key' => $key,
+            'active' => 1,
+            'description' => 'seed for delete test',
+            'class_name' => 'WebserviceRequest',
+        ]);
+
+        return (int) \Db::getInstance()->Insert_ID();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Completes the WebserviceKey CRUD. Adds `DELETE /webservice-keys/{webserviceKeyId}` (single) via `DeleteWebserviceKeyCommand` and `DELETE /webservice-keys/bulk-delete` (bulk) via `BulkDeleteWebserviceKeyCommand` — body `{webserviceKeyIds: [int, ...]}`. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; new `WebserviceKeyDeleteEndpointTest` seeds rows via `\Db::insert('webservice_account', ...)`, exercises DELETE + bulk-DELETE, verifies row-count = 0. |

Single-delete op is added to the existing `WebserviceKey.php` (which already declares `CQRSCreate` / `CQRSGet` / `CQRSPartialUpdate`); bulk op lives in a separate `BulkWebserviceKeys.php` resource following the `BulkDeleteCategories` precedent.