### PR TITLE
Add SetProductImagesForAllShop Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Product/ProductShopImagesAssociation.php
+++ b/src/ApiPlatform/Resources/Product/ProductShopImagesAssociation.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\SetProductImagesForAllShopCommand;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/products/{productId}/image-shop-associations',
+            requirements: ['productId' => '\d+'],
+            read: false,
+            CQRSCommand: SetProductImagesForAllShopCommand::class,
+            scopes: ['product_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ProductNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ProductShopImagesAssociation
+{
+    public int $productId;
+
+    /**
+     * Array of {productImageId, shopIds} settings — each item mirrors the ProductImageSetting VO shape.
+     */
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'productImageId' => ['type' => 'integer'],
+                'shopIds' => ['type' => 'array', 'items' => ['type' => 'integer']],
+            ],
+            'required' => ['productImageId', 'shopIds'],
+        ],
+    ])]
+    #[Assert\NotBlank]
+    public array $productImageSettings;
+}

--- a/tests/Integration/ApiPlatform/ProductShopImagesAssociationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductShopImagesAssociationEndpointTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ProductShopImagesAssociationEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['product_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'product image shop associations endpoint' => ['PUT', '/products/1/image-shop-associations'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `PUT /products/{productId}/image-shop-associations` using `CQRSUpdate` with `SetProductImagesForAllShopCommand`. Body: `{productImageSettings: [{productImageId, shopIds[]}, ...]}` — mirrors the `ProductImageSetting` VO shape. Each entry maps an image to a set of shops the image should belong to; images not listed are detached from all shops. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Scope-protection test only for now — full happy-path coverage would need multi-shop fixtures + seeded product images that the existing test infrastructure does not currently expose. |

**⚠️ Depends on PrestaShop/PrestaShop#42049** — that PR adds a public `setProductImageSettings(array)` bulk setter to the command. Today only the per-item `addProductSetting()` adder exists, which Symfony's serializer can't drive from a JSON body. After #42049 lands the endpoint will start denormalizing correctly.