### PR TITLE
Add RefreshExchangeRates Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Currency/ExchangeRateRefresh.php
+++ b/src/ApiPlatform/Resources/Currency/ExchangeRateRefresh.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Currency;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Command\RefreshExchangeRatesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Currency\Exception\CannotRefreshExchangeRatesException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/currencies/exchange-rate-refreshes',
+            allowEmptyBody: true,
+            CQRSCommand: RefreshExchangeRatesCommand::class,
+            scopes: ['currency_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CannotRefreshExchangeRatesException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ExchangeRateRefresh
+{
+}

--- a/tests/Integration/ApiPlatform/ExchangeRateRefreshEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ExchangeRateRefreshEndpointTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ExchangeRateRefreshEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['currency_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'refresh exchange rates endpoint' => ['POST', '/currencies/exchange-rate-refreshes'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `POST /currencies/exchange-rate-refreshes` using `CQRSCreate` with `RefreshExchangeRatesCommand` (empty body). Delegates to `Currency::refreshCurrencies()` which fetches the PrestaShop currency XML feed. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; new `ExchangeRateRefreshEndpointTest` covers scope protection only — a full happy-path test would hit an external endpoint (`PS_CURRENCY_FEED_URL`) which is flaky in CI. `CannotRefreshExchangeRatesException` maps to HTTP 422 when the feed is unreachable. |