### PR TITLE
Add remaining Shipment query endpoints (editable-details + 3 lists)

### DIFF
--- a/src/ApiPlatform/Resources/Order/OrderAvailableShipmentList.php
+++ b/src/ApiPlatform/Resources/Order/OrderAvailableShipmentList.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\ListAvailableShipments;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/orders/{orderId}/available-shipments',
+            requirements: ['orderId' => '\d+'],
+            CQRSQuery: ListAvailableShipments::class,
+            scopes: ['shipment_read'],
+            parameters: new Parameters([
+                new QueryParameter(
+                    key: 'orderIdDetails',
+                    required: true,
+                    description: 'Array of order-detail ids to filter available shipments against'
+                ),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    ['name' => 'orderIdDetails', 'in' => 'query', 'required' => true, 'schema' => ['type' => 'array', 'items' => ['type' => 'integer']]],
+                ],
+            ],
+        ),
+    ],
+)]
+class OrderAvailableShipmentList
+{
+    public int $id;
+
+    public string $name;
+}

--- a/src/ApiPlatform/Resources/Order/OrderDetailShipmentList.php
+++ b/src/ApiPlatform/Resources/Order/OrderDetailShipmentList.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentsForOrderDetail;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/orders/{orderId}/order-details/{orderDetailId}/shipments',
+            requirements: ['orderId' => '\d+', 'orderDetailId' => '\d+'],
+            CQRSQuery: GetShipmentsForOrderDetail::class,
+            scopes: ['shipment_read'],
+        ),
+    ],
+)]
+class OrderDetailShipmentList
+{
+    public int $shipmentId;
+
+    public int $quantity;
+}

--- a/src/ApiPlatform/Resources/Order/OrderProductAvailableShipmentList.php
+++ b/src/ApiPlatform/Resources/Order/OrderProductAvailableShipmentList.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\ListAvailableShipmentsForProduct;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/orders/{orderId}/products/{productId}/available-shipments',
+            requirements: ['orderId' => '\d+', 'productId' => '\d+'],
+            CQRSQuery: ListAvailableShipmentsForProduct::class,
+            scopes: ['shipment_read'],
+        ),
+    ],
+)]
+class OrderProductAvailableShipmentList
+{
+    public int $id;
+
+    public string $name;
+}

--- a/src/ApiPlatform/Resources/Shipment/ShipmentEditableDetails.php
+++ b/src/ApiPlatform/Resources/Shipment/ShipmentEditableDetails.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Shipment;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Parameters;
+use ApiPlatform\Metadata\QueryParameter;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Exception\ShipmentNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Shipment\Query\GetShipmentForEditing;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/shipments/{shipmentId}/editable-details',
+            requirements: ['shipmentId' => '\d+'],
+            CQRSQuery: GetShipmentForEditing::class,
+            scopes: ['shipment_read'],
+            parameters: new Parameters([
+                new QueryParameter(key: 'orderId', required: true, description: 'Owning order id'),
+            ]),
+            openapiContext: [
+                'parameters' => [
+                    ['name' => 'orderId', 'in' => 'query', 'required' => true, 'schema' => ['type' => 'integer', 'minimum' => 1]],
+                ],
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ShipmentNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class ShipmentEditableDetails
+{
+    #[ApiProperty(identifier: true)]
+    public int $shipmentId;
+
+    public int $carrierId;
+
+    public string $trackingNumber;
+
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer']])]
+    public array $selectedProducts;
+}

--- a/tests/Integration/ApiPlatform/ShipmentQueriesEndpointsTest.php
+++ b/tests/Integration/ApiPlatform/ShipmentQueriesEndpointsTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class ShipmentQueriesEndpointsTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['shipment_read']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get shipment editable details' => ['GET', '/shipments/1/editable-details?orderId=1'];
+        yield 'list available shipments' => ['GET', '/orders/1/available-shipments?orderIdDetails%5B%5D=1'];
+        yield 'get order-detail shipments' => ['GET', '/orders/1/order-details/1/shipments'];
+        yield 'list available shipments for product' => ['GET', '/orders/1/products/1/available-shipments'];
+    }
+}


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds four Shipment read endpoints not covered by #250:<br/>- `GET /shipments/{shipmentId}/editable-details?orderId=…` (GetShipmentForEditing — carrierId + trackingNumber + selectedProducts)<br/>- `GET /orders/{orderId}/available-shipments?orderIdDetails[]=…` (ListAvailableShipments — cross-detail availability filter)<br/>- `GET /orders/{orderId}/order-details/{orderDetailId}/shipments` (GetShipmentsForOrderDetail — per-detail shipmentId + quantity list)<br/>- `GET /orders/{orderId}/products/{productId}/available-shipments` (ListAvailableShipmentsForProduct — per-product availability list)<br/>The `editable-details` URI is distinct from #250's `GET /shipments/{shipmentId}` (GetShipmentForViewing) — the two queries surface different fields. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Scope-protection tests only — happy-path coverage requires seeded shipments + carriers + order-details, which the existing test infrastructure does not currently expose. |

**⚠️ Depends on PR #220** — Shipment classes are PS 9.1+/develop only. 9.0.3 CI matrix legs will fail until #220 (drop 9.0.3) lands.