### PR TITLE
Expose GetTaxRuleList as GET /tax-rules-groups/{id}/tax-rules

### DIFF
--- a/src/ApiPlatform/Resources/TaxRulesGroup/TaxRuleList.php
+++ b/src/ApiPlatform/Resources/TaxRulesGroup/TaxRuleList.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\TaxRulesGroup;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\TaxRule\Query\GetTaxRuleList;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPaginate;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSPaginate(
+            uriTemplate: '/tax-rules-groups/{taxRulesGroupId}/tax-rules',
+            CQRSQuery: GetTaxRuleList::class,
+            scopes: [
+                'tax_rules_group_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][langId]' => '[languageId]',
+            ],
+            itemsField: 'taxRules',
+            countField: 'totalCount',
+        ),
+    ],
+    exceptionToStatus: [
+        TaxRulesGroupNotFoundException::class => Response::HTTP_NOT_FOUND,
+    ],
+)]
+class TaxRuleList
+{
+    public int $taxRulesGroupId;
+
+    #[ApiProperty(identifier: true)]
+    public int $taxRuleId;
+
+    public string $countryName;
+
+    public string $stateName;
+
+    public string $zipcode;
+
+    public int $behavior;
+
+    public string $taxName;
+
+    public string $taxRate;
+
+    public string $description;
+}

--- a/src/ApiPlatform/Resources/TaxRulesGroup/TaxRuleList.php
+++ b/src/ApiPlatform/Resources/TaxRulesGroup/TaxRuleList.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\TaxRulesGroup;
 
-use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\Exception\TaxRulesGroupNotFoundException;
 use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\TaxRule\Query\GetTaxRuleList;
@@ -33,6 +32,7 @@ use Symfony\Component\HttpFoundation\Response;
     operations: [
         new CQRSPaginate(
             uriTemplate: '/tax-rules-groups/{taxRulesGroupId}/tax-rules',
+            requirements: ['taxRulesGroupId' => '\d+'],
             CQRSQuery: GetTaxRuleList::class,
             scopes: [
                 'tax_rules_group_read',
@@ -53,7 +53,6 @@ class TaxRuleList
 {
     public int $taxRulesGroupId;
 
-    #[ApiProperty(identifier: true)]
     public int $taxRuleId;
 
     public string $countryName;

--- a/src/ApiPlatform/Resources/TaxRulesGroup/TaxRuleList.php
+++ b/src/ApiPlatform/Resources/TaxRulesGroup/TaxRuleList.php
@@ -42,6 +42,7 @@ use Symfony\Component\HttpFoundation\Response;
             ],
             itemsField: 'taxRules',
             countField: 'totalCount',
+            experimentalOperation: true,
         ),
     ],
     exceptionToStatus: [

--- a/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\TaxRule\Query\GetTaxRuleList;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\Resources\DatabaseDump;
 
@@ -372,6 +373,9 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
 
     public function testListTaxRulesOfExistingGroup(): void
     {
+        if (!class_exists(GetTaxRuleList::class)) {
+            $this->markTestSkipped('GetTaxRuleList query is only available on PrestaShop develop.');
+        }
         // Group 1 comes from the default install fixtures. We only assert the
         // response shape — the exact number of rules can vary by installed
         // country pack, so we check every returned item matches the DTO.
@@ -394,12 +398,18 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
 
     public function testListTaxRulesPagination(): void
     {
+        if (!class_exists(GetTaxRuleList::class)) {
+            $this->markTestSkipped('GetTaxRuleList query is only available on PrestaShop develop.');
+        }
         $response = $this->listItems('/tax-rules-groups/1/tax-rules?limit=1&offset=0', ['tax_rules_group_read']);
         $this->assertLessThanOrEqual(1, count($response['items']));
     }
 
     public function testListTaxRulesForMissingGroup(): void
     {
+        if (!class_exists(GetTaxRuleList::class)) {
+            $this->markTestSkipped('GetTaxRuleList query is only available on PrestaShop develop.');
+        }
         // GetTaxRuleList does not check parent existence — a missing group
         // just yields an empty rule set, mirroring the BO controller behavior.
         $response = $this->listItems('/tax-rules-groups/999999/tax-rules', ['tax_rules_group_read']);

--- a/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
@@ -84,10 +84,13 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
             '/tax-rules-groups/1/set-status',
         ];
 
-        yield 'list tax rules endpoint' => [
-            'GET',
-            '/tax-rules-groups/1/tax-rules',
-        ];
+        // Only registered on PS versions where the CQRS query exists (>= develop).
+        if (class_exists(GetTaxRuleList::class)) {
+            yield 'list tax rules endpoint' => [
+                'GET',
+                '/tax-rules-groups/1/tax-rules',
+            ];
+        }
     }
 
     public function testAddTaxRulesGroup(): int

--- a/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
+++ b/tests/Integration/ApiPlatform/TaxRulesGroupEndpointTest.php
@@ -38,7 +38,7 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
     {
         parent::tearDownAfterClass();
         // Reset DB as it was before this test
-        DatabaseDump::restoreTables(['tax_rules_group', 'tax_rules_group_shop']);
+        DatabaseDump::restoreTables(['tax_rules_group', 'tax_rules_group_shop', 'tax_rule']);
     }
 
     public static function getProtectedEndpoints(): iterable
@@ -81,6 +81,11 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
         yield 'toggle status endpoint' => [
             'PATCH',
             '/tax-rules-groups/1/set-status',
+        ];
+
+        yield 'list tax rules endpoint' => [
+            'GET',
+            '/tax-rules-groups/1/tax-rules',
         ];
     }
 
@@ -363,6 +368,43 @@ class TaxRulesGroupEndpointTest extends ApiTestCase
         }
 
         $this->assertEquals(50, $this->countItems('/tax-rules-groups', ['tax_rules_group_read']));
