### PR TITLE
Add VirtualProductFile Admin API endpoints (add + update)

### DIFF
--- a/src/ApiPlatform/Resources/Product/VirtualProductFile.php
+++ b/src/ApiPlatform/Resources/Product/VirtualProductFile.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\InvalidProductTypeException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Command\AddVirtualProductFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Command\UpdateVirtualProductFileCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\VirtualProductFileConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\Product\VirtualProductFile\Exception\VirtualProductFileNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/products/{productId}/virtual-file',
+            requirements: ['productId' => '\d+'],
+            CQRSCommand: AddVirtualProductFileCommand::class,
+            scopes: ['product_write'],
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/virtual-product-files/{virtualProductFileId}',
+            requirements: ['virtualProductFileId' => '\d+'],
+            read: false,
+            CQRSCommand: UpdateVirtualProductFileCommand::class,
+            scopes: ['product_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+        VirtualProductFileNotFoundException::class => Response::HTTP_NOT_FOUND,
+        InvalidProductTypeException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        VirtualProductFileConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class VirtualProductFile
+{
+    public int $productId;
+
+    #[ApiProperty(identifier: true)]
+    public int $virtualProductFileId;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $filePath;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $displayName;
+
+    public ?int $accessDays = null;
+
+    public ?int $downloadTimesLimit = null;
+
+    public ?\DateTimeImmutable $expirationDate = null;
+}

--- a/src/ApiPlatform/Resources/Product/VirtualProductFile.php
+++ b/src/ApiPlatform/Resources/Product/VirtualProductFile.php
@@ -38,13 +38,13 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiResource(
     operations: [
         new CQRSCreate(
-            uriTemplate: '/products/{productId}/virtual-file',
+            uriTemplate: '/products/{productId}/virtual-files',
             requirements: ['productId' => '\d+'],
             CQRSCommand: AddVirtualProductFileCommand::class,
             scopes: ['product_write'],
         ),
         new CQRSPartialUpdate(
-            uriTemplate: '/virtual-product-files/{virtualProductFileId}',
+            uriTemplate: '/products/virtual-files/{virtualProductFileId}',
             requirements: ['virtualProductFileId' => '\d+'],
             read: false,
             CQRSCommand: UpdateVirtualProductFileCommand::class,

--- a/tests/Integration/ApiPlatform/VirtualProductFileEndpointTest.php
+++ b/tests/Integration/ApiPlatform/VirtualProductFileEndpointTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class VirtualProductFileEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'add virtual product file endpoint' => ['POST', '/products/1/virtual-file'];
+        yield 'update virtual product file endpoint' => ['PATCH', '/virtual-product-files/1'];
+    }
+}

--- a/tests/Integration/ApiPlatform/VirtualProductFileEndpointTest.php
+++ b/tests/Integration/ApiPlatform/VirtualProductFileEndpointTest.php
@@ -32,7 +32,7 @@ class VirtualProductFileEndpointTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'add virtual product file endpoint' => ['POST', '/products/1/virtual-file'];
-        yield 'update virtual product file endpoint' => ['PATCH', '/virtual-product-files/1'];
+        yield 'add virtual product file endpoint' => ['POST', '/products/1/virtual-files'];
+        yield 'update virtual product file endpoint' => ['PATCH', '/products/virtual-files/1'];
     }
 }


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds:<br/>- `POST /products/{productId}/virtual-file` (AddVirtualProductFileCommand — body `{filePath, displayName, accessDays?, downloadTimesLimit?, expirationDate?}`)<br/>- `PATCH /virtual-product-files/{virtualProductFileId}` (UpdateVirtualProductFileCommand — ID-only ctor + optional setters).<br/>`filePath` in the POST body points to a temp file on disk that the uploader will validate + copy to `_PS_DOWNLOAD_DIR_`. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Scope-protection tests only — happy-path coverage requires seeding a TYPE_VIRTUAL product AND placing a real file at the target `filePath`, which the existing test infrastructure does not currently expose. |