### PR TITLE
Add CancelOrderProduct Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderProductCancellation.php
+++ b/src/ApiPlatform/Resources/Order/OrderProductCancellation.php
@@ -25,8 +25,8 @@ namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\CancelOrderProductCommand;
-use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotCancelOrderProductException;
-use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CartRuleValidityException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidCancelProductException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\InvalidOrderStateException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
@@ -44,8 +44,8 @@ use Symfony\Component\Validator\Constraints as Assert;
     ],
     exceptionToStatus: [
         OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
-        CannotCancelOrderProductException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
-        CartRuleValidityException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        InvalidCancelProductException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        InvalidOrderStateException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
         OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
     ],
 )]

--- a/src/ApiPlatform/Resources/Order/OrderProductCancellation.php
+++ b/src/ApiPlatform/Resources/Order/OrderProductCancellation.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\CancelOrderProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CannotCancelOrderProductException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\CartRuleValidityException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/orders/{orderId}/product-cancellations',
+            requirements: ['orderId' => '\d+'],
+            CQRSCommand: CancelOrderProductCommand::class,
+            scopes: ['order_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CannotCancelOrderProductException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CartRuleValidityException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderProductCancellation
+{
+    public int $orderId;
+
+    /**
+     * Associative map { "orderDetailId": cancelQuantity }.
+     */
+    #[ApiProperty(openapiContext: [
+        'type' => 'object',
+        'description' => 'Map of orderDetailId (string int) → quantity to cancel',
+        'additionalProperties' => ['type' => 'integer', 'minimum' => 1],
+        'example' => ['1' => 2, '2' => 1],
+    ])]
+    #[Assert\NotBlank]
+    public array $cancelledProducts;
+}

--- a/tests/Integration/ApiPlatform/OrderProductCancellationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderProductCancellationEndpointTest.php
@@ -34,13 +34,18 @@ class OrderProductCancellationEndpointTest extends ApiTestCase
         parent::setUpBeforeClass();
         self::createApiClient(['order_write']);
 
-        // Pick any fixture order together with one of its order_detail rows.
-        // Fashion demo orders are in paid states, so this is enough to exercise
-        // the InvalidOrderStateException::ALREADY_PAID branch (422).
+        // Pick a fixture order that has at least one order_payment row: that is
+        // what Order::hasPayments() checks, so checkOrderState() short-circuits
+        // to InvalidOrderStateException::ALREADY_PAID (422) before any stock
+        // movement is written. Without this filter the negative test can pick
+        // an order that proceeds into the cancel path and hits the unrelated
+        // StockMvt::setIdEmployee(null) TypeError (core #41803).
         $row = \Db::getInstance()->getRow(
             'SELECT o.`id_order`, od.`id_order_detail`
              FROM `' . _DB_PREFIX_ . 'orders` o
-             INNER JOIN `' . _DB_PREFIX_ . 'order_detail` od ON od.`id_order` = o.`id_order`'
+             INNER JOIN `' . _DB_PREFIX_ . 'order_detail` od ON od.`id_order` = o.`id_order`
+             INNER JOIN `' . _DB_PREFIX_ . 'order_payment` op ON op.`order_reference` = o.`reference`
+             LIMIT 1'
         );
         self::$paidOrderId = (int) $row['id_order'];
         self::$paidOrderDetailId = (int) $row['id_order_detail'];
