### PR TITLE
Add OrderReturn delete + bulk-delete Admin API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/OrderReturn/BulkOrderReturns.php
+++ b/src/ApiPlatform/Resources/OrderReturn/BulkOrderReturns.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderReturn;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Command\BulkDeleteOrderReturnsCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/order-returns/bulk-delete',
+            CQRSCommand: BulkDeleteOrderReturnsCommand::class,
+            scopes: ['order_return_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderReturnNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkOrderReturns
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $orderReturnIds;
+}

--- a/src/ApiPlatform/Resources/OrderReturn/OrderReturn.php
+++ b/src/ApiPlatform/Resources/OrderReturn/OrderReturn.php
@@ -24,11 +24,13 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderReturn;
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Command\DeleteOrderReturnCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Command\UpdateOrderReturnStateCommand;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnConstraintException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Query\GetOrderReturnForEditing;
 use PrestaShop\PrestaShop\Core\Domain\OrderReturnState\Exception\OrderReturnStateNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
 use Symfony\Component\HttpFoundation\Response;
@@ -48,6 +50,12 @@ use Symfony\Component\Validator\Constraints as Assert;
             read: false,
             CQRSCommand: UpdateOrderReturnStateCommand::class,
             CQRSQuery: GetOrderReturnForEditing::class,
+            scopes: ['order_return_write'],
+        ),
+        new CQRSDelete(
+            uriTemplate: '/order-returns/{orderReturnId}',
+            requirements: ['orderReturnId' => '\d+'],
+            CQRSCommand: DeleteOrderReturnCommand::class,
             scopes: ['order_return_write'],
         ),
     ],

--- a/tests/Integration/ApiPlatform/OrderReturnDeleteEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderReturnDeleteEndpointTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+class OrderReturnDeleteEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        DatabaseDump::restoreTables(['order_return', 'order_return_detail']);
+        self::createApiClient(['order_return_write']);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables(['order_return', 'order_return_detail']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'delete endpoint' => ['DELETE', '/order-returns/999999'];
+        yield 'bulk delete endpoint' => ['DELETE', '/order-returns/bulk-delete'];
+    }
+
+    public function testDeleteOrderReturn(): void
+    {
+        $id = $this->seedOrderReturn();
+
+        $this->requestApi(
+            'DELETE',
+            '/order-returns/' . $id,
+            null,
+            ['order_return_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $stillThere = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'order_return` WHERE `id_order_return` = ' . $id
+        );
+        $this->assertSame(0, $stillThere);
+    }
+
+    public function testBulkDeleteOrderReturns(): void
+    {
+        $ids = [$this->seedOrderReturn(), $this->seedOrderReturn()];
+
+        $this->requestApi(
+            'DELETE',
+            '/order-returns/bulk-delete',
+            ['orderReturnIds' => $ids],
+            ['order_return_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        $stillThere = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'order_return` WHERE `id_order_return` IN (' . implode(', ', $ids) . ')'
+        );
+        $this->assertSame(0, $stillThere);
+    }
+
+    private function seedOrderReturn(): int
+    {
+        $orderId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_order` FROM `' . _DB_PREFIX_ . 'orders` ORDER BY `id_order` ASC'
+        );
+        $customerId = (int) \Db::getInstance()->getValue(
+            'SELECT `id_customer` FROM `' . _DB_PREFIX_ . 'orders` WHERE `id_order` = ' . $orderId
+        );
+        \Db::getInstance()->insert('order_return', [
+            'id_customer' => $customerId,
+            'id_order' => $orderId,
+            'state' => 1,
+            'question' => 'Seed for delete test',
+        ]);
+
+        return (int) \Db::getInstance()->Insert_ID();
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds:<br/>- `DELETE /order-returns/{orderReturnId}` (DeleteOrderReturnCommand)<br/>- `DELETE /order-returns/bulk-delete` (BulkDeleteOrderReturnsCommand)<br/>Single-delete op added to the existing `OrderReturn.php` (which already has GET + PATCH); bulk op lives in a new `BulkOrderReturns.php` file. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; `OrderReturnDeleteEndpointTest` seeds order-return rows via `\Db::insert('order_return', …)`, exercises DELETE + bulk-DELETE, verifies row-count = 0. |

**⚠️ Depends on PR #220** — `DeleteOrderReturnCommand` / `BulkDeleteOrderReturnsCommand` were introduced in PS 9.1+/develop and do not exist at the 9.0.3 tag. The 9.0.3 CI matrix legs will fail here until #220 (drop 9.0.3 from CI) lands.