### PR TITLE
Filter endpoints based on core version compatibility

### DIFF
--- a/config/admin/services.yml
+++ b/config/admin/services.yml
@@ -57,3 +57,15 @@ services:
     autowire: true
     arguments:
       $decorated: '@.inner'
+
+  # Filters Admin API operations whose minVersion/maxVersion extra properties don't match the running core
+  # version. On PrestaShop >= 9.2 the equivalent core decorator exists and is injected as an optional
+  # reference: when present this module decorator is a pure pass-through.
+  # Note: module resources must declare the gating via extraProperties (['minVersion' => 'x.y.z']), NOT via
+  # the named constructor arguments which only exist in the core operation classes since PrestaShop 9.2.
+  # @deprecated remove together with the class once the module requires PrestaShop >= 9.2.
+  PrestaShop\Module\APIResources\ApiPlatform\Metadata\Resource\Factory\CoreVersionCompatibilityMetadataCollectionFactoryDecorator:
+    decorates: api_platform.metadata.resource.metadata_collection_factory
+    arguments:
+      $decorated: '@.inner'
+      $coreVersionDecorator: '@?PrestaShopBundle\ApiPlatform\Metadata\Resource\Factory\CoreVersionCompatibilityMetadataCollectionFactoryDecorator'

--- a/src/ApiPlatform/Metadata/Resource/Factory/CoreVersionCompatibilityMetadataCollectionFactoryDecorator.php
+++ b/src/ApiPlatform/Metadata/Resource/Factory/CoreVersionCompatibilityMetadataCollectionFactoryDecorator.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Metadata\Resource\Factory;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Operation;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use PrestaShop\PrestaShop\Core\Version;
+
+/**
+ * This factory decorates the ApiPlatform default resource factory. It looks into each operation and checks
+ * if the extra properties minVersion and/or maxVersion are defined, if the running core version is out of the
+ * declared bounds the operation is removed. This means the operation is not visible in Swagger, and it's not
+ * used to generate the api routing, so it's not usable at all and returns a 404.
+ *
+ * Both bounds are inclusive and compared with version_compare, so its semantics apply as-is (note for example
+ * that 9.2.0-beta.1 < 9.2.0). No validation is performed on the version strings.
+ *
+ * The filtering applies in both prod and debug mode, unless the experimental endpoints feature flag is
+ * enabled. Note that the core version constant lags behind the actual content of the development branches
+ * (Version::VERSION is only bumped at release time), so enable the feature flag to work with an endpoint
+ * gated on a not-yet-released version.
+ *
+ * @deprecated This class is a duplicate of
+ * PrestaShopBundle\ApiPlatform\Metadata\Resource\Factory\CoreVersionCompatibilityMetadataCollectionFactoryDecorator
+ * introduced in PrestaShop 9.2.0. It only exists so that the minVersion/maxVersion extra properties are honored
+ * when the module runs on PrestaShop < 9.2 (it is a pure pass-through when the core decorator is detected, to
+ * avoid double filtering). Remove this class and its service declaration in config/admin/services.yml as soon
+ * as the module requires PrestaShop >= 9.2.
+ */
+class CoreVersionCompatibilityMetadataCollectionFactoryDecorator implements ResourceMetadataCollectionFactoryInterface
+{
+    public function __construct(
+        private readonly ResourceMetadataCollectionFactoryInterface $decorated,
+        private readonly FeatureFlagStateCheckerInterface $featureFlagStateChecker,
+        // The core twin decorator is injected as an optional reference: it is non-null on PrestaShop >= 9.2
+        // where the core already filters, in which case this decorator is a pure pass-through
+        private readonly ?ResourceMetadataCollectionFactoryInterface $coreVersionDecorator = null,
+    ) {
+    }
+
+    public function create(string $resourceClass): ResourceMetadataCollection
+    {
+        // We call the original method since we only want to alter the result of this method.
+        $resourceMetadataCollection = $this->decorated->create($resourceClass);
+
+        // The core decorator already handles the filtering on PrestaShop >= 9.2
+        if (null !== $this->coreVersionDecorator) {
+            return $resourceMetadataCollection;
+        }
+
+        // In debug and prod mode we always hide the incompatible endpoints, unless the experimental endpoints are forcefully enabled
+        if ($this->areExperimentalEndpointsEnabled()) {
+            return $resourceMetadataCollection;
+        }
+
+        /** @var ApiResource $resourceMetadata */
+        foreach ($resourceMetadataCollection as $resourceMetadata) {
+            $operations = $resourceMetadata->getOperations();
+            /** @var Operation $operation */
+            foreach ($operations as $key => $operation) {
+                if (!$this->isCompatibleWithCoreVersion($operation)) {
+                    $operations->remove($key);
+                }
+            }
+        }
+
+        return $resourceMetadataCollection;
+    }
+
+    private function isCompatibleWithCoreVersion(Operation $operation): bool
+    {
+        $extraProperties = $operation->getExtraProperties();
+        if (!empty($extraProperties['minVersion']) && version_compare(Version::VERSION, $extraProperties['minVersion'], '<')) {
+            return false;
+        }
+        if (!empty($extraProperties['maxVersion']) && version_compare(Version::VERSION, $extraProperties['maxVersion'], '>')) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * This decorator is implied during cache clearing which would fail when the shop is not installed
+     * because the DB config is not set up yet. So we protected the feature flag fetching in a try/catch
+     * and return false (default value) in case of an error.
+     *
+     * @return bool
+     */
+    private function areExperimentalEndpointsEnabled(): bool
+    {
+        try {
+            return $this->featureFlagStateChecker->isEnabled(FeatureFlagSettings::FEATURE_FLAG_ADMIN_API_EXPERIMENTAL_ENDPOINTS);
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+}

--- a/tests/Integration/ApiPlatform/ApiTestCase.php
+++ b/tests/Integration/ApiPlatform/ApiTestCase.php
@@ -28,6 +28,7 @@ use PrestaShop\PrestaShop\Core\Domain\ApiClient\Command\AddApiClientCommand;
 use PrestaShop\PrestaShop\Core\Domain\Configuration\ShopConfigurationInterface;
 use PrestaShop\PrestaShop\Core\Domain\Language\Command\AddLanguageCommand;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use PrestaShop\PrestaShop\Core\Version;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -138,6 +139,18 @@ abstract class ApiTestCase extends SymfonyApiTestCase
         }
 
         return parent::createClient($kernelOptions, $defaultOptions);
+    }
+
+    /**
+     * Skips the test when the PrestaShop core version is lower than the required minimum version. Useful
+     * for endpoints relying on the minVersion extra property: on older cores they are filtered out (404),
+     * so their tests can only run on core versions that actually expose them.
+     */
+    protected function markTestSkippedByMinVersion(string $minVersion): void
+    {
+        if (version_compare(Version::VERSION, $minVersion, '<')) {
+            static::markTestSkipped(sprintf('This test requires PrestaShop >= %s (current core version: %s)', $minVersion, Version::VERSION));
+        }
     }
 
     /**

--- a/tests/Integration/ApiPlatform/CoreVersionCompatibilityDecoratorTest.php
+++ b/tests/Integration/ApiPlatform/CoreVersionCompatibilityDecoratorTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use ApiPlatform\Metadata\ApiResource;
+use ApiPlatform\Metadata\Get;
+use ApiPlatform\Metadata\Operations;
+use ApiPlatform\Metadata\Resource\Factory\ResourceMetadataCollectionFactoryInterface;
+use ApiPlatform\Metadata\Resource\ResourceMetadataCollection;
+use PHPUnit\Framework\TestCase;
+use PrestaShop\Module\APIResources\ApiPlatform\Metadata\Resource\Factory\CoreVersionCompatibilityMetadataCollectionFactoryDecorator;
+use PrestaShop\PrestaShop\Core\FeatureFlag\DisabledFeatureFlagStateChecker;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagStateCheckerInterface;
+use PrestaShop\PrestaShop\Core\Version;
+
+/**
+ * Logic-level test for the (deprecated) module twin of the core CoreVersionCompatibilityMetadataCollectionFactoryDecorator.
+ * The versioned operations use extreme min/max versions (1.0.0 and 99.99.99) plus the running Version::VERSION for the
+ * inclusive bound cases, so the expectations hold on every core version of the CI matrix.
+ */
+class CoreVersionCompatibilityDecoratorTest extends TestCase
+{
+    // All the operations in their declaration order, expected when the filtering is bypassed
+    private const ALL_OPERATIONS = [
+        'no_version',
+        'min_below',
+        'min_equal',
+        'min_above',
+        'max_above',
+        'max_equal',
+        'max_below',
+        'range_in',
+        'range_out',
+    ];
+
+    private const EXPECTED_KEPT_OPERATIONS = [
+        'no_version',
+        'min_below',
+        'min_equal',
+        'max_above',
+        'max_equal',
+        'range_in',
+    ];
+
+    public function testIncompatibleOperationsAreFiltered(): void
+    {
+        $decorator = new CoreVersionCompatibilityMetadataCollectionFactoryDecorator(
+            $this->buildDecoratedFactory(),
+            new DisabledFeatureFlagStateChecker(),
+        );
+
+        $this->assertEquals(self::EXPECTED_KEPT_OPERATIONS, $this->getOperationNames($decorator->create('resourceClass')));
+    }
+
+    public function testPassThroughWhenCoreDecoratorIsPresent(): void
+    {
+        // When the core twin decorator is detected (PrestaShop >= 9.2) the module decorator filters nothing,
+        // the core is responsible for the filtering
+        $coreDecorator = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $decorator = new CoreVersionCompatibilityMetadataCollectionFactoryDecorator(
+            $this->buildDecoratedFactory(),
+            new DisabledFeatureFlagStateChecker(),
+            $coreDecorator,
+        );
+
+        $this->assertEquals(self::ALL_OPERATIONS, $this->getOperationNames($decorator->create('resourceClass')));
+    }
+
+    public function testEnabledExperimentalEndpointsFeatureFlagFiltersNothing(): void
+    {
+        $featureFlagStateChecker = $this->createMock(FeatureFlagStateCheckerInterface::class);
+        $featureFlagStateChecker->method('isEnabled')->willReturn(true);
+
+        $decorator = new CoreVersionCompatibilityMetadataCollectionFactoryDecorator(
+            $this->buildDecoratedFactory(),
+            $featureFlagStateChecker,
+        );
+
+        $this->assertEquals(self::ALL_OPERATIONS, $this->getOperationNames($decorator->create('resourceClass')));
+    }
+
+    private function buildDecoratedFactory(): ResourceMetadataCollectionFactoryInterface
+    {
+        // The operations are built with the generic Get operation and raw extra properties on purpose:
+        // the minVersion/maxVersion named constructor arguments only exist on PrestaShop >= 9.2 while this
+        // test must run against every supported core version
+        $collection = new ResourceMetadataCollection('resourceClass', [
+            (new ApiResource())->withOperations(new Operations([
+                'no_version' => new Get(uriTemplate: '/no-version'),
+                'min_below' => new Get(uriTemplate: '/min-below', extraProperties: ['minVersion' => '1.0.0']),
+                'min_equal' => new Get(uriTemplate: '/min-equal', extraProperties: ['minVersion' => Version::VERSION]),
+                'min_above' => new Get(uriTemplate: '/min-above', extraProperties: ['minVersion' => '99.99.99']),
+                'max_above' => new Get(uriTemplate: '/max-above', extraProperties: ['maxVersion' => '99.99.99']),
+                'max_equal' => new Get(uriTemplate: '/max-equal', extraProperties: ['maxVersion' => Version::VERSION]),
+                'max_below' => new Get(uriTemplate: '/max-below', extraProperties: ['maxVersion' => '1.0.0']),
+                'range_in' => new Get(uriTemplate: '/range-in', extraProperties: ['minVersion' => '1.0.0', 'maxVersion' => '99.99.99']),
+                'range_out' => new Get(uriTemplate: '/range-out', extraProperties: ['minVersion' => '98.0.0', 'maxVersion' => '99.99.99']),
+            ])),
+        ]);
+
+        $decoratedFactory = $this->createMock(ResourceMetadataCollectionFactoryInterface::class);
+        $decoratedFactory->method('create')->willReturn($collection);
+
+        return $decoratedFactory;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getOperationNames(ResourceMetadataCollection $resourceMetadataCollection): array
+    {
+        $operationNames = [];
+        /** @var ApiResource $resourceMetadata */
+        foreach ($resourceMetadataCollection as $resourceMetadata) {
+            foreach ($resourceMetadata->getOperations() as $operationName => $operation) {
+                $operationNames[] = $operationName;
+            }
+        }
+
+        return $operationNames;
+    }
+}

--- a/tests/Integration/ApiPlatform/VersionedEndpointsTest.php
+++ b/tests/Integration/ApiPlatform/VersionedEndpointsTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PrestaShop\PrestaShop\Core\Version;
+
+/**
+ * End-to-end test of the minVersion/maxVersion endpoint filtering, handled by the module's (deprecated)
+ * CoreVersionCompatibilityMetadataCollectionFactoryDecorator on PrestaShop < 9.2 and by its core twin
+ * on PrestaShop >= 9.2.
+ *
+ * The test resource (see VersionedApiResource) is not part of the module resources: it is copied into the
+ * module's src/ApiPlatform/Resources folder for the duration of this test class only, so it never pollutes
+ * the OpenApi documentation of a real shop. Its version boundaries are chosen so that a different combination
+ * of endpoints is filtered on each core version of the CI matrix, and the expectations are computed at runtime
+ * from Version::VERSION so they stay accurate on any core version.
+ *
+ * The tests run in separate PHP processes because the compiled container class of the kernel stays loaded
+ * in the PHP process once booted: when the whole suite runs in a single process, a kernel booted before
+ * this class copied the test resource keeps serving its old routes (without the test resource) even after
+ * the cache has been cleared. For the same reason, the resource is copied and the cache is cleared BEFORE
+ * the parent setUpBeforeClass boots the first kernel of each process.
+ */
+#[RunTestsInSeparateProcesses]
+class VersionedEndpointsTest extends ApiTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!copy(self::getFixtureResourcePath(), self::getInstalledResourcePath())) {
+            throw new \RuntimeException(sprintf('Could not copy the test resource to %s', self::getInstalledResourcePath()));
+        }
+        self::clearCache();
+        parent::setUpBeforeClass();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+        if (file_exists(self::getInstalledResourcePath())) {
+            unlink(self::getInstalledResourcePath());
+        }
+        self::clearCache();
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get versioned endpoint' => [
+            'GET',
+            '/test/module/versioned/always/hook/1',
+        ];
+    }
+
+    public function testVersionedEndpointsAreFilteredBasedOnCoreVersion(): void
+    {
+        // The version filtering applies in debug mode as well (unless the experimental endpoints feature
+        // flag is enabled), so the default test kernel can be used directly
+        $bearerToken = $this->getBearerToken(['hook_read']);
+        $client = static::createClient();
+
+        foreach (self::getVersionedEndpoints() as $description => [$endpointUrl, $expectedAvailable]) {
+            $client->request('GET', $endpointUrl, [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $bearerToken,
+                ],
+            ]);
+            self::assertResponseStatusCodeSame(
+                $expectedAvailable ? 200 : 404,
+                sprintf('Unexpected response status for endpoint "%s" (%s) on PrestaShop %s', $endpointUrl, $description, Version::VERSION)
+            );
+        }
+    }
+
+    /**
+     * The expected availability is computed at runtime against the actual core version, with the same
+     * inclusive version_compare semantics as the decorator, so this test runs accurately on every core
+     * version of the CI matrix (9.0.x, 9.1.x, 9.2.x, develop).
+     *
+     * @return iterable<string, array{string, bool}>
+     */
+    private static function getVersionedEndpoints(): iterable
+    {
+        yield 'no version constraint, always available' => [
+            '/test/module/versioned/always/hook/1',
+            true,
+        ];
+
+        yield 'minVersion 9.1.0, filtered on lower core versions' => [
+            '/test/module/versioned/min-91/hook/1',
+            version_compare(Version::VERSION, '9.1.0', '>='),
+        ];
+
+        yield 'minVersion 9.2.0, filtered on lower core versions' => [
+            '/test/module/versioned/min-92/hook/1',
+            version_compare(Version::VERSION, '9.2.0', '>='),
+        ];
+
+        yield 'maxVersion 9.1.9999, filtered on higher core versions' => [
+            '/test/module/versioned/max-91/hook/1',
+            version_compare(Version::VERSION, '9.1.9999', '<='),
+        ];
+
+        yield 'minVersion 99.99.99, never available' => [
+            '/test/module/versioned/never/hook/1',
+            false,
+        ];
+    }
+
+    private static function getFixtureResourcePath(): string
+    {
+        return __DIR__ . '/../../Resources/ApiPlatform/Resources/VersionedApiResource.php';
+    }
+
+    /**
+     * The resource must be copied into the module folder that is scanned for ApiPlatform resources. It is
+     * resolved through _PS_MODULE_DIR_ (redefined to tests/Resources/modules/ in the test bootstrap) which
+     * contains a symbolic link to the actual module folder.
+     */
+    private static function getInstalledResourcePath(): string
+    {
+        return _PS_MODULE_DIR_ . 'ps_apiresources/src/ApiPlatform/Resources/VersionedApiResource.php';
+    }
+
+    /**
+     * The compiled metadata (and its filtering) is cached, so the cache must be cleared after the test
+     * resource is added and after it is removed.
+     */
+    private static function clearCache(): void
+    {
+        $commandLine = 'php -d memory_limit=-1 ' . _PS_ROOT_DIR_ . '/bin/console cache:clear --no-warmup --no-interaction --env=test --app-id=admin-api --quiet';
+        $result = 0;
+        system($commandLine, $result);
+        if ($result !== 0) {
+            throw new \RuntimeException('Could not clear the cache');
+        }
+    }
+}

