### PR TITLE
Add CmsPageCategory localized-name Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryLocalizedName.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryLocalizedName.php
@@ -30,7 +30,7 @@ use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
 #[ApiResource(
     operations: [
         new CQRSGet(
-            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}/localized-name',
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}/localized-names',
             requirements: ['cmsPageCategoryId' => '\d+'],
             CQRSQuery: GetCmsPageCategoryNameForListing::class,
             scopes: ['cms_page_category_read'],

--- a/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryLocalizedName.php
+++ b/src/ApiPlatform/Resources/CmsPageCategory/CmsPageCategoryLocalizedName.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CmsPageCategory;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CmsPageCategory\Query\GetCmsPageCategoryNameForListing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/cms-page-categories/{cmsPageCategoryId}/localized-name',
+            requirements: ['cmsPageCategoryId' => '\d+'],
+            CQRSQuery: GetCmsPageCategoryNameForListing::class,
+            scopes: ['cms_page_category_read'],
+            CQRSQueryMapping: [
+                '[_queryResult]' => '[name]',
+            ],
+        ),
+    ],
+)]
+class CmsPageCategoryLocalizedName
+{
+    #[ApiProperty(identifier: true)]
+    public int $cmsPageCategoryId;
+
+    public string $name;
+}

--- a/tests/Integration/ApiPlatform/CmsPageCategoryLocalizedNameEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CmsPageCategoryLocalizedNameEndpointTest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class CmsPageCategoryLocalizedNameEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['cms_page_category_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get cms page category localized name' => ['GET', '/cms-page-categories/1/localized-name'];
+    }
+
+    public function testGetLocalizedName(): void
+    {
+        $result = $this->getItem('/cms-page-categories/1/localized-name', ['cms_page_category_read']);
+
+        $this->assertArrayHasKey('cmsPageCategoryId', $result);
+        $this->assertSame(1, $result['cmsPageCategoryId']);
+        $this->assertArrayHasKey('name', $result);
+        $this->assertIsString($result['name']);
+    }
+}

--- a/tests/Integration/ApiPlatform/CmsPageCategoryLocalizedNameEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CmsPageCategoryLocalizedNameEndpointTest.php
@@ -32,12 +32,12 @@ class CmsPageCategoryLocalizedNameEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'get cms page category localized name' => ['GET', '/cms-page-categories/1/localized-name'];
+        yield 'get cms page category localized name' => ['GET', '/cms-page-categories/1/localized-names'];
     }
 
     public function testGetLocalizedName(): void
     {
-        $result = $this->getItem('/cms-page-categories/1/localized-name', ['cms_page_category_read']);
+        $result = $this->getItem('/cms-page-categories/1/localized-names', ['cms_page_category_read']);
 
         $this->assertArrayHasKey('cmsPageCategoryId', $result);
         $this->assertSame(1, $result['cmsPageCategoryId']);


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `GET /cms-page-categories/{cmsPageCategoryId}/localized-name` using `CQRSGet` with `GetCmsPageCategoryNameForListing`. Uses `[_queryResult]` scalar wrap — the handler returns a plain string (the localized category name in the context language) surfaced as `{name}`. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; `CmsPageCategoryLocalizedNameEndpointTest` fetches id=1 (ROOT) and expects a string name. |

**⚠️ Depends on PrestaShop/PrestaShop#42046** — that PR adds an explicit ctor arg (`?int $cmsPageCategoryId`) to the query. Without it the handler reads `id_cms_category` from the current HTTP request instead, which means the URL segment `{cmsPageCategoryId}` is ignored and the response is always the root-category name. The test targets id=1 = ROOT so it stays green during the transition; it will validate the URL-driven id once the core change reaches this module's CI dependencies.