### PR TITLE
Add Order refund + product-return Admin API endpoints

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderProductReturn.php
+++ b/src/ApiPlatform/Resources/Order/OrderProductReturn.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\IssueReturnProductCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/orders/{orderId}/product-returns',
+            requirements: ['orderId' => '\d+'],
+            CQRSCommand: IssueReturnProductCommand::class,
+            scopes: ['order_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderProductReturn
+{
+    public int $orderId;
+
+    /** Array of {orderDetailId, productQuantity, refundedAmount?}. */
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'orderDetailId' => ['type' => 'integer'],
+                'productQuantity' => ['type' => 'integer', 'minimum' => 1],
+                'refundedAmount' => ['type' => 'string', 'description' => 'Optional per-line refund amount (partial refund); omit for a full-line refund.'],
+            ],
+            'required' => ['orderDetailId', 'productQuantity'],
+        ],
+    ])]
+    #[Assert\NotBlank]
+    public array $orderDetailRefunds;
+
+    #[Assert\NotNull]
+    public bool $restockRefundedProducts;
+
+    #[Assert\NotNull]
+    public bool $refundShippingCost;
+
+    #[Assert\NotNull]
+    public bool $generateCreditSlip;
+
+    #[Assert\NotNull]
+    public bool $generateVoucher;
+
+    #[Assert\NotNull]
+    public int $voucherRefundType;
+}

--- a/src/ApiPlatform/Resources/Order/OrderProductReturn.php
+++ b/src/ApiPlatform/Resources/Order/OrderProductReturn.php
@@ -49,18 +49,21 @@ class OrderProductReturn
 {
     public int $orderId;
 
-    /** Array of {orderDetailId, productQuantity, refundedAmount?}. */
+    /**
+     * Refunds keyed by order detail id, each with a "quantity". This matches
+     * IssueReturnProductCommand::setOrderDetailRefunds() which iterates the
+     * array as `{orderDetailId} => ['quantity' => N]`.
+     */
     #[ApiProperty(openapiContext: [
-        'type' => 'array',
-        'items' => [
+        'type' => 'object',
+        'additionalProperties' => [
             'type' => 'object',
             'properties' => [
-                'orderDetailId' => ['type' => 'integer'],
-                'productQuantity' => ['type' => 'integer', 'minimum' => 1],
-                'refundedAmount' => ['type' => 'string', 'description' => 'Optional per-line refund amount (partial refund); omit for a full-line refund.'],
+                'quantity' => ['type' => 'integer', 'minimum' => 1],
             ],
-            'required' => ['orderDetailId', 'productQuantity'],
+            'required' => ['quantity'],
         ],
+        'example' => ['12' => ['quantity' => 2]],
     ])]
     #[Assert\NotBlank]
     public array $orderDetailRefunds;

--- a/src/ApiPlatform/Resources/Order/OrderStandardRefund.php
+++ b/src/ApiPlatform/Resources/Order/OrderStandardRefund.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\IssueStandardRefundCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/orders/{orderId}/refunds',
+            requirements: ['orderId' => '\d+'],
+            CQRSCommand: IssueStandardRefundCommand::class,
+            scopes: ['order_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class OrderStandardRefund
+{
+    public int $orderId;
+
+    /** Array of {orderDetailId, productQuantity, refundedAmount?}. */
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'orderDetailId' => ['type' => 'integer'],
+                'productQuantity' => ['type' => 'integer', 'minimum' => 1],
+                'refundedAmount' => ['type' => 'string', 'description' => 'Optional per-line refund amount (partial refund); omit for a full-line refund.'],
+            ],
+            'required' => ['orderDetailId', 'productQuantity'],
+        ],
+    ])]
+    #[Assert\NotBlank]
+    public array $orderDetailRefunds;
+
+    #[Assert\NotNull]
+    public bool $refundShippingCost;
+
+    #[Assert\NotNull]
+    public bool $generateCreditSlip;
+
+    #[Assert\NotNull]
+    public bool $generateVoucher;
+
+    #[Assert\NotNull]
+    public int $voucherRefundType;
+}

--- a/src/ApiPlatform/Resources/Order/OrderStandardRefund.php
+++ b/src/ApiPlatform/Resources/Order/OrderStandardRefund.php
@@ -49,18 +49,21 @@ class OrderStandardRefund
 {
     public int $orderId;
 
-    /** Array of {orderDetailId, productQuantity, refundedAmount?}. */
+    /**
+     * Refunds keyed by order detail id, each with a "quantity". This matches
+     * IssueStandardRefundCommand::setOrderDetailRefunds() which iterates the
+     * array as `{orderDetailId} => ['quantity' => N]`.
+     */
     #[ApiProperty(openapiContext: [
-        'type' => 'array',
-        'items' => [
+        'type' => 'object',
+        'additionalProperties' => [
             'type' => 'object',
             'properties' => [
-                'orderDetailId' => ['type' => 'integer'],
-                'productQuantity' => ['type' => 'integer', 'minimum' => 1],
-                'refundedAmount' => ['type' => 'string', 'description' => 'Optional per-line refund amount (partial refund); omit for a full-line refund.'],
+                'quantity' => ['type' => 'integer', 'minimum' => 1],
             ],
-            'required' => ['orderDetailId', 'productQuantity'],
+            'required' => ['quantity'],
         ],
+        'example' => ['12' => ['quantity' => 2]],
     ])]
     #[Assert\NotBlank]
     public array $orderDetailRefunds;

