### PR TITLE
Add QuickAccess Admin API endpoints (CRUD + bulk-delete + toggle)

### DIFF
--- a/src/ApiPlatform/Resources/QuickAccess/BulkQuickAccesses.php
+++ b/src/ApiPlatform/Resources/QuickAccess/BulkQuickAccesses.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\QuickAccess;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Command\BulkDeleteQuickAccessCommand;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Exception\CannotDeleteQuickAccessException;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Exception\QuickAccessNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/quick-accesses/bulk-delete',
+            CQRSCommand: BulkDeleteQuickAccessCommand::class,
+            scopes: ['quick_access_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        QuickAccessNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CannotDeleteQuickAccessException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkQuickAccesses
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $quickAccessIds;
+}

--- a/src/ApiPlatform/Resources/QuickAccess/QuickAccess.php
+++ b/src/ApiPlatform/Resources/QuickAccess/QuickAccess.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\QuickAccess;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Command\AddQuickAccessCommand;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Command\DeleteQuickAccessCommand;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Command\EditQuickAccessCommand;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Command\ToggleQuickAccessNewWindowCommand;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Exception\CannotAddQuickAccessException;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Exception\CannotDeleteQuickAccessException;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Exception\CannotEditQuickAccessException;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Exception\QuickAccessConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Exception\QuickAccessNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\QuickAccess\Query\GetQuickAccessForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/quick-accesses',
+            CQRSCommand: AddQuickAccessCommand::class,
+            scopes: ['quick_access_write'],
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSGet(
+            uriTemplate: '/quick-accesses/{quickAccessId}',
+            requirements: ['quickAccessId' => '\d+'],
+            CQRSQuery: GetQuickAccessForEditing::class,
+            scopes: ['quick_access_read'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/quick-accesses/{quickAccessId}',
+            requirements: ['quickAccessId' => '\d+'],
+            read: false,
+            CQRSCommand: EditQuickAccessCommand::class,
+            scopes: ['quick_access_write'],
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/quick-accesses/{quickAccessId}',
+            requirements: ['quickAccessId' => '\d+'],
+            CQRSCommand: DeleteQuickAccessCommand::class,
+            scopes: ['quick_access_write'],
+        ),
+        new CQRSUpdate(
+            uriTemplate: '/quick-accesses/{quickAccessId}/new-window-toggles',
+            requirements: ['quickAccessId' => '\d+'],
+            allowEmptyBody: true,
+            read: false,
+            CQRSCommand: ToggleQuickAccessNewWindowCommand::class,
+            scopes: ['quick_access_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        QuickAccessNotFoundException::class => Response::HTTP_NOT_FOUND,
+        QuickAccessConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CannotAddQuickAccessException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CannotEditQuickAccessException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CannotDeleteQuickAccessException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class QuickAccess
+{
+    #[ApiProperty(identifier: true)]
+    public int $quickAccessId;
+
+    #[LocalizedValue]
+    #[Assert\NotBlank(groups: ['Create'])]
+    public array $localizedNames;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $link;
+
+    #[Assert\NotNull(groups: ['Create'])]
+    public bool $newWindow;
+
+    public const COMMAND_MAPPING = [
+        '[localizedNames]' => '[localizedNames]',
+        '[link]' => '[link]',
+        '[newWindow]' => '[newWindow]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/QuickAccessEndpointTest.php
+++ b/tests/Integration/ApiPlatform/QuickAccessEndpointTest.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class QuickAccessEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['quick_access', 'quick_access_lang']);
+        self::createApiClient(['quick_access_write', 'quick_access_read']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['quick_access', 'quick_access_lang']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create endpoint' => ['POST', '/quick-accesses'];
+        yield 'get endpoint' => ['GET', '/quick-accesses/1'];
+        yield 'update endpoint' => ['PATCH', '/quick-accesses/1'];
+        yield 'delete endpoint' => ['DELETE', '/quick-accesses/1'];
+        yield 'bulk delete endpoint' => ['DELETE', '/quick-accesses/bulk-delete'];
+        yield 'toggle new window endpoint' => ['PUT', '/quick-accesses/1/new-window-toggles'];
+    }
+
+    public function testCreateQuickAccess(): int
+    {
+        $result = $this->requestApi(
+            'POST',
+            '/quick-accesses',
+            [
+                'localizedNames' => [1 => 'Test link'],
+                'link' => 'index.php?controller=AdminModules',
+                'newWindow' => false,
+            ],
+            ['quick_access_write'],
+            Response::HTTP_CREATED
+        );
+
+        $this->assertArrayHasKey('quickAccessId', $result);
+        $this->assertIsInt($result['quickAccessId']);
+        $this->assertGreaterThan(0, $result['quickAccessId']);
+
+        return $result['quickAccessId'];
+    }
+
+    /**
+     * @depends testCreateQuickAccess
+     */
+    public function testGetQuickAccess(int $quickAccessId): int
+    {
+        $result = $this->getItem('/quick-accesses/' . $quickAccessId, ['quick_access_read']);
+        $this->assertSame($quickAccessId, $result['quickAccessId']);
+        $this->assertArrayHasKey('link', $result);
+        $this->assertArrayHasKey('newWindow', $result);
+        $this->assertArrayHasKey('localizedNames', $result);
+
+        return $quickAccessId;
+    }
+
+    /**
+     * @depends testGetQuickAccess
+     */
+    public function testEditQuickAccess(int $quickAccessId): int
+    {
+        $this->requestApi(
+            'PATCH',
+            '/quick-accesses/' . $quickAccessId,
+            ['link' => 'index.php?controller=AdminEmployees'],
+            ['quick_access_write'],
+            Response::HTTP_OK
+        );
+
+        $link = (string) \Db::getInstance()->getValue(
+            'SELECT `link` FROM `' . _DB_PREFIX_ . 'quick_access` WHERE `id_quick_access` = ' . $quickAccessId
+        );
+        $this->assertSame('index.php?controller=AdminEmployees', $link);
+
+        return $quickAccessId;
+    }
+
+    /**
+     * @depends testEditQuickAccess
+     */
+    public function testToggleNewWindow(int $quickAccessId): int
+    {
+        $before = (int) \Db::getInstance()->getValue(
+            'SELECT `new_window` FROM `' . _DB_PREFIX_ . 'quick_access` WHERE `id_quick_access` = ' . $quickAccessId
+        );
+
+        $this->requestApi(
+            'PUT',
+            '/quick-accesses/' . $quickAccessId . '/new-window-toggles',
+            null,
+            ['quick_access_write'],
+            Response::HTTP_OK
+        );
+
+        $after = (int) \Db::getInstance()->getValue(
+            'SELECT `new_window` FROM `' . _DB_PREFIX_ . 'quick_access` WHERE `id_quick_access` = ' . $quickAccessId
+        );
+        $this->assertNotSame($before, $after);
+
+        return $quickAccessId;
+    }
+
+    /**
+     * @depends testToggleNewWindow
+     */
+    public function testDeleteQuickAccess(int $quickAccessId): void
+    {
+        $this->requestApi(
+            'DELETE',
+            '/quick-accesses/' . $quickAccessId,
+            null,
+            ['quick_access_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $stillThere = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'quick_access` WHERE `id_quick_access` = ' . $quickAccessId
+        );
+        $this->assertSame(0, $stillThere);
+    }
+
+    public function testBulkDeleteQuickAccesses(): void
+    {
+        $ids = [];
+        foreach (['A', 'B'] as $suffix) {
+            $result = $this->requestApi(
+                'POST',
+                '/quick-accesses',
+                [
+                    'localizedNames' => [1 => 'Seed ' . $suffix],
+                    'link' => 'index.php?controller=AdminModules&seed=' . $suffix,
+                    'newWindow' => false,
+                ],
+                ['quick_access_write'],
+                Response::HTTP_CREATED
+            );
+            $ids[] = $result['quickAccessId'];
+        }
+
+        $this->requestApi(
+            'DELETE',
+            '/quick-accesses/bulk-delete',
+            ['quickAccessIds' => $ids],
+            ['quick_access_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $stillThere = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'quick_access` WHERE `id_quick_access` IN (' . implode(', ', $ids) . ')'
+        );
+        $this->assertSame(0, $stillThere);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Full CRUD for the QuickAccess admin bookmarks: create / read / edit / delete + bulk-delete, plus a per-item toggle of the `new_window` column via `PUT /quick-accesses/{id}/new-window-toggles`. Uses the classic ID-only-ctor + setters `EditCommand` pattern, and standard `BulkDelete*` layout in a companion resource file. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; `QuickAccessEndpointTest` walks the full CRUD chain via `@depends` (create → get → edit → toggle → delete), then a separate bulk-delete test seeds two rows via the endpoint and verifies row-count = 0. |

**⚠️ Depends on PR #220** — the `QuickAccess` core CQRS classes were introduced in PS 9.1+/develop and do not exist at the 9.0.3 tag. The 9.0.3 integration / PHPStan CI legs will fail here until #220 (drop 9.0.3 from the module CI matrix) lands. The endpoints are functional on 9.1.x and develop.