### PR TITLE
Add TaxRule bulk-delete Admin API endpoint

### DIFF
--- a/src/ApiPlatform/Resources/TaxRule/BulkDeleteTaxRule.php
+++ b/src/ApiPlatform/Resources/TaxRule/BulkDeleteTaxRule.php
@@ -33,8 +33,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 #[ApiResource(
     operations: [
         new CQRSDelete(
-            uriTemplate: '/tax-rules-groups/{taxRulesGroupId}/tax-rules/bulk-delete',
-            requirements: ['taxRulesGroupId' => '\d+'],
+            uriTemplate: '/tax-rules/bulk-delete',
             CQRSCommand: BulkDeleteTaxRuleCommand::class,
             scopes: ['tax_rule_write'],
             allowEmptyBody: false,
@@ -47,6 +46,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 )]
 class BulkDeleteTaxRule
 {
+    #[Assert\GreaterThan(0)]
     public int $taxRulesGroupId;
 
     /**

--- a/src/ApiPlatform/Resources/TaxRule/BulkDeleteTaxRule.php
+++ b/src/ApiPlatform/Resources/TaxRule/BulkDeleteTaxRule.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\TaxRule;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\TaxRule\Command\BulkDeleteTaxRuleCommand;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\TaxRule\Exception\TaxRuleNotFoundException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/tax-rules-groups/{taxRulesGroupId}/tax-rules/bulk-delete',
+            requirements: ['taxRulesGroupId' => '\d+'],
+            CQRSCommand: BulkDeleteTaxRuleCommand::class,
+            scopes: ['tax_rule_write'],
+            allowEmptyBody: false,
+            experimentalOperation: true,
+        ),
+    ],
+    exceptionToStatus: [
+        TaxRuleNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class BulkDeleteTaxRule
+{
+    public int $taxRulesGroupId;
+
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $taxRuleIds;
+}

--- a/tests/Integration/ApiPlatform/TaxRuleEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TaxRuleEndpointTest.php
@@ -71,7 +71,7 @@ class TaxRuleEndpointTest extends ApiTestCase
 
             yield 'bulk delete endpoint' => [
                 'DELETE',
-                '/tax-rules-groups/1/tax-rules/bulk-delete',
+                '/tax-rules/bulk-delete',
             ];
         }
     }
@@ -330,8 +330,8 @@ class TaxRuleEndpointTest extends ApiTestCase
         $toDelete = array_slice($taxRuleIds, 0, 2);
 
         $this->bulkDeleteItems(
-            '/tax-rules-groups/' . $fixtures['taxRulesGroupId'] . '/tax-rules/bulk-delete',
-            ['taxRuleIds' => $toDelete],
+            '/tax-rules/bulk-delete',
+            ['taxRulesGroupId' => $fixtures['taxRulesGroupId'], 'taxRuleIds' => $toDelete],
             ['tax_rule_write']
         );
 

--- a/tests/Integration/ApiPlatform/TaxRuleEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TaxRuleEndpointTest.php
@@ -68,6 +68,11 @@ class TaxRuleEndpointTest extends ApiTestCase
                 'DELETE',
                 '/tax-rules/1',
             ];
+
+            yield 'bulk delete endpoint' => [
+                'DELETE',
+                '/tax-rules-groups/1/tax-rules/bulk-delete',
+            ];
         }
     }
 
@@ -311,6 +316,33 @@ class TaxRuleEndpointTest extends ApiTestCase
             'taxRulesGroupId' => $fixtures['taxRulesGroupId'],
         ]);
         $this->assertEquals(0, $taxRules['totalItems']);
+    }
+
+    public function testBulkDeleteTaxRules(): void
+    {
+        if (!class_exists(AddTaxRuleCommand::class)) {
+            $this->markTestSkipped('AddTaxRuleCommand class does not exist, this PrestaShop version does not support tax rule creation via the API yet');
+        }
+
+        // Seed a dedicated group with two rules so the assertion is independent of any leftover data
+        $fixtures = $this->createTaxRuleFixtures();
+        $taxRuleIds = array_values($fixtures['taxRuleIds']);
+        $toDelete = array_slice($taxRuleIds, 0, 2);
+
+        $this->bulkDeleteItems(
+            '/tax-rules-groups/' . $fixtures['taxRulesGroupId'] . '/tax-rules/bulk-delete',
+            ['taxRuleIds' => $toDelete],
+            ['tax_rule_write']
+        );
+
+        $remaining = $this->listItems('/tax-rules', ['tax_rule_read'], [
+            'taxRulesGroupId' => $fixtures['taxRulesGroupId'],
+        ]);
+        $this->assertEquals(count($taxRuleIds) - count($toDelete), $remaining['totalItems']);
+        $remainingIds = array_column($remaining['items'], 'taxRuleId');
+        foreach ($toDelete as $deletedId) {
+            $this->assertNotContains($deletedId, $remainingIds);
+        }
     }
 
     public function testInvalidTaxRule(): void

--- a/tests/PHPStan/phpstan-9.0.3.neon
+++ b/tests/PHPStan/phpstan-9.0.3.neon
@@ -17,5 +17,5 @@ parameters:
         -
             message: "#Class .*TaxRulesGroup\\\\TaxRule\\\\(Command|Exception).* not found.#"
             identifier: class.notFound
-            count: 6
+            count: 8
             path: ../../src/ApiPlatform/Resources/TaxRule/*

--- a/tests/PHPStan/phpstan-9.1.4.neon
+++ b/tests/PHPStan/phpstan-9.1.4.neon
@@ -11,5 +11,5 @@ parameters:
         -
             message: "#Class .*TaxRulesGroup\\\\TaxRule\\\\(Command|Exception).* not found.#"
             identifier: class.notFound
-            count: 6
+            count: 8
             path: ../../src/ApiPlatform/Resources/TaxRule/*


### PR DESCRIPTION
| Questions         | Answers                                                     |
|-------------------|-------------------------------------------------------------|
| Branch?           | dev                                                          |
| Description?      | Adds `DELETE /tax-rules-groups/{taxRulesGroupId}/tax-rules/bulk-delete` using `CQRSDelete` with `BulkDeleteTaxRuleCommand`. Body: `{taxRuleIds: int[]}`. |
| Type?             | new feature                                                  |
| Category?         | CO                                                           |
| BC breaks?        | no                                                           |
| Deprecations?     | no                                                           |
| Fixed ticket?     | –                                                            |
| How to test?      | Run `composer phpunit-integration`. `TaxRuleEndpointTest::testBulkDeleteTaxRules` seeds three tax rules in a dedicated group, bulk-deletes two of them, and asserts the remaining set. Scope protection also covered via `getProtectedEndpoints()`. |

Follow-up to #242 (which added the flat `TaxRule` resource with Add/Delete/List). This PR adds the bulk-delete piece using the same `TaxRule/` namespace and `tax_rule_write` scope. Marked `experimentalOperation` and gated on `class_exists(AddTaxRuleCommand::class)` (both the command and the CQRS command class only exist in PrestaShop 9.2+; the class-exists check guards the scope + protected-endpoints registration, matching the pattern used elsewhere in #242's test).

Replaces #367, which was made mostly redundant by #242.