### PR TITLE
Add CMS redirection helper queries (parent + category-of-page)

### DIFF
--- a/src/ApiPlatform/Resources/CmsPage/CmsPageCategoryForRedirection.php
+++ b/src/ApiPlatform/Resources/CmsPage/CmsPageCategoryForRedirection.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPage;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPage\Query\GetCmsCategoryIdForRedirection;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/cms-pages/{cmsPageId}/category-for-redirection',
+            requirements: ['cmsPageId' => '\d+'],
+            CQRSQuery: GetCmsCategoryIdForRedirection::class,
+            scopes: ['cms_page_read'],
+            CQRSQueryMapping: [
+                '[_queryResult]' => '[cmsPageCategoryId]',
+            ],
+        ),
+    ],
+)]
+class CmsPageCategoryForRedirection
+{
+    #[ApiProperty(identifier: true)]
+    public int $cmsPageId;
+
+    public int $cmsPageCategoryId;
+}

--- a/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryParentForRedirection.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryParentForRedirection.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageParentCategoryIdForRedirection;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}/parent-for-redirection',
+            requirements: ['cmsPageCategoryId' => '\d+'],
+            CQRSQuery: GetCmsPageParentCategoryIdForRedirection::class,
+            scopes: ['cms_page_category_read'],
+            CQRSQueryMapping: [
+                '[_queryResult]' => '[parentId]',
+            ],
+        ),
+    ],
+)]
+class CmsPageCategoryParentForRedirection
+{
+    #[ApiProperty(identifier: true)]
+    public int $cmsPageCategoryId;
+
+    public int $parentId;
+}

--- a/tests/Integration/ApiPlatform/CmsRedirectionQueriesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CmsRedirectionQueriesEndpointTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class CmsRedirectionQueriesEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['cms_page_category_read', 'cms_page_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'cms page category parent-for-redirection' => ['GET', '/cms-page-categories/1/parent-for-redirection'];
+        yield 'cms page category-for-redirection' => ['GET', '/cms-pages/1/category-for-redirection'];
+    }
+
+    public function testGetCmsPageCategoryParent(): void
+    {
+        // ROOT (1) has no parent → handler catches and returns ROOT (1)
+        $result = $this->getItem('/cms-page-categories/1/parent-for-redirection', ['cms_page_category_read']);
+
+        $this->assertArrayHasKey('cmsPageCategoryId', $result);
+        $this->assertSame(1, $result['cmsPageCategoryId']);
+        $this->assertArrayHasKey('parentId', $result);
+        $this->assertIsInt($result['parentId']);
+    }
+
+    public function testGetCmsPageCategoryOfPage(): void
+    {
+        // Unknown page id → handler catches CmsPageException, returns ROOT (1)
+        $result = $this->getItem('/cms-pages/999999/category-for-redirection', ['cms_page_read']);
+
+        $this->assertArrayHasKey('cmsPageId', $result);
+        $this->assertSame(999999, $result['cmsPageId']);
+        $this->assertArrayHasKey('cmsPageCategoryId', $result);
+        $this->assertIsInt($result['cmsPageCategoryId']);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Two mono-arg read endpoints used by the front-office redirection routing:<br/>- `GET /cms-page-categories/{cmsPageCategoryId}/parent-for-redirection` exposes `GetCmsPageParentCategoryIdForRedirection` → `{parentId: int}`.<br/>- `GET /cms-pages/{cmsPageId}/category-for-redirection` exposes `GetCmsCategoryIdForRedirection` → `{cmsPageCategoryId: int}`.<br/>Both use the `[_queryResult]` scalar-wrap mapping around the returned `CmsPageCategoryId` VO (mono-arg → normalizer collapses to int). |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; new `CmsRedirectionQueriesEndpointTest` covers scope protection and both happy paths (root-parent and unknown-page fallback → ROOT id). |

Standalone files under `CmsPageCategory/` and `CmsPage/` folders to avoid touching in-progress PRs #262 / #193 (CmsPageCategory CRUD) and #165 (CmsPage CRUD).