### PR TITLE
Add MailTemplate get + edit Admin API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/MailTemplate/MailTemplate.php
+++ b/src/ApiPlatform/Resources/MailTemplate/MailTemplate.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\MailTemplate;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Command\EditEmailBodyTemplateCommand;
+use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Exception\FileNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Exception\InvalidArgumentException;
+use PrestaShop\PrestaShop\Core\Domain\MailTemplate\Query\GetEmailBodyTemplateForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/mail-templates/{templateName}',
+            requirements: ['templateName' => '[a-zA-Z0-9_-]+'],
+            CQRSQuery: GetEmailBodyTemplateForEditing::class,
+            scopes: ['mail_template_read'],
+            openapiContext: [
+                'parameters' => [
+                    ['name' => 'locale', 'in' => 'query', 'required' => true, 'schema' => ['type' => 'string']],
+                    ['name' => 'source', 'in' => 'query', 'required' => true, 'schema' => ['type' => 'string', 'enum' => ['core', 'module']]],
+                    ['name' => 'moduleName', 'in' => 'query', 'required' => false, 'schema' => ['type' => 'string', 'default' => '']],
+                ],
+            ],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/mail-templates/{templateName}',
+            requirements: ['templateName' => '[a-zA-Z0-9_-]+'],
+            read: false,
+            CQRSCommand: EditEmailBodyTemplateCommand::class,
+            scopes: ['mail_template_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        FileNotFoundException::class => Response::HTTP_NOT_FOUND,
+        InvalidArgumentException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class MailTemplate
+{
+    #[ApiProperty(identifier: true)]
+    public string $templateName;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $locale;
+
+    /** 'core' or 'module' */
+    #[Assert\Choice(choices: ['core', 'module'], groups: ['Create'])]
+    public string $source;
+
+    public string $moduleName = '';
+
+    public string $htmlContent = '';
+
+    public string $txtContent = '';
+}

--- a/tests/Integration/ApiPlatform/MailTemplateEditEndpointTest.php
+++ b/tests/Integration/ApiPlatform/MailTemplateEditEndpointTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class MailTemplateEditEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['mail_template_read', 'mail_template_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get mail template' => ['GET', '/mail-templates/order_conf?locale=en-US&source=core'];
+        yield 'edit mail template' => ['PATCH', '/mail-templates/order_conf'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds two endpoints on a single template file (identified by `templateName` + `locale` + `source` + optional `moduleName`):<br/>- `GET /mail-templates/{templateName}?locale=…&source=…&moduleName=…` (GetEmailBodyTemplateForEditing → returns `htmlContent` + `txtContent`)<br/>- `PATCH /mail-templates/{templateName}` body `{locale, source, moduleName?, htmlContent, txtContent}` (EditEmailBodyTemplateCommand)<br/>Follows #370 (list). |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; scope-protection tests only — a full happy-path test would need to seed a writable per-locale mail-template file tree. |

**⚠️ Depends on PR #220** — the core MailTemplate domain was introduced in PS 9.1+/develop and does not exist at the 9.0.3 tag. The 9.0.3 CI matrix legs will fail here until #220 (drop 9.0.3 from CI) lands.