### PR TITLE
Add AddOrderFromBackOffice Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Order/BackOfficeOrder.php
+++ b/src/ApiPlatform/Resources/Order/BackOfficeOrder.php
@@ -48,27 +48,30 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 class BackOfficeOrder
 {
-    #[Assert\NotBlank]
-    #[Assert\GreaterThan(0)]
-    public int $cartId;
+    public function __construct(
+        #[Assert\NotBlank]
+        #[Assert\GreaterThan(0)]
+        public int $cartId = 0,
 
-    /**
-     * Employee that placed the order. Pass NoEmployeeId::NO_EMPLOYEE_ID_VALUE (0)
-     * to skip employee attribution — this also short-circuits the
-     * translator-dependent "Manual order — Employee: …" internal note code path.
-     */
-    public int $employeeId = NoEmployeeId::NO_EMPLOYEE_ID_VALUE;
+        /**
+         * Technical name of the installed payment module driving validateOrder(),
+         * e.g. 'ps_wirepayment', 'ps_checkpayment', 'boorder'.
+         */
+        #[Assert\NotBlank]
+        public string $paymentModuleName = '',
 
-    public string $orderMessage = '';
+        #[Assert\NotBlank]
+        #[Assert\GreaterThan(0)]
+        public int $orderStateId = 0,
 
-    /**
-     * Technical name of the installed payment module driving validateOrder(),
-     * e.g. 'ps_wirepayment', 'ps_checkpayment', 'boorder'.
-     */
-    #[Assert\NotBlank]
-    public string $paymentModuleName;
+        /**
+         * Employee that placed the order. Defaults to NoEmployeeId::NO_EMPLOYEE_ID_VALUE (0)
+         * — this also short-circuits the translator-dependent "Manual order —
+         * Employee: …" internal note code path.
+         */
+        public int $employeeId = NoEmployeeId::NO_EMPLOYEE_ID_VALUE,
 
-    #[Assert\NotBlank]
-    #[Assert\GreaterThan(0)]
-    public int $orderStateId;
+        public string $orderMessage = '',
+    ) {
+    }
 }

--- a/src/ApiPlatform/Resources/Order/BackOfficeOrder.php
+++ b/src/ApiPlatform/Resources/Order/BackOfficeOrder.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Order;
+
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Cart\Exception\CartNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\NoEmployeeId;
+use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddOrderFromBackOfficeCommand;
+use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSCreate(
+            uriTemplate: '/orders',
+            CQRSCommand: AddOrderFromBackOfficeCommand::class,
+            scopes: ['order_write'],
+        ),
+    ],
+    exceptionToStatus: [
+        CartNotFoundException::class => Response::HTTP_NOT_FOUND,
+        OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BackOfficeOrder
+{
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
+    public int $cartId;
+
+    /**
+     * Employee that placed the order. Pass NoEmployeeId::NO_EMPLOYEE_ID_VALUE (0)
+     * to skip employee attribution — this also short-circuits the
+     * translator-dependent "Manual order — Employee: …" internal note code path.
+     */
+    public int $employeeId = NoEmployeeId::NO_EMPLOYEE_ID_VALUE;
+
+    public string $orderMessage = '';
+
+    /**
+     * Technical name of the installed payment module driving validateOrder(),
+     * e.g. 'ps_wirepayment', 'ps_checkpayment', 'boorder'.
+     */
+    #[Assert\NotBlank]
+    public string $paymentModuleName;
+
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
+    public int $orderStateId;
+}

--- a/src/ApiPlatform/Resources/Order/BackOfficeOrder.php
+++ b/src/ApiPlatform/Resources/Order/BackOfficeOrder.php
@@ -28,6 +28,7 @@ use PrestaShop\PrestaShop\Core\Domain\Employee\ValueObject\NoEmployeeId;
 use PrestaShop\PrestaShop\Core\Domain\Order\Command\AddOrderFromBackOfficeCommand;
 use PrestaShop\PrestaShop\Core\Domain\Order\Exception\OrderException;
 use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\Exception\InvalidModuleException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -41,6 +42,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     ],
     exceptionToStatus: [
         CartNotFoundException::class => Response::HTTP_NOT_FOUND,
+        InvalidModuleException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
         OrderException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
     ],
 )]

--- a/tests/Integration/ApiPlatform/BackOfficeOrderEndpointTest.php
+++ b/tests/Integration/ApiPlatform/BackOfficeOrderEndpointTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+class BackOfficeOrderEndpointTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::createApiClient(['order_write']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'add order from back office endpoint' => ['POST', '/orders'];
+    }
+}

--- a/tests/Integration/ApiPlatform/BackOfficeOrderEndpointTest.php
+++ b/tests/Integration/ApiPlatform/BackOfficeOrderEndpointTest.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use Symfony\Component\HttpFoundation\Response;
+
 class BackOfficeOrderEndpointTest extends ApiTestCase
 {
     public static function setUpBeforeClass(): void
@@ -33,5 +35,22 @@ class BackOfficeOrderEndpointTest extends ApiTestCase
     public static function getProtectedEndpoints(): iterable
     {
         yield 'add order from back office endpoint' => ['POST', '/orders'];
+    }
+
+    public function testAddOrderWithMalformedPaymentModuleNameReturns422(): void
+    {
+        // A malformed paymentModuleName ("bad module!") passes Assert\NotBlank
+        // but AddOrderFromBackOfficeCommand::assertIsModuleName() throws
+        // InvalidModuleException — must surface as 422, not 500.
+        $this->createItem(
+            '/orders',
+            [
+                'cartId' => 1,
+                'paymentModuleName' => 'bad module!',
+                'orderStateId' => 1,
+            ],
+            ['order_write'],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
     }
 }


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `POST /orders` using `CQRSCreate` with `AddOrderFromBackOfficeCommand`. Body: `{cartId, employeeId?, orderMessage?, paymentModuleName, orderStateId}`. The Command turns an existing cart into an actual order by delegating to the payment module's `validateOrder()` — the exact BO checkout path a merchant would trigger from the admin panel. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | Related to PrestaShop/PrestaShop#39630                       |
| How to test?      | Scope-protection test only — a full happy-path test would need seeding a paid-ready cart with valid delivery + billing addresses, plus an installed payment module, which the existing test infrastructure does not currently expose. |

## `employeeId` trap

The handler uses `Context::getContext()->getTranslator()` to build a *"Manual order — Employee: …"* internal note, which is potentially fragile in a headless API context. That code path is guarded by `if ($command->getEmployeeId()->getValue())` — passing `NoEmployeeId::NO_EMPLOYEE_ID_VALUE` (`0`, the default value in this resource) short-circuits it so the endpoint is safe. Callers who need the internal note should attach `employeeId` explicitly.