### PR TITLE
Document the index base of the position properties

### DIFF
--- a/src/ApiPlatform/Resources/Attribute/AttributeGroup.php
+++ b/src/ApiPlatform/Resources/Attribute/AttributeGroup.php
@@ -118,6 +118,7 @@ class AttributeGroup
     #[Assert\NotBlank(allowNull: true)]
     public array $shopIds;
 
+    #[ApiProperty(openapiContext: ['type' => 'integer', 'description' => 'Zero based position among its siblings, matching the value stored by PrestaShop. The back office list adds 1 for display.'])]
     public int $position;
 
     public const QUERY_MAPPING = [

--- a/src/ApiPlatform/Resources/Attribute/AttributeGroupList.php
+++ b/src/ApiPlatform/Resources/Attribute/AttributeGroupList.php
@@ -48,6 +48,7 @@ class AttributeGroupList
 
     public int $values;
 
+    #[ApiProperty(openapiContext: ['type' => 'integer', 'description' => 'Zero based position among its siblings, matching the value stored by PrestaShop. The back office list adds 1 for display.'])]
     public int $position;
 
     public const MAPPING = [

--- a/src/ApiPlatform/Resources/Attribute/AttributeList.php
+++ b/src/ApiPlatform/Resources/Attribute/AttributeList.php
@@ -57,6 +57,7 @@ class AttributeList
 
     public int $values;
 
+    #[ApiProperty(openapiContext: ['type' => 'integer', 'description' => 'Zero based position among its siblings, matching the value stored by PrestaShop. The back office list adds 1 for display.'])]
     public int $position;
 
     public const MAPPING = [

--- a/src/ApiPlatform/Resources/Category/Category.php
+++ b/src/ApiPlatform/Resources/Category/Category.php
@@ -172,6 +172,7 @@ class Category
     #[DefaultLanguage(groups: ['Update'], fieldName: 'metaDescriptions', allowNull: true)]
     public array $metaDescriptions;
 
+    #[ApiProperty(openapiContext: ['type' => 'integer', 'description' => 'Zero based position among its siblings, matching the value stored by PrestaShop. The back office list adds 1 for display.'])]
     public int $position;
 
     public int $parentCategoryId;

--- a/src/ApiPlatform/Resources/Feature/FeatureList.php
+++ b/src/ApiPlatform/Resources/Feature/FeatureList.php
@@ -50,6 +50,7 @@ class FeatureList
 
     public int $values;
 
+    #[ApiProperty(openapiContext: ['type' => 'integer', 'description' => 'Zero based position among its siblings, matching the value stored by PrestaShop. The back office list adds 1 for display.'])]
     public int $position;
 
     public const MAPPING = [

--- a/src/ApiPlatform/Resources/Feature/FeatureValue.php
+++ b/src/ApiPlatform/Resources/Feature/FeatureValue.php
@@ -101,6 +101,7 @@ class FeatureValue
     ])]
     public array $values;
 
+    #[ApiProperty(openapiContext: ['type' => 'integer', 'description' => 'Zero based position among its siblings, matching the value stored by PrestaShop. The back office list adds 1 for display.'])]
     public int $position;
 
     public const QUERY_MAPPING = [

--- a/src/ApiPlatform/Resources/Feature/FeatureValueList.php
+++ b/src/ApiPlatform/Resources/Feature/FeatureValueList.php
@@ -57,6 +57,7 @@ class FeatureValueList
 
     public string $value;
 
+    #[ApiProperty(openapiContext: ['type' => 'integer', 'description' => 'Zero based position among its siblings, matching the value stored by PrestaShop. The back office list adds 1 for display.'])]
     public int $position;
 
     public const MAPPING = [

--- a/src/ApiPlatform/Resources/Product/NewProductImage.php
+++ b/src/ApiPlatform/Resources/Product/NewProductImage.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
 
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Command\AddProductImageCommand;
@@ -68,6 +69,7 @@ class NewProductImage
 
     public bool $cover;
 
+    #[ApiProperty(openapiContext: ['type' => 'integer', 'description' => 'One based position among the images of the product, matching the value stored by PrestaShop.'])]
     public int $position;
 
     public array $shopIds;

--- a/src/ApiPlatform/Resources/Product/ProductImage.php
+++ b/src/ApiPlatform/Resources/Product/ProductImage.php
@@ -88,6 +88,7 @@ class ProductImage
 
     public bool $cover;
 
+    #[ApiProperty(openapiContext: ['type' => 'integer', 'description' => 'One based position among the images of the product, matching the value stored by PrestaShop.'])]
     public int $position;
 
     public array $shopIds;

--- a/src/ApiPlatform/Resources/Product/ProductImageList.php
+++ b/src/ApiPlatform/Resources/Product/ProductImageList.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
 
+use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\Product\Exception\ProductNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\Product\Image\Query\GetProductImages;
@@ -64,6 +65,7 @@ class ProductImageList
 
     public bool $cover;
 
+    #[ApiProperty(openapiContext: ['type' => 'integer', 'description' => 'One based position among the images of the product, matching the value stored by PrestaShop.'])]
     public int $position;
 
     public array $shopIds;


### PR DESCRIPTION
Fixes PrestaShop/PrestaShop#39753

### Problem

Nothing in the API tells a consumer which base a `position` is counted from, and the answer is not the same for every resource. PrestaShop stores most positions 0 based and two of them 1 based, and the resources expose the stored value as it is:

| resource | base | source |
|---|---|---|
| `AttributeGroup`, `AttributeGroupList` | 0 | `prestashop.core.grid.attribute_group.position_definition`, no `$firstPosition` so the default `0` |
| `AttributeList` | 0 | `prestashop.core.grid.attribute.position_definition`, same |
| `FeatureList`, `FeatureValue`, `FeatureValueList` | 0 | `prestashop.core.grid.feature*.position_definition`, same |
| `Category` | 0 | `Category::cleanPositions()` re-indexes from 0 |
| `ProductImage`, `ProductImageList`, `NewProductImage` | 1 | `prestashop.core.grid.image.position_definition` declares `$firstPosition: 1` |

Measured on a 9.2.0 install:

```
MIN(position)   attribute 0   feature 0   feature_value 0   category 0   image 1   category_product 1
```

The report that prompted this is about attribute groups: the back office shows position 1 for the first row while `GET /attributes/groups` returns 0. That difference is a display convention rather than a second data convention - core says so where the grid filter has to undo it, in `AttributeGroupQueryBuilder`:

```php
// When filtering by position,
// value must be decreased by 1,
// since position value in database starts at 0,
// but for user display positions are increased by 1.
```

### Why documenting rather than renumbering

The read side already round-trips with the write side. `PUT /attributes/groups/positions` is declared with `positionDefinition: 'prestashop.core.grid.attribute_group.position_definition'`, so it consumes the same 0 based space the read returns; shifting the read to 1 based would break the endpoint against its own writer, and would have to be repeated for every resource that shares the mechanism. The `image` resources are 1 based for the same reason in the other direction.

So this adds the description to the OpenAPI schema of each `position` property and changes no value.

`ApiProperty` had to be imported in `ProductImageList` and `NewProductImage`, which did not use it yet.
