### PR TITLE
Expose Combination FeatureValues (GET/POST/DELETE)

### DIFF
--- a/src/ApiPlatform/Resources/Product/CombinationFeatureValues.php
+++ b/src/ApiPlatform/Resources/Product/CombinationFeatureValues.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\Product;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\Exception\CombinationNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\FeatureValue\Command\RemoveAllFeatureValuesFromCombinationCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\FeatureValue\Command\SetCombinationFeatureValuesCommand;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\FeatureValue\Query\GetCombinationFeatureValues;
+use PrestaShop\PrestaShop\Core\Domain\Product\FeatureValue\Exception\InvalidProductFeatureValuesFormatException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGetCollection;
+use PrestaShopBundle\ApiPlatform\Metadata\LocalizedValue;
+use Symfony\Component\HttpFoundation\Response;
+
+#[ApiResource(
+    operations: [
+        new CQRSGetCollection(
+            uriTemplate: '/products/combinations/{combinationId}/feature-values',
+            requirements: ['combinationId' => '\d+'],
+            CQRSQuery: GetCombinationFeatureValues::class,
+            scopes: [
+                'product_read',
+            ],
+            CQRSQueryMapping: [
+                '[_context][shopId]' => '[shopId]',
+            ],
+            ApiResourceMapping: [
+                '[isCustom]' => '[custom]',
+            ],
+            experimentalOperation: true,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/products/combinations/{combinationId}/feature-values',
+            requirements: ['combinationId' => '\d+'],
+            CQRSCommand: SetCombinationFeatureValuesCommand::class,
+            scopes: [
+                'product_write',
+            ],
+            status: Response::HTTP_NO_CONTENT,
+            output: false,
+            experimentalOperation: true,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/products/combinations/{combinationId}/feature-values',
+            requirements: ['combinationId' => '\d+'],
+            CQRSCommand: RemoveAllFeatureValuesFromCombinationCommand::class,
+            scopes: [
+                'product_write',
+            ],
+            status: Response::HTTP_NO_CONTENT,
+            output: false,
+            experimentalOperation: true,
+        ),
+    ],
+    exceptionToStatus: [
+        CombinationNotFoundException::class => Response::HTTP_NOT_FOUND,
+        InvalidProductFeatureValuesFormatException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class CombinationFeatureValues
+{
+    public int $combinationId;
+
+    public int $featureId;
+
+    public int $featureValueId;
+
+    #[LocalizedValue]
+    public array $localizedValues;
+
+    public bool $custom;
+
+    #[ApiProperty(openapiContext: [
+        'type' => 'array',
+        'description' => 'Feature values to attach to the combination. Each item: {feature_id: int, feature_value_id?: int, custom_values?: {langId: string}}',
+        'items' => ['type' => 'object'],
+    ])]
+    public ?array $featureValues = null;
+}

--- a/tests/Integration/ApiPlatform/ProductCombinationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductCombinationEndpointTest.php
@@ -366,7 +366,7 @@ class ProductCombinationEndpointTest extends ApiTestCase
     /**
      * @depends testCreateProductCombinations
      */
-    public function testGetCombinationFeatureValuesEmpty(int $productId, array $newCombinationIds): int
+    public function testGetCombinationFeatureValuesEmpty(array $newCombinationIds): int
     {
         if (!class_exists(GetCombinationFeatureValues::class)) {
             $this->markTestSkipped('Combination feature-value CQRS classes only exist on PrestaShop develop.');

--- a/tests/Integration/ApiPlatform/ProductCombinationEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ProductCombinationEndpointTest.php
@@ -25,8 +25,10 @@ namespace PsApiResourcesTest\Integration\ApiPlatform;
 use PrestaShop\PrestaShop\Adapter\Attribute\Repository\AttributeRepository;
 use PrestaShop\PrestaShop\Adapter\AttributeGroup\Repository\AttributeGroupRepository;
 use PrestaShop\PrestaShop\Core\Domain\AttributeGroup\ValueObject\AttributeGroupId;
+use PrestaShop\PrestaShop\Core\Domain\Product\Combination\FeatureValue\Query\GetCombinationFeatureValues;
 use PrestaShop\PrestaShop\Core\Domain\Product\ValueObject\ProductType;
 use PrestaShop\PrestaShop\Core\Domain\Shop\ValueObject\ShopConstraint;
+use Symfony\Component\HttpFoundation\Response;
 use Tests\Resources\Resetter\ProductResetter;
 
 class ProductCombinationEndpointTest extends ApiTestCase
@@ -91,6 +93,22 @@ class ProductCombinationEndpointTest extends ApiTestCase
             'GET',
             '/products/combinations/1',
         ];
+
+        // Only registered when the CQRS query/commands exist (>= PS develop).
+        if (class_exists(GetCombinationFeatureValues::class)) {
+            yield 'get feature values endpoint' => [
+                'GET',
+                '/products/combinations/1/feature-values',
+            ];
+            yield 'set feature values endpoint' => [
+                'POST',
+                '/products/combinations/1/feature-values',
+            ];
+            yield 'delete feature values endpoint' => [
+                'DELETE',
+                '/products/combinations/1/feature-values',
+            ];
+        }
     }
 
     public function testAddProductWithCombinations(): int
