### PR TITLE
Add `#[SinceVersion]` attribute for declarative core-version gating

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -160,6 +160,44 @@ the current usage pattern.
 - Nested fields use bracket notation:
   `'[basicInformation][localizedNames]' => '[names]'`.
 
+## Version gating
+
+When an operation (or a whole resource) is only available in a specific
+PrestaShop Core version and above, mark it with the
+`#[SinceVersion]` attribute from
+`PrestaShop\Module\APIResources\ApiPlatform\Metadata`:
+
+```php
+use PrestaShop\Module\APIResources\ApiPlatform\Metadata\SinceVersion;
+
+#[SinceVersion('9.2.0')]
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/warehouses/{warehouseId}',
+            // ...
+        ),
+    ],
+)]
+class Warehouse
+{
+}
+```
+
+The attribute is purely declarative: the module does not enforce it at
+runtime (the Core simply won't register operations whose CQRS classes
+don't exist yet on an older version). Its purpose is discoverability
+for **clients** — SDKs, admin apps, integration tests — which can:
+
+- Read the attribute via reflection to grey out unavailable UI, or
+- Consume it through an OpenAPI decorator that exposes it as
+  `x-since-version` in the generated schema.
+
+Place it on the class when the whole resource is version-gated, or on a
+single operation when only one method of an existing resource is new.
+The attribute is repeatable, so a resource can declare both a class-level
+floor and a stricter version on a specific operation.
+
 ## Multi-shop
 
 > **Experimental — feature flag required.** Admin API support for

--- a/src/ApiPlatform/Metadata/SinceVersion.php
+++ b/src/ApiPlatform/Metadata/SinceVersion.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Metadata;
+
+use Attribute;
+
+/**
+ * Marks the minimum PrestaShop Core version required for an API resource
+ * or a single operation. Purely declarative — consumed by clients or by
+ * an OpenAPI decorator (exposed as `x-since-version`) so that callers can
+ * gate UI or fall back gracefully when the target shop is on an older core.
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+final class SinceVersion
+{
+    public function __construct(public readonly string $version)
+    {
+    }
+}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | New `#[SinceVersion]` attribute to mark the minimum PrestaShop Core version an API resource or operation requires
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Discussion in #399
| Sponsor company   |

Introduces a lightweight, purely declarative attribute — no runtime cost, no automatic enforcement — that lets us tag resources or single operations with the minimum core version they require.

```php
use PrestaShop\Module\APIResources\ApiPlatform\Metadata\SinceVersion;

#[SinceVersion('9.2.0')]
#[ApiResource(
    operations: [
        new CQRSGet(uriTemplate: '/warehouses/{warehouseId}'),
    ],
)]
class Warehouse { }
```

Attribute targets `TARGET_CLASS | TARGET_METHOD` and is `IS_REPEATABLE`, so it can also apply per-operation (e.g. when only one operation of a resource is version-gated).

## What this PR contains

- `src/ApiPlatform/Metadata/SinceVersion.php` — the attribute (36 lines)
- `CONTEXT.md` — a "Version gating" section documenting the intended usage

## Deliberately out of scope (follow-ups)

- OpenAPI decorator that exposes the value as `x-since-version` on the corresponding path / operation. That's where the actual value for consumers comes from — this PR is groundwork.
- First real usage on a resource.
- Complementary attributes (`UntilVersion`?) — see the discussion in #399.

## Rationale

See #399 for the full proposal. Short version: the module currently ships endpoints whose core dependencies live only on `develop`. Without a declarative signal, consumers (BOs, mobile apps, integrators) discover the mismatch at runtime as an HTTP 500. `#[SinceVersion]` is the first step toward an OpenAPI-exposed signal that lets clients gate their UI or pick fallbacks.

## Related

- #399 — proposal / discussion
- #398 — branching strategy for backports (orthogonal, both mechanisms can coexist)