### PR TITLE
Add Country toggle-status + bulk-toggle + bulk-update-zone endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Country/BulkCountriesStatus.php
+++ b/src/ApiPlatform/Resources/Country/BulkCountriesStatus.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Country;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkToggleCountriesStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/countries/bulk-toggle-status',
+            read: false,
+            CQRSCommand: BulkToggleCountriesStatusCommand::class,
+            scopes: ['country_write'],
+            CQRSCommandMapping: [
+                '[enabled]' => '[expectedStatus]',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CountryNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkCountriesStatus
+{
+    #[Assert\NotNull]
+    public bool $enabled;
+
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $countryIds;
+}

--- a/src/ApiPlatform/Resources/Country/BulkCountriesZone.php
+++ b/src/ApiPlatform/Resources/Country/BulkCountriesZone.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Country;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkUpdateCountryZoneCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryException;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/countries/bulk-update-zone',
+            read: false,
+            CQRSCommand: BulkUpdateCountryZoneCommand::class,
+            scopes: ['country_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CountryNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CountryException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkCountriesZone
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $countryIds;
+
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
+    public int $newZoneId;
+}

--- a/src/ApiPlatform/Resources/Country/CountryStatus.php
+++ b/src/ApiPlatform/Resources/Country/CountryStatus.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Country;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\ToggleCountryStatusCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/countries/{countryId}/toggle-status',
+            requirements: ['countryId' => '\d+'],
+            allowEmptyBody: true,
+            read: false,
+            CQRSCommand: ToggleCountryStatusCommand::class,
+            scopes: ['country_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CountryNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class CountryStatus
+{
+    #[ApiProperty(identifier: true)]
+    public int $countryId;
+}

--- a/tests/Integration/ApiPlatform/CountryStatusZoneEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CountryStatusZoneEndpointTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class CountryStatusZoneEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['country', 'country_lang', 'country_shop']);
+        self::createApiClient(['country_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['country', 'country_lang', 'country_shop']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'toggle status endpoint' => ['PUT', '/countries/1/toggle-status'];
+        yield 'bulk toggle status endpoint' => ['PUT', '/countries/bulk-toggle-status'];
+        yield 'bulk update zone endpoint' => ['PUT', '/countries/bulk-update-zone'];
+    }
+
+    public function testToggleCountryStatus(): void
+    {
+        $countryId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_country` FROM `' . _DB_PREFIX_ . 'country` ORDER BY `id_country` ASC'
+        );
+        $before = (int) \Db::getInstance()->getValue(
+            'SELECT `active` FROM `' . _DB_PREFIX_ . 'country` WHERE `id_country` = ' . $countryId
+        );
+
+        $this->requestApi(
+            'PUT',
+            '/countries/' . $countryId . '/toggle-status',
+            null,
+            ['country_write'],
+            Response::HTTP_OK
+        );
+
+        $after = (int) \Db::getInstance()->getValue(
+            'SELECT `active` FROM `' . _DB_PREFIX_ . 'country` WHERE `id_country` = ' . $countryId
+        );
+        $this->assertNotSame($before, $after);
+    }
+
+    public function testBulkToggleCountriesStatus(): void
+    {
+        $ids = array_map('intval', array_column(
+            \Db::getInstance()->executeS(
+                'SELECT `id_country` FROM `' . _DB_PREFIX_ . 'country` ORDER BY `id_country` ASC LIMIT 2'
+            ),
+            'id_country'
+        ));
+
+        $this->requestApi(
+            'PUT',
+            '/countries/bulk-toggle-status',
+            ['enabled' => false, 'countryIds' => $ids],
+            ['country_write'],
+            Response::HTTP_OK
+        );
+
+        $activeCount = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'country` WHERE `active` = 1 AND `id_country` IN (' . implode(', ', $ids) . ')'
+        );
+        $this->assertSame(0, $activeCount);
+    }
+
+    public function testBulkUpdateCountriesZone(): void
+    {
+        $ids = array_map('intval', array_column(
+            \Db::getInstance()->executeS(
+                'SELECT `id_country` FROM `' . _DB_PREFIX_ . 'country` ORDER BY `id_country` ASC LIMIT 2'
+            ),
+            'id_country'
+        ));
+        $newZoneId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_zone` FROM `' . _DB_PREFIX_ . 'zone` WHERE `active` = 1 ORDER BY `id_zone` DESC LIMIT 1'
+        );
+
+        $this->requestApi(
+            'PUT',
+            '/countries/bulk-update-zone',
+            ['countryIds' => $ids, 'newZoneId' => $newZoneId],
+            ['country_write'],
+            Response::HTTP_OK
+        );
+
+        $otherZoneCount = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'country` WHERE `id_zone` != ' . $newZoneId . ' AND `id_country` IN (' . implode(', ', $ids) . ')'
+        );
+        $this->assertSame(0, $otherZoneCount);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds three status/zone mutation endpoints on Country (standalone files to avoid touching the existing `Country.php`):<br/>- `PUT /countries/{countryId}/toggle-status` (ToggleCountryStatusCommand)<br/>- `PUT /countries/bulk-toggle-status` (BulkToggleCountriesStatusCommand — body `{enabled, countryIds}`, `enabled → expectedStatus`)<br/>- `PUT /countries/bulk-update-zone` (BulkUpdateCountryZoneCommand — body `{countryIds, newZoneId}`) |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; `CountryStatusZoneEndpointTest` toggles the first country (verifies `active` flipped) and bulk-updates zone on the two first countries. |

**⚠️ Depends on PR #220** — the three commands were introduced in PS 9.1+/develop and do not exist at the 9.0.3 tag. The 9.0.3 integration / PHPStan CI legs will fail here until #220 (drop 9.0.3 from the module CI matrix) lands.