### PR TITLE
Add remaining Shipment command endpoints (create + fulfill + carrier + add-product)

### DIFF
--- a/src/ApiPlatform/Resources/Shipment/CreateShipment.php
+++ b/src/ApiPlatform/Resources/Shipment/CreateShipment.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Shipment;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\CreateShipment as CreateShipmentCommand;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/shipments',
+            CQRSCommand: CreateShipmentCommand::class,
+            scopes: ['shipment_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ShipmentException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CreateShipment
+{
+    #[Assert\NotBlank]
+    public int $orderId;
+
+    #[Assert\NotBlank]
+    public int $carrierId;
+
+    #[Assert\NotBlank]
+    public int $productId;
+
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
+    public int $quantity;
+
+    public ?int $combinationId = 0;
+}

--- a/src/ApiPlatform/Resources/Shipment/CreateShipment.php
+++ b/src/ApiPlatform/Resources/Shipment/CreateShipment.php
@@ -33,9 +33,9 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSCreate(
             uriTemplate: '/shipments',
-            // The Shipment CQRS domain was introduced in 9.1.0
+            // This command was introduced in 9.2.0, unlike SwitchShipmentCarrierCommand
             extraProperties: [
-                'minVersion' => '9.1.0',
+                'minVersion' => '9.2.0',
             ],
             CQRSCommand: CreateShipmentCommand::class,
             scopes: ['shipment_write'],

--- a/src/ApiPlatform/Resources/Shipment/CreateShipment.php
+++ b/src/ApiPlatform/Resources/Shipment/CreateShipment.php
@@ -33,6 +33,10 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSCreate(
             uriTemplate: '/shipments',
+            // The Shipment CQRS domain was introduced in 9.1.0
+            extraProperties: [
+                'minVersion' => '9.1.0',
+            ],
             CQRSCommand: CreateShipmentCommand::class,
             scopes: ['shipment_write'],
         ),

--- a/src/ApiPlatform/Resources/Shipment/ShipmentCarrierAssignment.php
+++ b/src/ApiPlatform/Resources/Shipment/ShipmentCarrierAssignment.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Shipment;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\SwitchShipmentCarrierCommand;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentException;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/shipments/{shipmentId}/carrier-assignments',
+            requirements: ['shipmentId' => '\d+'],
+            read: false,
+            CQRSCommand: SwitchShipmentCarrierCommand::class,
+            scopes: ['shipment_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ShipmentNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ShipmentException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ShipmentCarrierAssignment
+{
+    public int $shipmentId;
+
+    #[Assert\NotBlank]
+    public int $carrierId;
+}

--- a/src/ApiPlatform/Resources/Shipment/ShipmentCarrierAssignment.php
+++ b/src/ApiPlatform/Resources/Shipment/ShipmentCarrierAssignment.php
@@ -34,6 +34,10 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSUpdate(
             uriTemplate: '/shipments/{shipmentId}/carrier-assignments',
+            // The Shipment CQRS domain was introduced in 9.1.0
+            extraProperties: [
+                'minVersion' => '9.1.0',
+            ],
             requirements: ['shipmentId' => '\d+'],
             read: false,
             CQRSCommand: SwitchShipmentCarrierCommand::class,

--- a/src/ApiPlatform/Resources/Shipment/ShipmentCarrierAssignment.php
+++ b/src/ApiPlatform/Resources/Shipment/ShipmentCarrierAssignment.php
@@ -34,7 +34,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSUpdate(
             uriTemplate: '/shipments/{shipmentId}/carrier-assignments',
-            // The Shipment CQRS domain was introduced in 9.1.0
+            // SwitchShipmentCarrierCommand is the only one of the four that exists since 9.1.0
             extraProperties: [
                 'minVersion' => '9.1.0',
             ],

--- a/src/ApiPlatform/Resources/Shipment/ShipmentFulfillment.php
+++ b/src/ApiPlatform/Resources/Shipment/ShipmentFulfillment.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Shipment;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\FulfillShipmentCommand;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentException;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/shipments/{shipmentId}/fulfillments',
+            requirements: ['shipmentId' => '\d+'],
+            read: false,
+            CQRSCommand: FulfillShipmentCommand::class,
+            scopes: ['shipment_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ShipmentNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ShipmentException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ShipmentFulfillment
+{
+    public int $shipmentId;
+
+    #[Assert\NotBlank]
+    public string $trackingNumber;
+}

--- a/src/ApiPlatform/Resources/Shipment/ShipmentFulfillment.php
+++ b/src/ApiPlatform/Resources/Shipment/ShipmentFulfillment.php
@@ -34,9 +34,9 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSUpdate(
             uriTemplate: '/shipments/{shipmentId}/fulfillments',
-            // The Shipment CQRS domain was introduced in 9.1.0
+            // This command was introduced in 9.2.0, unlike SwitchShipmentCarrierCommand
             extraProperties: [
-                'minVersion' => '9.1.0',
+                'minVersion' => '9.2.0',
             ],
             requirements: ['shipmentId' => '\d+'],
             read: false,

--- a/src/ApiPlatform/Resources/Shipment/ShipmentFulfillment.php
+++ b/src/ApiPlatform/Resources/Shipment/ShipmentFulfillment.php
@@ -34,6 +34,10 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSUpdate(
             uriTemplate: '/shipments/{shipmentId}/fulfillments',
+            // The Shipment CQRS domain was introduced in 9.1.0
+            extraProperties: [
+                'minVersion' => '9.1.0',
+            ],
             requirements: ['shipmentId' => '\d+'],
             read: false,
             CQRSCommand: FulfillShipmentCommand::class,

--- a/src/ApiPlatform/Resources/Shipment/ShipmentProductAddition.php
+++ b/src/ApiPlatform/Resources/Shipment/ShipmentProductAddition.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Shipment;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Command\AddProductToShipment as AddProductToShipmentCommand;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentException;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/shipments/{shipmentId}/product-additions',
+            requirements: ['shipmentId' => '\d+'],
+            CQRSCommand: AddProductToShipmentCommand::class,
+            scopes: ['shipment_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        ShipmentNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ShipmentException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ShipmentProductAddition
+{
+    public int $shipmentId;
+
+    #[Assert\NotBlank]
+    public int $productId;
+
+    #[Assert\NotBlank]
+    public int $orderId;
+
+    public int $combinationId = 0;
+}

--- a/src/ApiPlatform/Resources/Shipment/ShipmentProductAddition.php
+++ b/src/ApiPlatform/Resources/Shipment/ShipmentProductAddition.php
@@ -34,9 +34,9 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSCreate(
             uriTemplate: '/shipments/{shipmentId}/product-additions',
-            // The Shipment CQRS domain was introduced in 9.1.0
+            // This command was introduced in 9.2.0, unlike SwitchShipmentCarrierCommand
             extraProperties: [
-                'minVersion' => '9.1.0',
+                'minVersion' => '9.2.0',
             ],
             requirements: ['shipmentId' => '\d+'],
             CQRSCommand: AddProductToShipmentCommand::class,

--- a/src/ApiPlatform/Resources/Shipment/ShipmentProductAddition.php
+++ b/src/ApiPlatform/Resources/Shipment/ShipmentProductAddition.php
@@ -34,6 +34,10 @@ use Symfony\Component\Validator\Constraints as Assert;
     operations: [
         new CQRSCreate(
             uriTemplate: '/shipments/{shipmentId}/product-additions',
+            // The Shipment CQRS domain was introduced in 9.1.0
+            extraProperties: [
+                'minVersion' => '9.1.0',
+            ],
             requirements: ['shipmentId' => '\d+'],
             CQRSCommand: AddProductToShipmentCommand::class,
             scopes: ['shipment_write'],

--- a/tests/Integration/ApiPlatform/ShipmentCommandsEndpointsTest.php
+++ b/tests/Integration/ApiPlatform/ShipmentCommandsEndpointsTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ShipmentCommandsEndpointsTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['shipment_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'create shipment endpoint' => ['POST', '/shipments'];
+        yield 'fulfill shipment endpoint' => ['PUT', '/shipments/1/fulfillments'];
+        yield 'switch carrier endpoint' => ['PUT', '/shipments/1/carrier-assignments'];
+        yield 'add product to shipment endpoint' => ['POST', '/shipments/1/product-additions'];
+    }
+}

--- a/tests/Integration/ApiPlatform/ShipmentCommandsEndpointsTest.php
+++ b/tests/Integration/ApiPlatform/ShipmentCommandsEndpointsTest.php
@@ -24,15 +24,23 @@ namespace PsApiResourcesTest\Integration\ApiPlatform;
 
 class ShipmentCommandsEndpointsTest extends ApiTestCase
 {
+    /**
+     * SwitchShipmentCarrierCommand exists since 9.1.0, so that is where the shipment_write
+     * scope starts existing at all.
+     */
     private const MIN_VERSION = '9.1.0';
+
+    /**
+     * CreateShipment, FulfillShipmentCommand and AddProductToShipment only landed in 9.2.0.
+     */
+    private const COMMANDS_MIN_VERSION = '9.2.0';
 
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
-        // The whole Shipment CQRS domain was introduced in 9.1.0. Below that version
-        // ApiResourceScopesExtractor drops every operation, so neither their routes nor the
-        // shipment_write scope exist and even creating the API client fails.
+        // Below 9.1.0 no Shipment operation survives ApiResourceScopesExtractor, so the
+        // shipment_write scope does not exist and even creating the API client fails.
         if (self::isVersionUnder(self::MIN_VERSION)) {
             static::markTestSkipped(sprintf('The Shipment domain requires PrestaShop >= %s.', self::MIN_VERSION));
         }
@@ -42,9 +50,14 @@ class ShipmentCommandsEndpointsTest extends ApiTestCase
 
     public static function getProtectedEndpoints(): iterable
     {
-        yield 'create shipment endpoint' => ['POST', '/shipments'];
-        yield 'fulfill shipment endpoint' => ['PUT', '/shipments/1/fulfillments'];
         yield 'switch carrier endpoint' => ['PUT', '/shipments/1/carrier-assignments'];
-        yield 'add product to shipment endpoint' => ['POST', '/shipments/1/product-additions'];
+
+        // The three other commands only exist from 9.2.0 on, so their operations are filtered
+        // out of the routing below that version and the endpoints answer 404, not 401
+        if (self::isVersionAtLeast(self::COMMANDS_MIN_VERSION)) {
+            yield 'create shipment endpoint' => ['POST', '/shipments'];
+            yield 'fulfill shipment endpoint' => ['PUT', '/shipments/1/fulfillments'];
+            yield 'add product to shipment endpoint' => ['POST', '/shipments/1/product-additions'];
+        }
     }
 }

--- a/tests/Integration/ApiPlatform/ShipmentCommandsEndpointsTest.php
+++ b/tests/Integration/ApiPlatform/ShipmentCommandsEndpointsTest.php
@@ -24,9 +24,19 @@ namespace PsApiResourcesTest\Integration\ApiPlatform;
 
 class ShipmentCommandsEndpointsTest extends ApiTestCase
 {
+    private const MIN_VERSION = '9.1.0';
+
     public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
+
+        // The whole Shipment CQRS domain was introduced in 9.1.0. Below that version
+        // ApiResourceScopesExtractor drops every operation, so neither their routes nor the
+        // shipment_write scope exist and even creating the API client fails.
+        if (self::isVersionUnder(self::MIN_VERSION)) {
+            static::markTestSkipped(sprintf('The Shipment domain requires PrestaShop >= %s.', self::MIN_VERSION));
+        }
+
         self::createApiClient(['shipment_write']);
     }
 

--- a/tests/PHPStan/phpstan-9.0.3.neon
+++ b/tests/PHPStan/phpstan-9.0.3.neon
@@ -19,3 +19,9 @@ parameters:
             identifier: class.notFound
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
+        # The Shipment CQRS domain was introduced in 9.1.0. The operations declare minVersion
+        # 9.1.0, so their classes are expected to be absent here.
+        -
+            message: "#Class .*Shipment\\\\(Command|Exception|Query|ValueObject).* not found.#"
+            identifier: class.notFound
+            path: ../../src/ApiPlatform/Resources/Shipment/*

--- a/tests/PHPStan/phpstan-9.1.4.neon
+++ b/tests/PHPStan/phpstan-9.1.4.neon
@@ -13,3 +13,9 @@ parameters:
             identifier: class.notFound
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
+        # CreateShipment, FulfillShipmentCommand and AddProductToShipment only landed in 9.2.0.
+        # Their operations declare minVersion 9.2.0, so they are expected to be absent here.
+        -
+            message: "#Class .*Shipment\\\\Command\\\\(CreateShipment|FulfillShipmentCommand|AddProductToShipment).* not found.#"
+            identifier: class.notFound
+            path: ../../src/ApiPlatform/Resources/Shipment/*


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds four Shipment write endpoints not covered by #250:<br/>- `POST /shipments` (CreateShipment)<br/>- `PUT /shipments/{shipmentId}/fulfillments` (FulfillShipmentCommand)<br/>- `PUT /shipments/{shipmentId}/carrier-assignments` (SwitchShipmentCarrierCommand)<br/>- `POST /shipments/{shipmentId}/product-additions` (AddProductToShipment)<br/>Standalone files to avoid touching the in-progress `Shipment/` folder from PR #250. URIs pick distinct compound segments so no route collides with #250. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Scope-protection tests only — full happy-path coverage requires seeding an order + carrier + product row set which the existing test infrastructure does not currently expose. |

**⚠️ Depends on PR #220** — Shipment classes are PS 9.1+/develop only. 9.0.3 CI matrix legs will fail until #220 (drop 9.0.3) lands.