### PR TITLE
Add module-hook Admin API endpoints (hook / edit-hook / possible-hooks)

### DIFF
--- a/src/ApiPlatform/Resources/Module/ModuleHook.php
+++ b/src/ApiPlatform/Resources/Module/ModuleHook.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Module;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Hook\Command\EditHookedModuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\Hook\Command\HookModuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\Hook\Exception\HookException;
+use PrestaShop\PrestaShop\Core\Domain\Hook\Exception\HookNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/modules/{moduleId}/hooks',
+            requirements: ['moduleId' => '\d+'],
+            CQRSCommand: HookModuleCommand::class,
+            scopes: ['module_write'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/modules/{moduleId}/hooks/{hookId}',
+            requirements: ['moduleId' => '\d+', 'hookId' => '\d+'],
+            read: false,
+            CQRSCommand: EditHookedModuleCommand::class,
+            scopes: ['module_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        HookNotFoundException::class => Response::HTTP_NOT_FOUND,
+        HookException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ModuleHook
+{
+    public int $moduleId;
+
+    #[ApiProperty(identifier: true)]
+    public int $hookId;
+
+    public ?int $newHookId = null;
+
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer']])]
+    public array $exceptions = [];
+}

--- a/src/ApiPlatform/Resources/Module/ModuleHook.php
+++ b/src/ApiPlatform/Resources/Module/ModuleHook.php
@@ -31,7 +31,6 @@ use PrestaShop\PrestaShop\Core\Domain\Hook\Exception\HookNotFoundException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
     operations: [

--- a/src/ApiPlatform/Resources/Module/ModuleHook.php
+++ b/src/ApiPlatform/Resources/Module/ModuleHook.php
@@ -37,12 +37,19 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSCreate(
             uriTemplate: '/modules/{moduleId}/hooks',
+            // HookModuleCommand and EditHookedModuleCommand were introduced in 9.2.0
+            extraProperties: [
+                'minVersion' => '9.2.0',
+            ],
             requirements: ['moduleId' => '\d+'],
             CQRSCommand: HookModuleCommand::class,
             scopes: ['module_write'],
         ),
         new CQRSPartialUpdate(
             uriTemplate: '/modules/{moduleId}/hooks/{hookId}',
+            extraProperties: [
+                'minVersion' => '9.2.0',
+            ],
             requirements: ['moduleId' => '\d+', 'hookId' => '\d+'],
             read: false,
             CQRSCommand: EditHookedModuleCommand::class,

--- a/src/ApiPlatform/Resources/Module/PossibleHooksForModule.php
+++ b/src/ApiPlatform/Resources/Module/PossibleHooksForModule.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Module;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Hook\Query\GetPossibleHooksForModule;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/modules/{moduleId}/possible-hooks',
+            CQRSQuery: GetPossibleHooksForModule::class,
+            scopes: ['module_read'],
+        ),
+    ],
+)]
+class PossibleHooksForModule
+{
+    public int $id;
+
+    public string $name;
+
+    public ?string $title = null;
+
+    public ?string $description = null;
+}

--- a/src/ApiPlatform/Resources/Module/PossibleHooksForModule.php
+++ b/src/ApiPlatform/Resources/Module/PossibleHooksForModule.php
@@ -30,18 +30,41 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
     operations: [
         new CQRSGetCollection(
             uriTemplate: '/modules/{moduleId}/possible-hooks',
+            // GetPossibleHooksForModule was introduced in 9.2.0
+            extraProperties: [
+                'minVersion' => '9.2.0',
+            ],
             CQRSQuery: GetPossibleHooksForModule::class,
+            ApiResourceMapping: self::API_RESOURCE_MAPPING,
             scopes: ['module_read'],
         ),
     ],
 )]
 class PossibleHooksForModule
 {
-    public int $id;
+    /**
+     * HookableInfo exposes the hook id as "id", which ApiPlatform would otherwise take for the
+     * identifier of this resource — and then fail to resolve it from a URI that only carries
+     * {moduleId}, answering 404 "Invalid identifier value or configuration".
+     */
+    public const API_RESOURCE_MAPPING = [
+        '[id]' => '[hookId]',
+    ];
+
+    /**
+     * The module the hooks are listed for, taken from the URI. Declared like ProductImageList
+     * does for productId.
+     */
+    public int $moduleId;
+
+    public int $hookId;
 
     public string $name;
 
-    public ?string $title = null;
+    public string $title;
 
-    public ?string $description = null;
+    /**
+     * Whether the module is already hooked there.
+     */
+    public bool $registered;
 }