--- a/tests/Resources/ApiPlatform/Resources/VersionedApiResource.php
+++ b/tests/Resources/ApiPlatform/Resources/VersionedApiResource.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Resources\ApiPlatform\Resources;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Hook\Exception\HookNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Hook\Query\GetHook;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+
+/**
+ * Test resource for VersionedEndpointsTest: it is NOT part of the module resources, it is copied into the
+ * module's src/ApiPlatform/Resources folder during the test only, then removed, so it never pollutes the
+ * OpenApi documentation of a real shop.
+ *
+ * The version gating is declared via extraProperties on purpose: the minVersion/maxVersion named constructor
+ * arguments only exist in the core operation classes since PrestaShop 9.2 while this resource must compile
+ * on every supported core version.
+ *
+ * The operations reuse the existing hook_read scope (available on every supported core version), and the
+ * version boundaries are chosen to produce a different filtering combination on each core version of the
+ * CI matrix (9.0.x, 9.1.x, 9.2.x, develop).
+ */
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/test/module/versioned/always/hook/{hookId}',
+            requirements: ['hookId' => '\d+'],
+            exceptionToStatus: [HookNotFoundException::class => 404],
+            CQRSQuery: GetHook::class,
+            scopes: ['hook_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+        ),
+        new CQRSGet(
+            uriTemplate: '/test/module/versioned/min-91/hook/{hookId}',
+            requirements: ['hookId' => '\d+'],
+            exceptionToStatus: [HookNotFoundException::class => 404],
+            CQRSQuery: GetHook::class,
+            scopes: ['hook_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            extraProperties: ['minVersion' => '9.1.0'],
+        ),
+        new CQRSGet(
+            uriTemplate: '/test/module/versioned/min-92/hook/{hookId}',
+            requirements: ['hookId' => '\d+'],
+            exceptionToStatus: [HookNotFoundException::class => 404],
+            CQRSQuery: GetHook::class,
+            scopes: ['hook_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            extraProperties: ['minVersion' => '9.2.0'],
+        ),
+        new CQRSGet(
+            uriTemplate: '/test/module/versioned/max-91/hook/{hookId}',
+            requirements: ['hookId' => '\d+'],
+            exceptionToStatus: [HookNotFoundException::class => 404],
+            CQRSQuery: GetHook::class,
+            scopes: ['hook_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            extraProperties: ['maxVersion' => '9.1.9999'],
+        ),
+        new CQRSGet(
+            uriTemplate: '/test/module/versioned/never/hook/{hookId}',
+            requirements: ['hookId' => '\d+'],
+            exceptionToStatus: [HookNotFoundException::class => 404],
+            CQRSQuery: GetHook::class,
+            scopes: ['hook_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            extraProperties: ['minVersion' => '99.99.99'],
+        ),
+    ],
+)]
+class VersionedApiResource
+{
+    #[ApiProperty(identifier: true)]
+    public int $hookId;
+
+    public bool $enabled;
+
+    public string $name;
+
+    public string $title;
+
+    public string $description;
+
+    protected const QUERY_MAPPING = [
+        // Transforms the url hookId parameter into the $id parameter for GetHook
+        '[hookId]' => '[id]',
+        // Transforms the query result Hook::getId into the Api resource hookId
+        '[id]' => '[hookId]',
+        '[active]' => '[enabled]',
+    ];
+}


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | dev
| Description?      | Adds a (deprecated from day one) twin of the core `CoreVersionCompatibilityMetadataCollectionFactoryDecorator` introduced in PrestaShop 9.2, so the `minVersion`/`maxVersion` extra properties also filter endpoints when the module runs on PrestaShop 9.0/9.1. See details below.
| Type?             | improvement
| Category?         | WS
| BC breaks?        | no
| Deprecations?     | yes
| How to test?      | See below.
| UI Tests          | -
| Fixed issue or discussion?     | -
| Related PRs       | Core counterpart: https://github.com/PrestaShop/PrestaShop/pull/42145
| Sponsor company   | PrestaShop SA

## Why

Some module endpoints rely on core fixes only available since a specific core version. The core PR (linked above) introduces `minVersion`/`maxVersion` extra properties and a metadata decorator that filters out incompatible operations (no OpenAPI listing, no route, 404) — but that decorator only exists from PrestaShop 9.2. This module supports 9.0.3+, so it ships its own copy of the decorator to get the same behavior on older cores.

## What is included

- `PrestaShop\Module\APIResources\ApiPlatform\Metadata\Resource\Factory\CoreVersionCompatibilityMetadataCollectionFactoryDecorator`, marked `@deprecated` immediately: it is a duplicate of the core decorator and must be removed once the module requires PrestaShop >= 9.2. Like its core twin (and `CQRSNotFoundMetadataCollectionFactoryDecorator`), the filtering applies in both debug and prod mode, unless the experimental endpoints feature flag is enabled.
- Double-filtering guard: the core decorator is injected as an optional reference (`@?`, same pattern as `ValidAddressFormatValidator`); when it is present (PS >= 9.2) the module decorator is a pure pass-through, the core one is responsible for the filtering.
- Usage rule (documented in `config/admin/services.yml`): module resources must declare the gating via `extraProperties: ['minVersion' => 'x.y.z']` — NOT the named constructor arguments, which only exist in the core operation classes since 9.2.
- New `ApiTestCase::markTestSkippedByMinVersion('x.y.z')` helper so endpoint tests relying on version-gated endpoints can skip cleanly on older cores of the CI matrix.
- Known limitation on PS < 9.2 (cosmetic): the Swagger UI OAuth scope list is built at container compile time by a core compiler pass that the module cannot decorate, so scopes attached only to filtered operations still appear there on 9.0/9.1. The BO API client form and OAuth scope validation use the runtime extractor, which is filtered correctly through the decorated metadata chain. Endpoints themselves return 404 in every case.

## Tests

- `CoreVersionCompatibilityDecoratorTest`: logic-level test of the decorator (inclusive bounds computed against the running `Version::VERSION`, pass-through when the core decorator is detected or the experimental endpoints feature flag is enabled). Runs green on every core version of the CI matrix.
- `VersionedEndpointsTest`: end-to-end test based on a dedicated test resource (`tests/Resources/ApiPlatform/Resources/VersionedApiResource.php`). The resource is NOT part of the module resources — it is copied into `src/ApiPlatform/Resources/` for the duration of the test class only, so it never pollutes the OpenAPI doc of a real shop. Its version boundaries (`9.1.0`, `9.2.0`, `9.1.9999`, `99.99.99`) produce a different filtering combination on each core version of the CI matrix, and the expected availability is computed at runtime from `Version::VERSION`:

| Endpoint | Gating | 9.0.x | 9.1.x | 9.2.x | develop |
|---|---|---|---|---|---|
| `/test/module/versioned/always` | none | 200 | 200 | 200 | 200 |
| `/test/module/versioned/min-91` | minVersion 9.1.0 | 404 | 200 | 200 | 200 |
| `/test/module/versioned/min-92` | minVersion 9.2.0 | 404 | 404 | 200 | 200 |
| `/test/module/versioned/max-91` | maxVersion 9.1.9999 | 200 | 200 | 404 | 404 |
| `/test/module/versioned/never` | minVersion 99.99.99 | 404 | 404 | 404 | 404 |

## How to test

Run the module integration tests against any supported core version (the CI matrix runs them on 9.0.x, 9.1.x, 9.2.x and develop):

```
composer create-test-db && composer run-module-tests
```

or locally from a dev shop: `_PS_ROOT_DIR_=/path/to/shop php /path/to/shop/vendor/phpunit/phpunit/phpunit -c tests/Integration/phpunit-local.xml --filter VersionedEndpointsTest`
