### PR TITLE
Add GetPermissionsForConfiguration Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Profile/ProfilePermissions.php
+++ b/src/ApiPlatform/Resources/Profile/ProfilePermissions.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Profile;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Profile\Permission\Query\GetPermissionsForConfiguration;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/profiles/{employeeProfileId}/permissions',
+            requirements: ['employeeProfileId' => '\d+'],
+            CQRSQuery: GetPermissionsForConfiguration::class,
+            scopes: ['profile_read'],
+        ),
+    ],
+)]
+class ProfilePermissions
+{
+    #[ApiProperty(identifier: true)]
+    public int $employeeProfileId;
+
+    public bool $hasEmployeeEditPermission;
+
+    /** Map { profileId: { tabId: {view, add, edit, delete}[] } } */
+    #[ApiProperty(openapiContext: ['type' => 'object'])]
+    public array $profilePermissionsForTabs;
+
+    /** Map { profileId: { moduleId: {view, configure, uninstall}[] } } */
+    #[ApiProperty(openapiContext: ['type' => 'object'])]
+    public array $profilePermissionsForModules;
+
+    /** Map { profileId: { view, add, edit, delete, all } } */
+    #[ApiProperty(openapiContext: ['type' => 'object'])]
+    public array $bulkConfiguration;
+
+    public array $profiles;
+
+    public array $tabs;
+
+    public array $permissions;
+}

--- a/tests/Integration/ApiPlatform/ProfilePermissionsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProfilePermissionsEndpointTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ProfilePermissionsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['profile_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'profile permissions endpoint' => ['GET', '/profiles/1/permissions'];
+    }
+
+    public function testGetPermissionsForConfiguration(): void
+    {
+        // Employee profile id 1 = SuperAdmin.
+        $result = $this->getItem('/profiles/1/permissions', ['profile_read']);
+
+        $this->assertArrayHasKey('employeeProfileId', $result);
+        $this->assertSame(1, $result['employeeProfileId']);
+        $this->assertArrayHasKey('profilePermissionsForTabs', $result);
+        $this->assertIsArray($result['profilePermissionsForTabs']);
+        $this->assertArrayHasKey('profilePermissionsForModules', $result);
+        $this->assertIsArray($result['profilePermissionsForModules']);
+        $this->assertArrayHasKey('bulkConfiguration', $result);
+        $this->assertIsArray($result['bulkConfiguration']);
+        $this->assertArrayHasKey('profiles', $result);
+        $this->assertArrayHasKey('tabs', $result);
+        $this->assertArrayHasKey('permissions', $result);
+        $this->assertArrayHasKey('hasEmployeeEditPermission', $result);
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `GET /profiles/{employeeProfileId}/permissions` using `CQRSGet` with `GetPermissionsForConfiguration`. Response mirrors the `ConfigurablePermissions` aggregate: `profilePermissionsForTabs`, `profilePermissionsForModules`, `bulkConfiguration`, `profiles`, `tabs`, `permissions`, `hasEmployeeEditPermission`. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Run `composer phpunit-integration`; `ProfilePermissionsEndpointTest` fetches profile 1 (SuperAdmin) and asserts the eight top-level fields. |

**⚠️ Depends on PrestaShop/PrestaShop#42048** — that PR exposes a raw `getBulkConfiguration(): array` accessor on `ConfigurablePermissions`. Today the bulk state is only reachable through per-profile-per-action `isBulk*Enabled(int $profileId)` methods, which the normalizer can't invoke on its own. Until #42048 lands the endpoint returns the aggregate minus `bulkConfiguration`; the field will start populating automatically after the core change reaches this module's CI dependencies.