### PR TITLE
Drop 9.1.x from the CI test matrix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         php: ${{ fromJSON(needs.workflow_matrix_generator.outputs.dynamic_matrix) }}
-        prestashop_version: ['develop', '9.2.x', '9.0.3', '9.1.x']
+        prestashop_version: ['develop', '9.2.x', '9.0.3']
         exclude:
           # 9.0.3 doesn't support PHP 8.5
           - php: '8.5'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -129,7 +129,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
           matrix:
-              presta_version: ['9.0.3', '9.1.x', 'develop', '9.2.x']
+              presta_version: ['9.0.3', 'develop', '9.2.x']
           fail-fast: false
       env:
           PHPRC: ${{ github.workspace }}/${{ github.event.repository.name }}/.phpstan-php-ini

--- a/tests/PHPStan/phpstan-9.1.x.neon
+++ b/tests/PHPStan/phpstan-9.1.x.neon
@@ -1,7 +1,0 @@
-includes:
-    - %currentWorkingDirectory%/tests/PHPStan/phpstan.neon
-
-parameters:
-    tmpDir: %currentWorkingDirectory%/var/phpstan-tmp/9.1.x
-    ignoreErrors:
-        # Add version-specific ignores here as needed


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Stop running the CI test suites against PrestaShop 9.1.x
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Follows up on #220
| Sponsor company   |

Same reasoning as #220 (drop 9.0.x): the module has not reached v1 yet, so we can stop testing against PrestaShop 9.1.x and stay aligned with `develop`.

This currently blocks a series of PRs (394, 393, 388, 387, 386, 374) whose endpoints rely on core classes present in `develop` but not backported to 9.1.x (e.g. `BulkDeleteCountriesCommand`, `*ExtraPropertyDefinition*`, `GetShipmentsForOrderDetail`, `CreateShipment`, `BulkDeleteProductsFromOrderReturnCommand`, `SearchProductsForFreeGift`). Once merged, these six PRs unblock without per-PR `ignoreErrors` shims.

This removes `9.1.x` from:
- the **PHPStan** matrix (`.github/workflows/php.yml`)
- the **integration** matrix (`.github/workflows/integration.yml`)
- the dedicated `tests/PHPStan/phpstan-9.1.x.neon` config (no longer referenced)

Module installability is left unchanged on purpose: this PR only drops CI coverage, not declared support. A follow-up issue will propose a branching strategy so the module can properly track and backport to released core versions once v1 lands.