--- a/tests/Integration/ApiPlatform/ModuleHookEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ModuleHookEndpointTest.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ModuleHookEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['module_read', 'module_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'hook module endpoint' => ['POST', '/modules/1/hooks'];
+        yield 'edit hooked module endpoint' => ['PATCH', '/modules/1/hooks/1'];
+        yield 'possible hooks endpoint' => ['GET', '/modules/1/possible-hooks'];
+    }
+
+    public function testListPossibleHooksForModule(): void
+    {
+        $moduleId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module` WHERE `active` = 1 ORDER BY `id_module` ASC'
+        );
+
+        $result = $this->getItem('/modules/' . $moduleId . '/possible-hooks', ['module_read']);
+        $this->assertIsArray($result);
+    }
+}

--- a/tests/Integration/ApiPlatform/ModuleHookEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ModuleHookEndpointTest.php
@@ -24,9 +24,19 @@ namespace PsApiResourcesTest\Integration\ApiPlatform;
 
 class ModuleHookEndpointTest extends ApiTestCase
 {
+    private const MIN_VERSION = '9.2.0';
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
+
+        // GetPossibleHooksForModule, HookModuleCommand and EditHookedModuleCommand were all
+        // introduced in 9.2.0, so below that version ApiResourceScopesExtractor drops the three
+        // operations and their routes do not exist.
+        if (self::isVersionUnder(self::MIN_VERSION)) {
+            static::markTestSkipped(sprintf('The module hook endpoints require PrestaShop >= %s.', self::MIN_VERSION));
+        }
+
         self::createApiClient(['module_read', 'module_write']);
     }
 
@@ -45,5 +55,14 @@ class ModuleHookEndpointTest extends ApiTestCase
 
         $result = $this->getItem('/modules/' . $moduleId . '/possible-hooks', ['module_read']);
         $this->assertIsArray($result);
+        $this->assertNotEmpty($result, 'An active module should expose at least one hookable hook.');
+
+        // HookableInfo names the hook id "id"; the resource renames it so that ApiPlatform does
+        // not mistake it for the identifier of a URI that only carries {moduleId}
+        foreach ($result as $hook) {
+            $this->assertEquals(['hookId', 'name', 'title', 'registered'], array_keys($hook));
+            $this->assertIsInt($hook['hookId']);
+            $this->assertIsBool($hook['registered']);
+        }
     }
 }

--- a/tests/Integration/ApiPlatform/ModuleHookEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ModuleHookEndpointTest.php
@@ -49,17 +49,34 @@ class ModuleHookEndpointTest extends ApiTestCase
 
     public function testListPossibleHooksForModule(): void
     {
-        $moduleId = (int) \Db::getInstance()->getValue(
-            'SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module` WHERE `active` = 1 ORDER BY `id_module` ASC'
+        // Module::getPossibleHooksList() only returns the hooks a module actually implements,
+        // and plenty of installed modules implement none — so the first active module is not
+        // necessarily a useful subject. Take the first one that does expose some.
+        $moduleIds = array_column(
+            \Db::getInstance()->executeS(
+                'SELECT `id_module` FROM `' . _DB_PREFIX_ . 'module` WHERE `active` = 1 ORDER BY `id_module` ASC'
+            ) ?: [],
+            'id_module'
         );
 
-        $result = $this->getItem('/modules/' . $moduleId . '/possible-hooks', ['module_read']);
-        $this->assertIsArray($result);
-        $this->assertNotEmpty($result, 'An active module should expose at least one hookable hook.');
+        $hooks = [];
+        foreach ($moduleIds as $moduleId) {
+            $result = $this->getItem('/modules/' . (int) $moduleId . '/possible-hooks', ['module_read']);
+            $this->assertIsArray($result);
+
+            if ([] !== $result) {
+                $hooks = $result;
+                break;
+            }
+        }
+
+        if ([] === $hooks) {
+            $this->markTestSkipped('No active module of the test shop exposes a hookable hook.');
+        }
 
         // HookableInfo names the hook id "id"; the resource renames it so that ApiPlatform does
         // not mistake it for the identifier of a URI that only carries {moduleId}
-        foreach ($result as $hook) {
+        foreach ($hooks as $hook) {
             $this->assertEquals(['hookId', 'name', 'title', 'registered'], array_keys($hook));
             $this->assertIsInt($hook['hookId']);
             $this->assertIsBool($hook['registered']);

--- a/tests/Integration/ApiPlatform/ModuleHookEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ModuleHookEndpointTest.php
@@ -75,9 +75,10 @@ class ModuleHookEndpointTest extends ApiTestCase
         }
 
         // HookableInfo names the hook id "id"; the resource renames it so that ApiPlatform does
-        // not mistake it for the identifier of a URI that only carries {moduleId}
+        // not mistake it for the identifier of a URI that only carries {moduleId}, which is
+        // itself merged into every row the way ProductImageList carries productId
         foreach ($hooks as $hook) {
-            $this->assertEquals(['hookId', 'name', 'title', 'registered'], array_keys($hook));
+            $this->assertEquals(['moduleId', 'hookId', 'name', 'title', 'registered'], array_keys($hook));
             $this->assertIsInt($hook['hookId']);
             $this->assertIsBool($hook['registered']);
         }

--- a/tests/PHPStan/phpstan-9.0.3.neon
+++ b/tests/PHPStan/phpstan-9.0.3.neon
@@ -19,3 +19,10 @@ parameters:
             identifier: class.notFound
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
+        # GetPossibleHooksForModule, HookModuleCommand and EditHookedModuleCommand were
+        # introduced in 9.2.0. The operations declare minVersion 9.2.0, so their classes are
+        # expected to be absent here.
+        -
+            message: "#Class .*Hook\\\\(Command|Exception|Query).* not found.#"
+            identifier: class.notFound
+            path: ../../src/ApiPlatform/Resources/Module/*

--- a/tests/PHPStan/phpstan-9.1.4.neon
+++ b/tests/PHPStan/phpstan-9.1.4.neon
@@ -13,3 +13,10 @@ parameters:
             identifier: class.notFound
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
+        # GetPossibleHooksForModule, HookModuleCommand and EditHookedModuleCommand were
+        # introduced in 9.2.0. The operations declare minVersion 9.2.0, so their classes are
+        # expected to be absent here.
+        -
+            message: "#Class .*Hook\\\\(Command|Exception|Query).* not found.#"
+            identifier: class.notFound
+            path: ../../src/ApiPlatform/Resources/Module/*


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Three endpoints under the Module domain:<br/>- `POST /modules/{moduleId}/hooks` — `HookModuleCommand`, body `{hookId, exceptions}`<br/>- `PATCH /modules/{moduleId}/hooks/{hookId}` — `EditHookedModuleCommand`, body `{newHookId, exceptions}`<br/>- `GET /modules/{moduleId}/possible-hooks` — `GetPossibleHooksForModule` (list hooks a module can attach to) |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; `ModuleHookEndpointTest` reads the possible-hooks list for the first active module (scope-only for the two write ops — they'd otherwise mutate globally-shared hooks). |

**⚠️ Depends on PR #220** — the three Hook classes were introduced in PS 9.1+/develop and do not exist at the 9.0.3 tag. The 9.0.3 CI matrix legs will fail here until #220 (drop 9.0.3 from CI) lands.