@@ -341,6 +359,46 @@ class ProductCombinationEndpointTest extends ApiTestCase
             'productEcotaxTaxExcluded' => 0.0,
             'quantity' => 0,
         ], $combination);
+
+        return $combinationId;
+    }
+
+    /**
+     * @depends testCreateProductCombinations
+     */
+    public function testGetCombinationFeatureValuesEmpty(int $productId, array $newCombinationIds): int
+    {
+        if (!class_exists(GetCombinationFeatureValues::class)) {
+            $this->markTestSkipped('Combination feature-value CQRS classes only exist on PrestaShop develop.');
+        }
+        $combinationId = $newCombinationIds[0];
+
+        $featureValues = $this->getItem('/products/combinations/' . $combinationId . '/feature-values', ['product_read']);
+        // Newly generated combination — no feature values attached yet.
+        $this->assertIsArray($featureValues);
+        $this->assertSame([], $featureValues);
+
+        return $combinationId;
+    }
+
+    /**
+     * @depends testGetCombinationFeatureValuesEmpty
+     */
+    public function testDeleteCombinationFeatureValuesIdempotent(int $combinationId): int
+    {
+        if (!class_exists(GetCombinationFeatureValues::class)) {
+            $this->markTestSkipped('Combination feature-value CQRS classes only exist on PrestaShop develop.');
+        }
+        // DELETE on an empty association must be idempotent (RemoveAll on empty is a no-op in core).
+        $this->deleteItem(
+            '/products/combinations/' . $combinationId . '/feature-values',
+            ['product_write'],
+            Response::HTTP_NO_CONTENT
+        );
+
+        // Read again to confirm still empty.
+        $featureValues = $this->getItem('/products/combinations/' . $combinationId . '/feature-values', ['product_read']);
+        $this->assertSame([], $featureValues);
 
         return $combinationId;
     }

--- a/tests/PHPStan/phpstan-9.0.3.neon
+++ b/tests/PHPStan/phpstan-9.0.3.neon
@@ -19,3 +19,9 @@ parameters:
             identifier: class.notFound
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
+        # Combination × FeatureValues CQRS layer only exists on develop; gated via experimentalOperation.
+        -
+            message: "#Class .*Combination\\\\FeatureValue\\\\(Command|Query|Exception).*|.*FeatureValue\\\\Exception\\\\InvalidProductFeatureValuesFormatException.* not found.#"
+            identifier: class.notFound
+            count: 4
+            path: ../../src/ApiPlatform/Resources/Product/CombinationFeatureValues.php

--- a/tests/PHPStan/phpstan-9.0.3.neon
+++ b/tests/PHPStan/phpstan-9.0.3.neon
@@ -20,8 +20,14 @@ parameters:
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
         # Combination × FeatureValues CQRS layer only exists on develop; gated via experimentalOperation.
+        # InvalidProductFeatureValuesFormatException is only introduced in 9.1, so 4 classes are missing on 9.0.
         -
-            message: "#Class .*Combination\\\\FeatureValue\\\\(Command|Query|Exception).*|.*FeatureValue\\\\Exception\\\\InvalidProductFeatureValuesFormatException.* not found.#"
+            message: "#Class .*Combination\\\\FeatureValue\\\\(Command|Query).* not found.#"
             identifier: class.notFound
-            count: 4
+            count: 3
+            path: ../../src/ApiPlatform/Resources/Product/CombinationFeatureValues.php
+        -
+            message: "#Class .*FeatureValue\\\\Exception\\\\InvalidProductFeatureValuesFormatException not found.#"
+            identifier: class.notFound
+            count: 1
             path: ../../src/ApiPlatform/Resources/Product/CombinationFeatureValues.php

--- a/tests/PHPStan/phpstan-9.0.3.neon
+++ b/tests/PHPStan/phpstan-9.0.3.neon
@@ -20,14 +20,8 @@ parameters:
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
         # Combination × FeatureValues CQRS layer only exists on develop; gated via experimentalOperation.
-        # InvalidProductFeatureValuesFormatException is only introduced in 9.1, so 4 classes are missing on 9.0.
         -
             message: "#Class .*Combination\\\\FeatureValue\\\\(Command|Query).* not found.#"
             identifier: class.notFound
             count: 3
-            path: ../../src/ApiPlatform/Resources/Product/CombinationFeatureValues.php
-        -
-            message: "#Class .*FeatureValue\\\\Exception\\\\InvalidProductFeatureValuesFormatException not found.#"
-            identifier: class.notFound
-            count: 1
             path: ../../src/ApiPlatform/Resources/Product/CombinationFeatureValues.php

