### PR TITLE
Add ForwardCustomerThread Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/CustomerService/CustomerThreadForward.php
+++ b/src/ApiPlatform/Resources/CustomerService/CustomerThreadForward.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\CustomerService;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Command\ForwardCustomerThreadCommand;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerServiceException;
+use PrestaShop\PrestaShop\Core\Domain\CustomerService\Exception\CustomerThreadNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/customer-threads/{customerThreadId}/forwards',
+            requirements: ['customerThreadId' => '\d+'],
+            CQRSCommand: ForwardCustomerThreadCommand::class,
+            scopes: ['customer_thread_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CustomerThreadNotFoundException::class => Response::HTTP_NOT_FOUND,
+        CustomerServiceException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CustomerThreadForward
+{
+    public int $customerThreadId;
+
+    #[Assert\NotBlank]
+    public string $comment;
+
+    /** Forward to another employee. Mutually exclusive with $email. */
+    public ?int $employeeId = null;
+
+    /** Forward to someone else by email. Mutually exclusive with $employeeId. */
+    #[Assert\Email(mode: Assert\Email::VALIDATION_MODE_STRICT)]
+    public ?string $email = null;
+}

--- a/src/ApiPlatform/Resources/CustomerService/CustomerThreadForward.php
+++ b/src/ApiPlatform/Resources/CustomerService/CustomerThreadForward.php
@@ -33,7 +33,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiResource(
     operations: [
         new CQRSCreate(
-            uriTemplate: '/customer-threads/{customerThreadId}/forwards',
+            uriTemplate: '/customer-services/{customerThreadId}/forwards',
             requirements: ['customerThreadId' => '\d+'],
             CQRSCommand: ForwardCustomerThreadCommand::class,
             scopes: ['customer_thread_write'],

--- a/tests/Integration/ApiPlatform/CustomerThreadForwardEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerThreadForwardEndpointTest.php
@@ -32,6 +32,6 @@ class CustomerThreadForwardEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'forward customer thread endpoint' => ['POST', '/customer-threads/1/forwards'];
+        yield 'forward customer thread endpoint' => ['POST', '/customer-services/1/forwards'];
     }
 }

--- a/tests/Integration/ApiPlatform/CustomerThreadForwardEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerThreadForwardEndpointTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class CustomerThreadForwardEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['customer_thread_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'forward customer thread endpoint' => ['POST', '/customer-threads/1/forwards'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `POST /customer-threads/{customerThreadId}/forwards` using `CQRSCreate` with `ForwardCustomerThreadCommand`. Body: `{comment, employeeId? \| email?}` — pass one of the two to select the forwarding target. Safe in CI: `PS_MAIL_METHOD = METHOD_DISABLE (3)` so `Mail::send` returns true without contacting an MTA. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Scope-protection test for now — a happy-path test would need to seed a `customer_thread` row + a valid employee id / email. |

**⚠️ Depends on PrestaShop/PrestaShop#42047** — the Command has a private ctor + static factories (same pattern as #42045). Until #42047 lands the resource is registered but Symfony can't denormalize the body. The endpoint will turn green automatically after the core change reaches this module's CI dependencies.