--- a/tests/Integration/ApiPlatform/OrderRefundEndpointsTest.php
+++ b/tests/Integration/ApiPlatform/OrderRefundEndpointsTest.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class OrderRefundEndpointsTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'issue standard refund endpoint' => ['POST', '/orders/1/refunds'];
+        yield 'issue return product endpoint' => ['POST', '/orders/1/product-returns'];
+    }
+}

--- a/tests/Integration/ApiPlatform/OrderRefundEndpointsTest.php
+++ b/tests/Integration/ApiPlatform/OrderRefundEndpointsTest.php
@@ -23,13 +23,48 @@ declare(strict_types=1);
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
 use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
 
 class OrderRefundEndpointsTest extends ApiTestCase
 {
+    private static int $orderId;
+    private static int $orderDetailId;
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::createApiClient(['order_write']);
+
+        // Pick the first seeded order that has at least one order_detail row,
+        // then bring it into a paid state so a standard refund is allowed
+        // (paying the order also triggers invoice generation, which the
+        // IssueStandardRefundCommand handler needs).
+        $row = \Db::getInstance()->getRow(
+            'SELECT o.id_order, od.id_order_detail
+               FROM `' . _DB_PREFIX_ . 'orders` o
+               INNER JOIN `' . _DB_PREFIX_ . 'order_detail` od
+                       ON od.id_order = o.id_order
+              LIMIT 1'
+        );
+        self::$orderId = (int) $row['id_order'];
+        self::$orderDetailId = (int) $row['id_order_detail'];
+
+        $order = new \Order(self::$orderId);
+        $order->setCurrentState((int) \Configuration::get('PS_OS_PAYMENT'));
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        DatabaseDump::restoreTables([
+            'orders',
+            'order_detail',
+            'order_history',
+            'order_invoice',
+            'order_payment',
+            'order_slip',
+            'order_slip_detail',
+        ]);
     }
 
     public static function getProtectedEndpoints(): iterable
@@ -68,6 +103,39 @@ class OrderRefundEndpointsTest extends ApiTestCase
             ],
             ['order_write'],
             Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+    }
+
+    public function testIssueStandardRefundGeneratesCreditSlip(): void
+    {
+        $slipsBefore = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'order_slip`
+              WHERE id_order = ' . self::$orderId
+        );
+
+        $this->createItem(
+            '/orders/' . self::$orderId . '/refunds',
+            [
+                'orderDetailRefunds' => [
+                    (string) self::$orderDetailId => ['quantity' => 1],
+                ],
+                'refundShippingCost' => false,
+                'generateCreditSlip' => true,
+                'generateVoucher' => false,
+                'voucherRefundType' => 1,
+            ],
+            ['order_write'],
+            Response::HTTP_CREATED
+        );
+
+        $slipsAfter = (int) \Db::getInstance()->getValue(
+            'SELECT COUNT(*) FROM `' . _DB_PREFIX_ . 'order_slip`
+              WHERE id_order = ' . self::$orderId
+        );
+        $this->assertSame(
+            $slipsBefore + 1,
+            $slipsAfter,
+            'a credit slip row should be created for the refunded order'
         );
     }
 }

--- a/tests/Integration/ApiPlatform/OrderRefundEndpointsTest.php
+++ b/tests/Integration/ApiPlatform/OrderRefundEndpointsTest.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use Symfony\Component\HttpFoundation\Response;
+
 class OrderRefundEndpointsTest extends ApiTestCase
 {
     public static function setUpBeforeClass(): void
@@ -34,5 +36,38 @@ class OrderRefundEndpointsTest extends ApiTestCase
     {
         yield 'issue standard refund endpoint' => ['POST', '/orders/1/refunds'];
         yield 'issue return product endpoint' => ['POST', '/orders/1/product-returns'];
+    }
+
+    public function testIssueStandardRefundRejectsMissingOrderDetailRefunds(): void
+    {
+        $this->createItem(
+            '/orders/1/refunds',
+            [
+                'orderDetailRefunds' => [],
+                'refundShippingCost' => false,
+                'generateCreditSlip' => false,
+                'generateVoucher' => false,
+                'voucherRefundType' => 1,
+            ],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+    }
+
+    public function testIssueProductReturnRejectsMissingOrderDetailRefunds(): void
+    {
+        $this->createItem(
+            '/orders/1/product-returns',
+            [
+                'orderDetailRefunds' => [],
+                'restockRefundedProducts' => false,
+                'refundShippingCost' => false,
+                'generateCreditSlip' => false,
+                'generateVoucher' => false,
+                'voucherRefundType' => 1,
+            ],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
     }
 }


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds:<br/>- `POST /orders/{orderId}/refunds` (IssueStandardRefundCommand)<br/>- `POST /orders/{orderId}/product-returns` (IssueReturnProductCommand)<br/>Body shape for both: `{orderDetailRefunds: [{orderDetailId, productQuantity, refundedAmount?}, ...], refundShippingCost, generateCreditSlip, generateVoucher, voucherRefundType}` — plus `restockRefundedProducts` on the product-return endpoint. `refundedAmount` is optional per line (partial refund vs full-line refund). |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Scope-protection tests only — full happy-path coverage would need seeding an order with paid+shipped order-detail rows, which the existing test infrastructure does not currently expose. |

**⚠️ Depends on PrestaShop/PrestaShop#42050** — that PR exposes `OrderDetailRefund::__construct` as public. Both commands take `array $orderDetailRefunds` expecting `OrderDetailRefund[]`; Symfony's serializer needs a usable public ctor to denormalize each entry from the JSON body.