### PR TITLE
Add BulkDeleteProductsFromOrderReturn Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/OrderReturn/BulkOrderReturnProducts.php
+++ b/src/ApiPlatform/Resources/OrderReturn/BulkOrderReturnProducts.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\OrderReturn;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Command\BulkDeleteProductsFromOrderReturnCommand;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\OrderReturn\Exception\OrderReturnNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/order-returns/{orderReturnId}/products/bulk-delete',
+            requirements: ['orderReturnId' => '\d+'],
+            CQRSCommand: BulkDeleteProductsFromOrderReturnCommand::class,
+            scopes: ['order_return_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        OrderReturnNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderReturnConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkOrderReturnProducts
+{
+    public int $orderReturnId;
+
+    /**
+     * Array of staged rows matching the Command ctor input shape.
+     * Each row: {order_detail_id: int, customization_id: int}.
+     */
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => [
+            'type' => 'object',
+            'properties' => [
+                'order_detail_id' => ['type' => 'integer'],
+                'customization_id' => ['type' => 'integer', 'default' => 0],
+            ],
+            'required' => ['order_detail_id'],
+        ],
+    ])]
+    #[Assert\NotBlank]
+    public array $stagedProductRows;
+}

--- a/tests/Integration/ApiPlatform/BulkOrderReturnProductsEndpointTest.php
+++ b/tests/Integration/ApiPlatform/BulkOrderReturnProductsEndpointTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class BulkOrderReturnProductsEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_return_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'bulk delete order return products' => ['DELETE', '/order-returns/1/products/bulk-delete'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `DELETE /order-returns/{orderReturnId}/products/bulk-delete` using `CQRSDelete` with `BulkDeleteProductsFromOrderReturnCommand`. Body: `{stagedProductRows: [{order_detail_id, customization_id?}, ...]}` — snake_case matches the Command's ctor read shape (`$row['order_detail_id']`, `$row['customization_id']`). Complements #372 (single-product delete + list). |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Scope-protection test only — happy-path coverage would need seeding an OrderReturn with real OrderReturnDetail rows which the existing test infrastructure does not currently expose. |

**⚠️ Depends on PR #220** — the OrderReturn product-mgmt commands are 9.1+/develop. 9.0.3 CI matrix legs will fail until #220 (drop 9.0.3) lands.