+    }
+
+    public function testListTaxRulesOfExistingGroup(): void
+    {
+        // Group 1 comes from the default install fixtures. We only assert the
+        // response shape — the exact number of rules can vary by installed
+        // country pack, so we check every returned item matches the DTO.
+        $response = $this->listItems('/tax-rules-groups/1/tax-rules', ['tax_rules_group_read']);
+        $this->assertArrayHasKey('items', $response);
+        $this->assertArrayHasKey('totalItems', $response);
+        $this->assertIsInt($response['totalItems']);
+        $this->assertCount($response['totalItems'] > 50 ? 50 : $response['totalItems'], $response['items']);
+
+        foreach ($response['items'] as $rule) {
+            $this->assertEquals(
+                ['taxRulesGroupId', 'taxRuleId', 'countryName', 'stateName', 'zipcode', 'behavior', 'taxName', 'taxRate', 'description'],
+                array_keys($rule)
+            );
+            $this->assertEquals(1, $rule['taxRulesGroupId']);
+            $this->assertIsInt($rule['taxRuleId']);
+            $this->assertIsInt($rule['behavior']);
+        }
+    }
+
+    public function testListTaxRulesPagination(): void
+    {
+        $response = $this->listItems('/tax-rules-groups/1/tax-rules?limit=1&offset=0', ['tax_rules_group_read']);
+        $this->assertLessThanOrEqual(1, count($response['items']));
+    }
+
+    public function testListTaxRulesForMissingGroup(): void
+    {
+        // GetTaxRuleList does not check parent existence — a missing group
+        // just yields an empty rule set, mirroring the BO controller behavior.
+        $response = $this->listItems('/tax-rules-groups/999999/tax-rules', ['tax_rules_group_read']);
+        $this->assertSame(0, $response['totalItems']);
+        $this->assertSame([], $response['items']);
     }
 
     public function testCreateInvalidTaxRulesGroup(): void

--- a/tests/PHPStan/phpstan-9.0.3.neon
+++ b/tests/PHPStan/phpstan-9.0.3.neon
@@ -19,3 +19,9 @@ parameters:
             identifier: class.notFound
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
+        # GetTaxRuleList only exists on develop; gated via experimentalOperation.
+        -
+            message: "#Class .*TaxRulesGroup\\\\TaxRule\\\\Query\\\\GetTaxRuleList not found.#"
+            identifier: class.notFound
+            count: 1
+            path: ../../src/ApiPlatform/Resources/TaxRulesGroup/TaxRuleList.php

--- a/tests/PHPStan/phpstan-9.1.4.neon
+++ b/tests/PHPStan/phpstan-9.1.4.neon
@@ -13,3 +13,9 @@ parameters:
             identifier: class.notFound
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
+        # GetTaxRuleList only exists on develop; gated via experimentalOperation.
+        -
+            message: "#Class .*TaxRulesGroup\\\\TaxRule\\\\Query\\\\GetTaxRuleList not found.#"
+            identifier: class.notFound
+            count: 1
+            path: ../../src/ApiPlatform/Resources/TaxRulesGroup/TaxRuleList.php


### PR DESCRIPTION
## Questions

| Question | Answer |
|---|---|
| Branch? | dev |
| Bug fix? | no |
| New feature? | yes |
| Category? | FO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | See test plan below |
| Fixed ticket? | Tracked in PrestaShop/PrestaShop#39630 |

## Description

Adds a paginated sub-resource that returns the tax rules attached to a tax rules group, delegating to the existing core CQRS query `GetTaxRuleList`.

- **Route**: `GET /tax-rules-groups/{taxRulesGroupId}/tax-rules?limit=&offset=`
- **CQRS**: `PrestaShop\PrestaShop\Core\Domain\TaxRulesGroup\TaxRule\Query\GetTaxRuleList`
- **Wrapper mapping**: `TaxRuleList { taxRules[], totalCount }` → `itemsField` / `countField`
- **Language**: `languageId` sourced from request context (`[_context][langId]`), same pattern as `CombinationList`
- **Scope**: `tax_rules_group_read` (mirrors `product_read` on `/products/{id}/images`)
- **Version gating**: the CQRS query only exists on `develop`, so the operation is marked `experimentalOperation: true`, the tests are guarded with `class_exists()`, and PHPStan version ignores cover `9.0.3` / `9.1.4` — same treatment as the existing TaxRule Command/Exception classes

Fields exposed match `TaxRuleForList`: `taxRuleId`, `countryName`, `stateName`, `zipcode`, `behavior`, `taxName`, `taxRate`, `description`, plus `taxRulesGroupId` from the URI.

## Test plan

- [x] CI green on the PrestaEdit fork: PHPStan (9.0.3 / 9.1.4 / 9.2.x / develop), PHP-CS-Fixer, Rector, PHPUnit, license headers, integration tests on the full PHP × PS matrix (8.1/8.4/8.5 × 9.0.3/9.1.4/9.2.x/develop) — see [PrestaEdit#1](https://github.com/PrestaEdit/ps_apiresources/pull/1)
- [ ] Local: `composer setup-local-tests && composer run-module-tests -- --filter TaxRulesGroupEndpointTest`
- [ ] Manual: hit `/tax-rules-groups/1/tax-rules` via Swagger UI, verify response shape and pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)