--- a/tests/PHPStan/phpstan-9.1.4.neon
+++ b/tests/PHPStan/phpstan-9.1.4.neon
@@ -13,3 +13,9 @@ parameters:
             identifier: class.notFound
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
+        # Combination × FeatureValues CQRS layer only exists on develop; gated via experimentalOperation.
+        -
+            message: "#Class .*Combination\\\\FeatureValue\\\\(Command|Query|Exception).*|.*FeatureValue\\\\Exception\\\\InvalidProductFeatureValuesFormatException.* not found.#"
+            identifier: class.notFound
+            count: 4
+            path: ../../src/ApiPlatform/Resources/Product/CombinationFeatureValues.php

--- a/tests/PHPStan/phpstan-9.1.4.neon
+++ b/tests/PHPStan/phpstan-9.1.4.neon
@@ -14,8 +14,9 @@ parameters:
             count: 6
             path: ../../src/ApiPlatform/Resources/TaxRule/*
         # Combination × FeatureValues CQRS layer only exists on develop; gated via experimentalOperation.
+        # The Product-side InvalidProductFeatureValuesFormatException exists since 9.1, so only the 3 CQRS classes are missing here.
         -
-            message: "#Class .*Combination\\\\FeatureValue\\\\(Command|Query|Exception).*|.*FeatureValue\\\\Exception\\\\InvalidProductFeatureValuesFormatException.* not found.#"
+            message: "#Class .*Combination\\\\FeatureValue\\\\(Command|Query).* not found.#"
             identifier: class.notFound
-            count: 4
+            count: 3
             path: ../../src/ApiPlatform/Resources/Product/CombinationFeatureValues.php

--- a/tests/PHPStan/phpstan-9.2.x.neon
+++ b/tests/PHPStan/phpstan-9.2.x.neon
@@ -1,0 +1,12 @@
+includes:
+    - %currentWorkingDirectory%/tests/PHPStan/phpstan.neon
+
+parameters:
+    tmpDir: %currentWorkingDirectory%/var/phpstan-tmp/9.2.x
+    ignoreErrors:
+        # Combination × FeatureValues CQRS layer only exists on develop; gated via experimentalOperation.
+        -
+            message: "#Class .*Combination\\\\FeatureValue\\\\(Command|Query|Exception).*|.*FeatureValue\\\\Exception\\\\InvalidProductFeatureValuesFormatException.* not found.#"
+            identifier: class.notFound
+            count: 4
+            path: ../../src/ApiPlatform/Resources/Product/CombinationFeatureValues.php

--- a/tests/PHPStan/phpstan-9.2.x.neon
+++ b/tests/PHPStan/phpstan-9.2.x.neon
@@ -5,8 +5,9 @@ parameters:
     tmpDir: %currentWorkingDirectory%/var/phpstan-tmp/9.2.x
     ignoreErrors:
         # Combination × FeatureValues CQRS layer only exists on develop; gated via experimentalOperation.
+        # InvalidProductFeatureValuesFormatException exists here, only the 3 CQRS classes are missing.
         -
-            message: "#Class .*Combination\\\\FeatureValue\\\\(Command|Query|Exception).*|.*FeatureValue\\\\Exception\\\\InvalidProductFeatureValuesFormatException.* not found.#"
+            message: "#Class .*Combination\\\\FeatureValue\\\\(Command|Query).* not found.#"
             identifier: class.notFound
-            count: 4
+            count: 3
             path: ../../src/ApiPlatform/Resources/Product/CombinationFeatureValues.php


### PR DESCRIPTION
## Questions

| Question | Answer |
|---|---|
| Branch? | dev |
| Bug fix? | no |
| New feature? | yes |
| Category? | BO |
| BC breaks? | no |
| Deprecations? | no |
| How to test? | See test plan |
| Fixed ticket? | Tracked in PrestaShop/PrestaShop#39630 |

## Description

Exposes three endpoints on top of the existing core CQRS layer for Combination × FeatureValues:

- \`GET /products/combinations/{combinationId}/feature-values\` → \`GetCombinationFeatureValues\` (shopId from request context)
- \`POST /products/combinations/{combinationId}/feature-values\` → \`SetCombinationFeatureValuesCommand\` (204 No Content)
- \`DELETE /products/combinations/{combinationId}/feature-values\` → \`RemoveAllFeatureValuesFromCombinationCommand\` (204, idempotent)

Payload for POST mirrors the CQRS shape:
\`\`\`json
{"featureValues": [
  {"feature_id": 1, "feature_value_id": 5},
  {"feature_id": 2, "custom_values": {"1": "custom text"}}
]}
\`\`\`

Scope: \`product_read\` / \`product_write\` (mirrors sibling Combination endpoints).

### Version gating

The three CQRS classes only exist on \`develop\` (not on 9.0/9.1/9.2). Following the pattern already established for the TaxRule Command/Exception classes:
- operations marked \`experimentalOperation: true\`
- integration tests guarded with \`class_exists()\`
- PHPStan ignores added for 9.0.3 / 9.1.4 / 9.2.x

## Test plan

- [x] CI green on the full matrix — see [PrestaEdit#2](https://github.com/PrestaEdit/ps_apiresources/pull/2)
- [ ] Local: \`composer setup-local-tests && composer run-module-tests -- --filter ProductCombinationEndpointTest\`
- [ ] Manual: seed a feature+value, POST/GET/DELETE via Swagger UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)