### PR TITLE
Add GetCmsPageCategoriesForBreadcrumb Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryBreadcrumbItem.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryBreadcrumbItem.php
@@ -29,7 +29,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
 #[ApiResource(
     operations: [
         new CQRSGetCollection(
-            uriTemplate: '/cms-page-categories/{currentCategoryId}/breadcrumb',
+            uriTemplate: '/cms-page-categories/{currentCategoryId}/breadcrumbs',
             requirements: ['currentCategoryId' => '\d+'],
             CQRSQuery: GetCmsPageCategoriesForBreadcrumb::class,
             scopes: ['cms_page_category_read'],

--- a/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryBreadcrumbItem.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryBreadcrumbItem.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageCategoriesForBreadcrumb;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/cms-page-categories/{currentCategoryId}/breadcrumb',
+            requirements: ['currentCategoryId' => '\d+'],
+            CQRSQuery: GetCmsPageCategoriesForBreadcrumb::class,
+            scopes: ['cms_page_category_read'],
+        ),
+    ],
+)]
+class CmsPageCategoryBreadcrumbItem
+{
+    public int $cmsPageCategoryId;
+
+    public string $name;
+}

--- a/tests/Integration/ApiPlatform/CmsPageCategoryBreadcrumbEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CmsPageCategoryBreadcrumbEndpointTest.php
@@ -32,13 +32,13 @@ class CmsPageCategoryBreadcrumbEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'breadcrumb endpoint' => ['GET', '/cms-page-categories/1/breadcrumb'];
+        yield 'breadcrumb endpoint' => ['GET', '/cms-page-categories/1/breadcrumbs'];
     }
 
     public function testBreadcrumbForRoot(): void
     {
         // ROOT (1) breadcrumb is a single-entry array pointing to itself.
-        $result = $this->getItem('/cms-page-categories/1/breadcrumb', ['cms_page_category_read']);
+        $result = $this->getItem('/cms-page-categories/1/breadcrumbs', ['cms_page_category_read']);
 
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);

--- a/tests/Integration/ApiPlatform/CmsPageCategoryBreadcrumbEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CmsPageCategoryBreadcrumbEndpointTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class CmsPageCategoryBreadcrumbEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['cms_page_category_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'breadcrumb endpoint' => ['GET', '/cms-page-categories/1/breadcrumb'];
+    }
+
+    public function testBreadcrumbForRoot(): void
+    {
+        // ROOT (1) breadcrumb is a single-entry array pointing to itself.
+        $result = $this->getItem('/cms-page-categories/1/breadcrumb', ['cms_page_category_read']);
+
+        $this->assertIsArray($result);
+        $this->assertNotEmpty($result);
+        foreach ($result as $row) {
+            $this->assertArrayHasKey('cmsPageCategoryId', $row);
+            $this->assertIsInt($row['cmsPageCategoryId']);
+            $this->assertArrayHasKey('name', $row);
+            $this->assertIsString($row['name']);
+        }
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `GET /cms-page-categories/{currentCategoryId}/breadcrumb` using `CQRSGetCollection` with `GetCmsPageCategoriesForBreadcrumb`. The core `Breadcrumb` result is an `IteratorAggregate` of `BreadcrumbItem {cmsPageCategoryId, name}`; the CQRSApiNormalizer iterates it to a plain items list which `CQRSGetCollection` surfaces as an array. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; `CmsPageCategoryBreadcrumbEndpointTest` fetches the breadcrumb for ROOT (id=1) and verifies each row has `cmsPageCategoryId` + `name`. |