### PR TITLE
Add MailTemplate listing Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/MailTemplate/MailTemplateList.php
+++ b/src/ApiPlatform/Resources/MailTemplate/MailTemplateList.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\MailTemplate;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Query\GetEmailBodyTemplatesForListing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/mail-templates',
+            CQRSQuery: GetEmailBodyTemplatesForListing::class,
+            scopes: ['mail_template_read'],
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'locale',
+                    required: true,
+                    description: 'Locale identifier (e.g. en-US, fr-FR)'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    ['name' => 'locale', 'in' => 'query', 'required' => true, 'schema' => ['type' => 'string']],
+                ],
+            ],
+        ),
+    ],
+)]
+class MailTemplateList
+{
+    public string $templateName;
+
+    public string $source;
+
+    public string $moduleName;
+
+    public bool $hasHtml;
+
+    public bool $hasTxt;
+}

--- a/tests/Integration/ApiPlatform/MailTemplateListEndpointTest.php
+++ b/tests/Integration/ApiPlatform/MailTemplateListEndpointTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class MailTemplateListEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['mail_template_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list mail templates endpoint' => ['GET', '/mail-templates?locale=en-US'];
+    }
+
+    public function testListMailTemplates(): void
+    {
+        $result = $this->getItem('/mail-templates?locale=en-US', ['mail_template_read']);
+
+        $this->assertIsArray($result);
+        // PS ships a bunch of English core templates — expect at least one row.
+        $this->assertNotEmpty($result);
+        foreach ($result as $row) {
+            $this->assertArrayHasKey('templateName', $row);
+            $this->assertArrayHasKey('source', $row);
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `GET /mail-templates?locale=…` using `CQRSGetCollection` with `GetEmailBodyTemplatesForListing`. Items expose `templateName`, `source`, `moduleName`, `hasHtml`, `hasTxt` (filesystem scan of core + module mail directories for the requested locale). Read-only for now — `GetEmailBodyTemplateForEditing` / `EditEmailBodyTemplateCommand` need the composite `EmailTemplateSource` VO which is less API-friendly and left for a follow-up. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; `MailTemplateListEndpointTest` fetches the `en-US` locale, expects a non-empty list (PS ships core English templates). |

**⚠️ Depends on PR #220** — the `MailTemplate` domain was introduced in PS 9.1+/develop and does not exist at the 9.0.3 tag. The 9.0.3 CI matrix legs will fail here until #220 (drop 9.0.3 from CI) lands.