### PR TITLE
Add BulkDeleteCountries endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Country/BulkDeleteCountries.php
+++ b/src/ApiPlatform/Resources/Country/BulkDeleteCountries.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Country;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkDeleteCountriesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Country\Exception\CountryNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/countries/bulk-delete',
+            CQRSCommand: BulkDeleteCountriesCommand::class,
+            openapiContext: [
+                'summary' => 'Delete multiple countries at once',
+                'description' => 'Deletes the countries whose identifiers are provided in the request body.',
+            ],
+            scopes: [
+                'country_write',
+            ],
+            allowEmptyBody: false,
+        ),
+    ],
+    exceptionToStatus: [
+        CountryNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteCountries
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $countryIds;
+}

--- a/tests/Integration/ApiPlatform/CountryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CountryEndpointTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use PrestaShop\PrestaShop\Core\Domain\Country\Command\BulkDeleteCountriesCommand;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Resources\DatabaseDump;
 
@@ -59,6 +60,7 @@ class CountryEndpointTest extends ApiTestCase
         yield 'update endpoint' => ['PATCH', '/countries/1'];
         yield 'delete endpoint' => ['DELETE', '/countries/1'];
         yield 'list endpoint' => ['GET', '/countries'];
+        yield 'bulk delete endpoint' => ['DELETE', '/countries/bulk-delete'];
     }
 
     public function testAddCountry(): int
@@ -390,6 +392,37 @@ class CountryEndpointTest extends ApiTestCase
     private function expectedAddressFormat(string $sentFormat): string
     {
         return interface_exists(self::CORE_ADDRESS_FORMAT_CHECKER) ? $sentFormat : '';
+    }
+
+    /**
+     * BulkDeleteCountriesCommand landed in PS develop (post-9.1). Gate the test so
+     * older cores that don't ship the command simply skip it.
+     */
+    public function testBulkDeleteCountries(): void
+    {
+        if (!class_exists(BulkDeleteCountriesCommand::class)) {
+            $this->markTestSkipped('BulkDeleteCountriesCommand is not available on this PrestaShop version.');
+        }
+
+        $ids = [];
+        foreach (['YA', 'YB'] as $isoCode) {
+            $payload = $this->getCreatePayload();
+            $payload['isoCode'] = $isoCode;
+            $payload['names'] = [
+                'en-US' => 'Bulk Country ' . $isoCode,
+                'fr-FR' => 'Pays Bulk ' . $isoCode,
+            ];
+            $created = $this->createItem('/countries', $payload, ['country_write']);
+            $ids[] = $created['countryId'];
+        }
+
+        $this->bulkDeleteItems('/countries/bulk-delete', [
+            'countryIds' => $ids,
+        ], ['country_write']);
+
+        foreach ($ids as $countryId) {
+            $this->getItem('/countries/' . $countryId, ['country_read'], Response::HTTP_NOT_FOUND);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- Exposes `BulkDeleteCountriesCommand` (added in PrestaShop develop/9.2, commit 9389aaf) as a new `DELETE /countries/bulk-delete` endpoint.
- Body: `{ \"countryIds\": [1, 2, 3] }`. Requires the `country_write` scope.
- Adds a `testBulkDeleteCountries` case in `CountryEndpointTest`, guarded on `class_exists(BulkDeleteCountriesCommand::class)` so older cores (9.0/9.1) simply skip it.

## Test plan
- [ ] `composer run-module-tests` on a PrestaShop develop checkout — verify the new test creates two countries, bulk-deletes them, and asserts 404 on each afterwards.
- [ ] Run the same suite on 9.1.x — the new test should be skipped, existing Country tests should still pass.
- [ ] Manually POST two countries via Swagger UI, then call `DELETE /countries/bulk-delete` with their IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)