### PR TITLE
Add UpdateCategoryPosition endpoint

### DIFF
--- a/src/ApiPlatform/Resources/Category/UpdateCategoryPosition.php
+++ b/src/ApiPlatform/Resources/Category/UpdateCategoryPosition.php
@@ -34,7 +34,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiResource(
     operations: [
         new CQRSUpdate(
-            uriTemplate: '/categories/update-position',
+            uriTemplate: '/categories/update-positions',
             output: false,
             CQRSCommand: UpdateCategoryPositionCommand::class,
             openapiContext: [

--- a/src/ApiPlatform/Resources/Category/UpdateCategoryPosition.php
+++ b/src/ApiPlatform/Resources/Category/UpdateCategoryPosition.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Category;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Category\Command\UpdateCategoryPositionCommand;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryException;
+use PrestaShop\PrestaShop\Core\Domain\Category\Exception\CategoryNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSUpdate(
+            uriTemplate: '/categories/update-position',
+            output: false,
+            CQRSCommand: UpdateCategoryPositionCommand::class,
+            openapiContext: [
+                'summary' => 'Update the position of a category within its parent',
+                'description' => 'Reorders a category inside its parent category. The "positions" array mirrors the payload emitted by the admin drag-and-drop grid: each value is a token in the form "prefix_{parentCategoryId}_{categoryId}", and its numeric key indicates the desired position.',
+            ],
+            scopes: [
+                'category_write',
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        CategoryException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        CategoryNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class UpdateCategoryPosition
+{
+    #[Assert\NotNull]
+    public int $categoryId;
+
+    #[Assert\NotNull]
+    public int $parentCategoryId;
+
+    #[Assert\NotNull]
+    public int $way;
+
+    /**
+     * @var string[]
+     */
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'items' => ['type' => 'string'],
+        'example' => ['tr_2_3', 'tr_2_5', 'tr_2_7'],
+    ])]
+    #[Assert\NotBlank]
+    public array $positions;
+
+    #[Assert\NotNull]
+    public bool $foundFirst;
+}

--- a/tests/Integration/ApiPlatform/CategoryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CategoryEndpointTest.php
@@ -102,7 +102,7 @@ class CategoryEndpointTest extends ApiTestCase
 
         yield 'update position endpoint' => [
             'PUT',
-            '/categories/update-position',
+            '/categories/update-positions',
         ];
     }
 
@@ -304,7 +304,7 @@ class CategoryEndpointTest extends ApiTestCase
             $initialB['position'] => 'tr_2_' . $catA,
         ];
 
-        $this->updateItem('/categories/update-position', [
+        $this->updateItem('/categories/update-positions', [
             'categoryId' => $catA,
             'parentCategoryId' => 2,
             'way' => 1,

--- a/tests/Integration/ApiPlatform/CategoryEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CategoryEndpointTest.php
@@ -99,6 +99,11 @@ class CategoryEndpointTest extends ApiTestCase
             'DELETE',
             '/categories/bulk-delete/associate_and_disable',
         ];
+
+        yield 'update position endpoint' => [
+            'PUT',
+            '/categories/update-position',
+        ];
     }
 
     public function testAddCategory(): int
@@ -281,6 +286,39 @@ class CategoryEndpointTest extends ApiTestCase
         foreach ($bulkCategories as $categoryId) {
             $this->getItem('/categories/' . $categoryId, ['category_read'], Response::HTTP_NOT_FOUND);
         }
+    }
+
+    public function testUpdateCategoryPosition(): void
+    {
+        // Two fresh siblings under Home (parent 2). Their initial positions are the
+        // next two slots; we then send the position tokens in reversed order so the
+        // second created category ends up in the first sibling's slot.
+        [$catA, $catB] = $this->createTemporaryCategories();
+
+        $initialA = $this->getItem('/categories/' . $catA, ['category_read']);
+        $initialB = $this->getItem('/categories/' . $catB, ['category_read']);
+        $this->assertLessThan($initialB['position'], $initialA['position']);
+
+        $positions = [
+            $initialA['position'] => 'tr_2_' . $catB,
+            $initialB['position'] => 'tr_2_' . $catA,
+        ];
+
+        $this->updateItem('/categories/update-position', [
+            'categoryId' => $catA,
+            'parentCategoryId' => 2,
+            'way' => 1,
+            'positions' => $positions,
+            'foundFirst' => true,
+        ], ['category_write'], Response::HTTP_NO_CONTENT);
+
+        $updatedA = $this->getItem('/categories/' . $catA, ['category_read']);
+        $updatedB = $this->getItem('/categories/' . $catB, ['category_read']);
+        $this->assertGreaterThan($updatedB['position'], $updatedA['position']);
+
+        // Clean up so the sibling count doesn't drift for later tests.
+        $this->deleteItem('/categories/' . $catA . '/associate_and_disable', ['category_write']);
+        $this->deleteItem('/categories/' . $catB . '/associate_and_disable', ['category_write']);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Exposes `UpdateCategoryPositionCommand` as a new `PUT /categories/update-position` endpoint, mirroring the admin grid drag-and-drop payload.
- Body: `{ \"categoryId\": int, \"parentCategoryId\": int, \"way\": int, \"positions\": string[], \"foundFirst\": bool }`. Requires the `category_write` scope.
- Position tokens follow the same `\"prefix_{parentId}_{categoryId}\"` convention parsed by the legacy handler.

## Test plan
- [ ] `composer run-module-tests` — verify `testUpdateCategoryPosition` creates two siblings under Home, swaps their positions via the API, and observes the reversed order on subsequent GETs.
- [ ] Manual sanity check via Swagger UI: pick a small sibling set (e.g. two categories under Home), swap them, confirm the admin back-office grid reflects the new order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)