### PR TITLE
Add GetProductStockMovements Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductStockMovements.php
+++ b/src/ApiPlatform/Resources/Product/ProductStockMovements.php
@@ -24,6 +24,8 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\StockAvailableNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Query\GetProductStockMovements;
@@ -38,6 +40,46 @@ use Symfony\Component\HttpFoundation\Response;
             scopes: ['product_read'],
             CQRSQueryMapping: [
                 '[_context][shopId]' => '[shopId]',
+            ],
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'offset',
+                    schema: ['type' => 'integer', 'minimum' => 0, 'default' => 0],
+                    required: false,
+                    description: 'Number of movements to skip (for pagination).'
+                ),
+                new QueryParameter(
+                    key: 'limit',
+                    schema: ['type' => 'integer', 'minimum' => 0, 'default' => GetProductStockMovements::DEFAULT_LIMIT],
+                    required: false,
+                    description: 'Maximum number of movements to return.'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    [
+                        'name' => 'offset',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'integer',
+                            'minimum' => 0,
+                            'default' => 0,
+                        ],
+                        'description' => 'Number of movements to skip (for pagination).',
+                    ],
+                    [
+                        'name' => 'limit',
+                        'in' => 'query',
+                        'required' => false,
+                        'schema' => [
+                            'type' => 'integer',
+                            'minimum' => 0,
+                            'default' => GetProductStockMovements::DEFAULT_LIMIT,
+                        ],
+                        'description' => 'Maximum number of movements to return.',
+                    ],
+                ],
             ],
         ),
     ],

--- a/src/ApiPlatform/Resources/Product/ProductStockMovements.php
+++ b/src/ApiPlatform/Resources/Product/ProductStockMovements.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Query\GetProductStockMovements;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/products/{productId}/stock-movements',
+            CQRSQuery: GetProductStockMovements::class,
+            scopes: ['product_read'],
+            CQRSQueryMapping: [
+                '[_context][shopId]' => '[shopId]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductStockMovements
+{
+    public string $type;
+
+    public bool $edition;
+
+    public bool $fromOrders;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer']])]
+    public array $stockMovementIds;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer']])]
+    public array $stockIds;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer']])]
+    public array $orderIds;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer']])]
+    public array $employeeIds;
+
+    public ?string $employeeName = null;
+
+    public int $deltaQuantity;
+
+    #[ApiProperty(openapiContext: ['type' => 'object', 'additionalProperties' => ['type' => 'string', 'format' => 'date-time']])]
+    public array $dates;
+}

--- a/src/ApiPlatform/Resources/Product/ProductStockMovements.php
+++ b/src/ApiPlatform/Resources/Product/ProductStockMovements.php
@@ -25,6 +25,7 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Exception\StockAvailableNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Query\GetProductStockMovements;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
 use Symfony\Component\HttpFoundation\Response;
@@ -42,6 +43,7 @@ use Symfony\Component\HttpFoundation\Response;
     ],
     exceptionToStatus: [
         ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        StockAvailableNotFoundException::class => Response::HTTP_NOT_FOUND,
     ],
 )]
 class ProductStockMovements

--- a/src/ApiPlatform/Resources/Product/ProductStockMovements.php
+++ b/src/ApiPlatform/Resources/Product/ProductStockMovements.php
@@ -44,13 +44,13 @@ use Symfony\Component\HttpFoundation\Response;
             parameters: new Parameters([
                 new QueryParameter(
                     key: 'offset',
-                    schema: ['type' => 'integer', 'minimum' => 0, 'default' => 0],
+                    schema: ['type' => 'integer'],
                     required: false,
                     description: 'Number of movements to skip (for pagination).'
                 ),
                 new QueryParameter(
                     key: 'limit',
-                    schema: ['type' => 'integer', 'minimum' => 0, 'default' => GetProductStockMovements::DEFAULT_LIMIT],
+                    schema: ['type' => 'integer'],
                     required: false,
                     description: 'Maximum number of movements to return.'
                 ),

--- a/tests/Integration/ApiPlatform/ProductStockMovementsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductStockMovementsEndpointTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ProductStockMovementsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list product stock movements endpoint' => ['GET', '/products/1/stock-movements'];
+    }
+
+    public function testListProductStockMovements(): void
+    {
+        $productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
+        );
+
+        $result = $this->getItem('/products/' . $productId . '/stock-movements', ['product_read']);
+
+        $this->assertIsArray($result);
+        foreach ($result as $row) {
+            $this->assertArrayHasKey('type', $row);
+            $this->assertArrayHasKey('deltaQuantity', $row);
+            $this->assertIsInt($row['deltaQuantity']);
+        }
+    }
+}

--- a/tests/Integration/ApiPlatform/ProductStockMovementsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductStockMovementsEndpointTest.php
@@ -79,6 +79,36 @@ class ProductStockMovementsEndpointTest extends ApiTestCase
         $this->assertArrayHasKey('add', $movement['dates']);
     }
 
