### PR TITLE
Align the customer search response keys with the create payload

### DIFF
--- a/src/ApiPlatform/Resources/Customer/FoundCustomer.php
+++ b/src/ApiPlatform/Resources/Customer/FoundCustomer.php
@@ -77,9 +77,9 @@ class FoundCustomer
     #[ApiProperty(identifier: true, openapiContext: ['type' => 'integer', 'example' => 1])]
     public int $idCustomer;
 
-    public string $firstname;
+    public string $firstName;
 
-    public string $lastname;
+    public string $lastName;
 
     public string $email;
 
@@ -105,5 +105,9 @@ class FoundCustomer
         '[id_customer]' => '[idCustomer]',
         '[fullname_and_email]' => '[fullnameAndEmail]',
         '[id_default_group]' => '[idDefaultGroup]',
+        // The CQRS result uses the legacy column names, which reached the response untouched and
+        // made this endpoint return firstname/lastname while POST /customers uses firstName/lastName.
+        '[firstname]' => '[firstName]',
+        '[lastname]' => '[lastName]',
     ];
 }

--- a/src/ApiPlatform/Resources/Customer/FoundCustomer.php
+++ b/src/ApiPlatform/Resources/Customer/FoundCustomer.php
@@ -75,7 +75,7 @@ use Symfony\Component\HttpFoundation\Response;
 class FoundCustomer
 {
     #[ApiProperty(identifier: true, openapiContext: ['type' => 'integer', 'example' => 1])]
-    public int $idCustomer;
+    public int $customerId;
 
     public string $firstName;
 
@@ -85,13 +85,18 @@ class FoundCustomer
 
     public string $fullnameAndEmail;
 
+    // POST /customers calls this "enabled" and returns a real boolean. Renaming it here needs the
+    // tiny-int to bool cast, which CQRSApiSerializer only applies when CAST_BOOL is in the context -
+    // and that is set by QueryListProvider only, not by the QueryProvider serving this collection.
+    // Typing this bool without that raises "The type of the enabled attribute must be bool, integer
+    // given". Left as active until the cast is reachable from a CQRSGetCollection.
     #[ApiProperty(openapiContext: ['type' => 'integer', 'example' => 1])]
     public int $active;
 
     public ?string $company;
 
     #[ApiProperty(openapiContext: ['type' => 'integer', 'example' => 3])]
-    public int $idDefaultGroup;
+    public int $defaultGroupId;
 
     #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
     public array $groups;
@@ -101,12 +106,13 @@ class FoundCustomer
         '[_context][shopConstraint]' => '[shopConstraint]',
     ];
 
+    // The CQRS result carries the legacy column names. Everything that was not mapped reached the
+    // response untouched, which is why this endpoint answered with firstname/lastname/active/id_*
+    // while POST /customers uses firstName/lastName/enabled/customerId.
     public const API_RESOURCE_MAPPING = [
-        '[id_customer]' => '[idCustomer]',
+        '[id_customer]' => '[customerId]',
         '[fullname_and_email]' => '[fullnameAndEmail]',
-        '[id_default_group]' => '[idDefaultGroup]',
-        // The CQRS result uses the legacy column names, which reached the response untouched and
-        // made this endpoint return firstname/lastname while POST /customers uses firstName/lastName.
+        '[id_default_group]' => '[defaultGroupId]',
         '[firstname]' => '[firstName]',
         '[lastname]' => '[lastName]',
     ];

--- a/tests/Integration/ApiPlatform/CustomerEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerEndpointTest.php
@@ -903,8 +903,8 @@ class CustomerEndpointTest extends ApiTestCase
         }
 
         $this->assertNotNull($foundCustomer, 'Created customer should be found in search results');
-        $this->assertEquals('Search', $foundCustomer['firstname']);
-        $this->assertEquals('Test', $foundCustomer['lastname']);
+        $this->assertEquals('Search', $foundCustomer['firstName']);
+        $this->assertEquals('Test', $foundCustomer['lastName']);
         $this->assertEquals('search.test@example.com', $foundCustomer['email']);
         $this->assertArrayHasKey('fullnameAndEmail', $foundCustomer);
         $this->assertArrayHasKey('groups', $foundCustomer);

