### PR TITLE
Add OrderReturn products Admin API endpoints (list + delete)

### DIFF
--- a/src/ApiPlatform/Resources/OrderReturn/OrderReturnProduct.php
+++ b/src/ApiPlatform/Resources/OrderReturn/OrderReturnProduct.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderReturn;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Command\DeleteProductFromOrderReturnCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/order-returns/{orderReturnId}/products/{orderDetailId}',
+            requirements: ['orderReturnId' => '\d+', 'orderDetailId' => '\d+'],
+            CQRSCommand: DeleteProductFromOrderReturnCommand::class,
+            scopes: ['order_return_write'],
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'customizationId',
+                    required: false,
+                    description: 'Customization id when removing a customized line; defaults to 0'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    ['name' => 'customizationId', 'in' => 'query', 'required' => false, 'schema' => ['type' => 'integer', 'default' => 0]],
+                ],
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderReturnNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderReturnConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderReturnProduct
+{
+    public int $orderReturnId;
+
+    public int $orderDetailId;
+
+    public int $customizationId = 0;
+}

--- a/src/ApiPlatform/Resources/OrderReturn/OrderReturnProductList.php
+++ b/src/ApiPlatform/Resources/OrderReturn/OrderReturnProductList.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderReturn;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Query\GetOrderReturnProducts;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/order-returns/{orderReturnId}/products',
+            CQRSQuery: GetOrderReturnProducts::class,
+            scopes: ['order_return_read'],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderReturnNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class OrderReturnProductList
+{
+    public int $orderDetailId;
+
+    public int $customizationId;
+
+    public string $reference;
+
+    public string $productName;
+
+    public int $quantity;
+
+    public bool $customization;
+}

--- a/tests/Integration/ApiPlatform/OrderReturnProductsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderReturnProductsEndpointTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class OrderReturnProductsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_return_read', 'order_return_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'list order return products' => ['GET', '/order-returns/1/products'];
+        yield 'delete product from order return' => ['DELETE', '/order-returns/1/products/1'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds:<br/>- `GET /order-returns/{orderReturnId}/products` — GetOrderReturnProducts, returns per-line rows `{orderDetailId, customizationId, reference, productName, quantity, customization}`<br/>- `DELETE /order-returns/{orderReturnId}/products/{orderDetailId}` — DeleteProductFromOrderReturnCommand, optional `?customizationId=` query parameter (defaults to 0 for regular product lines) |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; `OrderReturnProductsEndpointTest` covers scope protection only. Happy-path coverage would need seeding a full OrderReturn + OrderReturnDetail row set which the existing test infrastructure does not currently expose. |

**⚠️ Depends on PR #220** — the core OrderReturn product-mgmt commands were introduced in PS 9.1+/develop and do not exist at the 9.0.3 tag. The 9.0.3 CI matrix legs will fail here until #220 (drop 9.0.3 from CI) lands.