+    public function testListProductStockMovementsRespectsOffsetAndLimit(): void
+    {
+        $productId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
+        );
+
+        \Context::getContext()->employee = new \Employee(1);
+
+        // Seed three additional movements so we have enough rows to page through.
+        $commandBus = static::createClient()->getContainer()->get('prestashop.core.command_bus');
+        foreach ([1, 2, 3] as $delta) {
+            $command = new UpdateProductStockAvailableCommand($productId, ShopConstraint::shop(1));
+            $command->setDeltaQuantity($delta);
+            $commandBus->handle($command);
+        }
+
+        $capped = $this->getItem('/products/' . $productId . '/stock-movements?limit=2', ['product_read']);
+        $this->assertIsArray($capped);
+        $this->assertCount(2, $capped, 'limit=2 should return at most 2 movements');
+
+        $offset = $this->getItem('/products/' . $productId . '/stock-movements?offset=1&limit=2', ['product_read']);
+        $this->assertIsArray($offset);
+        $this->assertCount(2, $offset);
+        $this->assertNotEquals(
+            $capped[0]['stockMovementIds'],
+            $offset[0]['stockMovementIds'],
+            'offset=1 should skip the first movement returned by offset=0'
+        );
+    }
+
     public function testListProductStockMovementsReturns404ForUnknownProduct(): void
     {
         $unknownProductId = 1 + (int) \Db::getInstance()->getValue(

--- a/tests/Integration/ApiPlatform/ProductStockMovementsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductStockMovementsEndpointTest.php
@@ -22,6 +22,11 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\Command\UpdateProductStockAvailableCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Stock\QueryResult\StockMovement;
+use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\HttpFoundation\Response;
+
 class ProductStockMovementsEndpointTest extends ApiTestCase
 {
     public static function setUpBeforeClass(): void
@@ -41,13 +46,40 @@ class ProductStockMovementsEndpointTest extends ApiTestCase
             'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
         );
 
+        // Ensure the product has a known stock movement to assert against.
+        $command = new UpdateProductStockAvailableCommand($productId, ShopConstraint::shop(1));
+        $command->setDeltaQuantity(7);
+        static::createClient()->getContainer()->get('prestashop.core.command_bus')->handle($command);
+
         $result = $this->getItem('/products/' . $productId . '/stock-movements', ['product_read']);
 
         $this->assertIsArray($result);
-        foreach ($result as $row) {
-            $this->assertArrayHasKey('type', $row);
-            $this->assertArrayHasKey('deltaQuantity', $row);
-            $this->assertIsInt($row['deltaQuantity']);
-        }
+        $this->assertNotEmpty($result, 'Expected at least one stock movement after applying a delta');
+
+        // Movements are returned most recent first, so the delta we just applied is at [0].
+        $movement = $result[0];
+        $this->assertSame(StockMovement::EDITION_TYPE, $movement['type']);
+        $this->assertTrue($movement['edition']);
+        $this->assertFalse($movement['fromOrders']);
+        $this->assertSame(7, $movement['deltaQuantity']);
+        $this->assertIsArray($movement['stockMovementIds']);
+        $this->assertNotEmpty($movement['stockMovementIds']);
+        $this->assertIsInt($movement['stockMovementIds'][0]);
+        $this->assertIsArray($movement['stockIds']);
+        $this->assertNotEmpty($movement['stockIds']);
+        $this->assertIsInt($movement['stockIds'][0]);
+        $this->assertIsArray($movement['orderIds']);
+        $this->assertIsArray($movement['employeeIds']);
+        $this->assertIsArray($movement['dates']);
+        $this->assertArrayHasKey('add', $movement['dates']);
+    }
+
+    public function testListProductStockMovementsReturns404ForUnknownProduct(): void
+    {
+        $unknownProductId = 1 + (int) \Db::getInstance()->getValue(
+            'SELECT MAX(`id_product`) FROM `' . _DB_PREFIX_ . 'product`'
+        );
+
+        $this->getItem('/products/' . $unknownProductId . '/stock-movements', ['product_read'], Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/Integration/ApiPlatform/ProductStockMovementsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductStockMovementsEndpointTest.php
@@ -46,6 +46,11 @@ class ProductStockMovementsEndpointTest extends ApiTestCase
             'SELECT `id_product` FROM `' . _DB_PREFIX_ . 'product` ORDER BY `id_product` ASC'
         );
 
+        // StockManager::saveMovement() forwards Context::getContext()->employee->id to
+        // StockMvt::setIdEmployee(), which is typed int — a null employee context throws a
+        // TypeError. Pin the default admin employee before seeding the movement.
+        \Context::getContext()->employee = new \Employee(1);
+
         // Ensure the product has a known stock movement to assert against.
         $command = new UpdateProductStockAvailableCommand($productId, ShopConstraint::shop(1));
         $command->setDeltaQuantity(7);


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `GET /products/{productId}/stock-movements` using `CQRSGetCollection` with `GetProductStockMovements`. Items expose `type`, `edition`, `fromOrders`, `stockMovementIds[]`, `stockIds[]`, `orderIds[]`, `employeeIds[]`, `employeeName`, `deltaQuantity`, `dates{}`. Uses `[_context][shopId]` mapping to auto-fill the required shopId from the API client context; offset/limit rely on the query's ctor defaults (0, 5). |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; new `ProductStockMovementsEndpointTest` covers scope protection and the list happy path. |