--- a/tests/Integration/ApiPlatform/CustomerEndpointTest.php
+++ b/tests/Integration/ApiPlatform/CustomerEndpointTest.php
@@ -896,7 +896,7 @@ class CustomerEndpointTest extends ApiTestCase
         // Find our customer in the results
         $foundCustomer = null;
         foreach ($searchResults as $result) {
-            if ($result['idCustomer'] === $customerId) {
+            if ($result['customerId'] === $customerId) {
                 $foundCustomer = $result;
                 break;
             }
@@ -908,6 +908,9 @@ class CustomerEndpointTest extends ApiTestCase
         $this->assertEquals('search.test@example.com', $foundCustomer['email']);
         $this->assertArrayHasKey('fullnameAndEmail', $foundCustomer);
         $this->assertArrayHasKey('groups', $foundCustomer);
+        // The keys a client gets back must be the ones it sent to POST /customers
+        $this->assertArrayHasKey('customerId', $foundCustomer);
+        $this->assertArrayHasKey('defaultGroupId', $foundCustomer);
     }
 
     public function testSearchCustomersByEmail(): void
@@ -934,7 +937,7 @@ class CustomerEndpointTest extends ApiTestCase
 
         $foundCustomer = null;
         foreach ($searchResults as $result) {
-            if ($result['idCustomer'] === $customerId) {
+            if ($result['customerId'] === $customerId) {
                 $foundCustomer = $result;
                 break;
             }
@@ -983,7 +986,7 @@ class CustomerEndpointTest extends ApiTestCase
         $this->assertNotEmpty($searchResults);
 
         // Both customers should be found (they both match "Multi")
-        $foundIds = array_column($searchResults, 'idCustomer');
+        $foundIds = array_column($searchResults, 'customerId');
         $this->assertContains($customer1['customerId'], $foundIds);
         $this->assertContains($customer2['customerId'], $foundIds);
     }


### PR DESCRIPTION
Fixes PrestaShop/PrestaShop#42131

### Problem

`GET /customers/search` describes a customer with different keys from the ones `POST /customers` and `PATCH /customers/{id}` accept and return for the same fields:

| create / update | search |
|---|---|
| `firstName` | `firstname` |
| `lastName` | `lastname` |
| `customerId` | `idCustomer` |
| `defaultGroupId` | `idDefaultGroup` |

A client that creates a customer and then searches for it gets the same data back under four different names.

The `SearchCustomers` CQRS result carries the legacy database column names. `FoundCustomer::API_RESOURCE_MAPPING` renamed `fullname_and_email`, and renamed `id_customer` / `id_default_group` only as far as `idCustomer` / `idDefaultGroup`, which is neither the column name nor the key the write endpoints use. `firstname` / `lastname` were not mapped at all and reached the response untouched.

### Fix

Map all four onto the names the write endpoints already use, and rename the matching properties on `FoundCustomer`. Both parts are required: `ApiResourceMapping` is applied while denormalizing into the resource class, so a mapped key that matches no property is a silent no-op - with the mapping alone the response is unchanged.

### Verification

Measured against a 9.2.0 install with this module, `GET /admin-api/customers/search?phrases[]=john`:

Before:

```json
{"2":{"idCustomer":2,"firstname":"John","lastname":"DOE","email":"pub@prestashop.com","fullnameAndEmail":"John DOE - pub@prestashop.com","active":1,"idDefaultGroup":3}}
```

After:

```json
{"2":{"customerId":2,"firstName":"John","lastName":"DOE","email":"pub@prestashop.com","fullnameAndEmail":"John DOE - pub@prestashop.com","active":1,"defaultGroupId":3}}
```

The types match the write side as well - `POST /customers` returns `customerId` and `defaultGroupId` as integers, measured on the same install.

`testSearchCustomers` already creates a customer through `POST /customers` and then asserts on the search result, so it covers the reported scenario once its assertions use the keys the write endpoint uses; two `assertArrayHasKey` calls are added for the two renamed ids. I could not execute the module's integration suite locally (`composer setup-local-tests` needs a fresh PrestaShop clone), so that part is left to CI.

### What is deliberately not in this PR

**`active`.** `POST /customers` calls the same field `enabled` and returns a real boolean, so aligning it means renaming *and* retyping. Typing the property `bool` here fails, measured:

```
500 The type of the "enabled" attribute must be "bool", "integer" given.
```

`CQRSApiSerializer` casts tiny-ints to booleans only when `CAST_BOOL` is in the serializer context, and that is set by `QueryListProvider` alone - the `QueryProvider` serving this `CQRSGetCollection` never sets it. So `enabled` needs a core-side change first; renaming the key while leaving the value `1` would be worse than the current mismatch. A comment on the property records this.

**The response container.** The endpoint answers with a JSON object keyed by customer id rather than a JSON array. That is core, not this module - `QueryResultSerializerTrait` preserves the query result's keys for collection operations, and `SearchCustomersHandler` indexes by `id_customer`. Fixed in PrestaShop/PrestaShop#42210.

### Note on compatibility

This changes four response keys of an existing endpoint. It is the direction the issue asks for, and it aligns the endpoint with `Customer`, but consumers reading the old keys from `/customers/search` will need to follow. Say the word if you would rather expose the new keys alongside the old ones instead.