@@ -78,8 +83,9 @@ class OrderProductCancellationEndpointTest extends ApiTestCase
 
     public function testCancelOnAlreadyPaidOrderReturns422(): void
     {
-        // Fixture orders are paid → checkOrderState() throws
-        // InvalidOrderStateException::ALREADY_PAID, mapped to 422.
+        // The fixture order was selected because it has an order_payment row,
+        // so checkOrderState() throws InvalidOrderStateException::ALREADY_PAID
+        // (via hasPayments()) and returns 422 before any stock movement.
         $this->createItem(
             '/orders/' . self::$paidOrderId . '/product-cancellations',
             ['cancelledProducts' => [(string) self::$paidOrderDetailId => 1]],

--- a/tests/Integration/ApiPlatform/OrderProductCancellationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderProductCancellationEndpointTest.php
@@ -22,16 +22,84 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use Symfony\Component\HttpFoundation\Response;
+
 class OrderProductCancellationEndpointTest extends ApiTestCase
 {
+    private static int $paidOrderId;
+    private static int $paidOrderDetailId;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::createApiClient(['order_write']);
+
+        // Pick any fixture order together with one of its order_detail rows.
+        // Fashion demo orders are in paid states, so this is enough to exercise
+        // the InvalidOrderStateException::ALREADY_PAID branch (422).
+        $row = \Db::getInstance()->getRow(
+            'SELECT o.`id_order`, od.`id_order_detail`
+             FROM `' . _DB_PREFIX_ . 'orders` o
+             INNER JOIN `' . _DB_PREFIX_ . 'order_detail` od ON od.`id_order` = o.`id_order`
+             LIMIT 1'
+        );
+        self::$paidOrderId = (int) $row['id_order'];
+        self::$paidOrderDetailId = (int) $row['id_order_detail'];
     }
 
     public static function getProtectedEndpoints(): iterable
     {
         yield 'cancel order product endpoint' => ['POST', '/orders/1/product-cancellations'];
+    }
+
+    public function testEmptyCancelledProductsReturns422(): void
+    {
+        // Assert\NotBlank on `cancelledProducts` rejects an empty map at
+        // validation time — before the handler runs.
+        $this->createItem(
+            '/orders/' . self::$paidOrderId . '/product-cancellations',
+            ['cancelledProducts' => []],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+    }
+
+    public function testInvalidQuantityReturns422(): void
+    {
+        // Quantity <= 0 triggers InvalidCancelProductException::INVALID_QUANTITY.
+        // checkInput() runs BEFORE checkOrderState(), so this fires even on a
+        // paid fixture order.
+        $this->createItem(
+            '/orders/' . self::$paidOrderId . '/product-cancellations',
+            ['cancelledProducts' => [(string) self::$paidOrderDetailId => 0]],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+    }
+
+    public function testCancelOnAlreadyPaidOrderReturns422(): void
+    {
+        // Fixture orders are paid → checkOrderState() throws
+        // InvalidOrderStateException::ALREADY_PAID, mapped to 422.
+        $this->createItem(
+            '/orders/' . self::$paidOrderId . '/product-cancellations',
+            ['cancelledProducts' => [(string) self::$paidOrderDetailId => 1]],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+    }
+
+    public function testCancelProductHappyPath(): void
+    {
+        // A real happy-path cancel decreases the order line's quantity, which
+        // eventually calls Core\Stock\StockManager::saveMovement(). In the API
+        // context there is no logged-in employee, so the movement recording
+        // hits StockMvt::setIdEmployee(null) → TypeError. Core PR
+        // PrestaShop/PrestaShop#41803 guards that; until it ships we cannot
+        // exercise the full success path in CI.
+        //
+        // Enable this test (and add unpaid-order + order_detail seeding) once
+        // #41803 is merged and available in the tested core versions.
+        self::markTestSkipped('Depends on core PR PrestaShop/PrestaShop#41803 (StockMvt null-employee guard).');
     }
 }

--- a/tests/Integration/ApiPlatform/OrderProductCancellationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderProductCancellationEndpointTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class OrderProductCancellationEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'cancel order product endpoint' => ['POST', '/orders/1/product-cancellations'];
+    }
+}

--- a/tests/Integration/ApiPlatform/OrderProductCancellationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/OrderProductCancellationEndpointTest.php
@@ -40,8 +40,7 @@ class OrderProductCancellationEndpointTest extends ApiTestCase
         $row = \Db::getInstance()->getRow(
             'SELECT o.`id_order`, od.`id_order_detail`
              FROM `' . _DB_PREFIX_ . 'orders` o
-             INNER JOIN `' . _DB_PREFIX_ . 'order_detail` od ON od.`id_order` = o.`id_order`
-             LIMIT 1'
+             INNER JOIN `' . _DB_PREFIX_ . 'order_detail` od ON od.`id_order` = o.`id_order`'
         );
         self::$paidOrderId = (int) $row['id_order'];
         self::$paidOrderDetailId = (int) $row['id_order_detail'];


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `POST /orders/{orderId}/product-cancellations` using `CQRSCreate` with `CancelOrderProductCommand`. Body: `{cancelledProducts: {\"orderDetailId\": quantity}}` — the associative map is the Command's ctor arg verbatim. URI segment `product-cancellations` is idempotent under Rector (last word `cancellations` already plural). |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; scope-protection tests only — a full happy-path test would need to seed a paid, non-shipped order + a valid order-detail row set which the existing test infrastructure does not currently expose. |