### PR TITLE
CI: pin PrestaShop 9.1.5 instead of the superseded 9.1.4 tag

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         php: ${{ fromJSON(needs.workflow_matrix_generator.outputs.dynamic_matrix) }}
-        prestashop_version: ['develop', '9.2.x', '9.0.3', '9.1.4']
+        prestashop_version: ['develop', '9.2.x', '9.0.3', '9.1.5']
         exclude:
           # 9.0.3 doesn't support PHP 8.5
           - php: '8.5'

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -129,7 +129,7 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
           matrix:
-              presta_version: ['9.0.3', '9.1.4', 'develop', '9.2.x']
+              presta_version: ['9.0.3', '9.1.5', 'develop', '9.2.x']
           fail-fast: false
       env:
           PHPRC: ${{ github.workspace }}/${{ github.event.repository.name }}/.phpstan-php-ini

--- a/tests/PHPStan/phpstan-9.1.5.neon
+++ b/tests/PHPStan/phpstan-9.1.5.neon
@@ -2,7 +2,7 @@ includes:
     - %currentWorkingDirectory%/tests/PHPStan/phpstan.neon
 
 parameters:
-    tmpDir: %currentWorkingDirectory%/var/phpstan-tmp/9.1.x
+    tmpDir: %currentWorkingDirectory%/var/phpstan-tmp/9.1.5
     ignoreErrors:
         # Add version-specific ignores here as needed
         # The TaxRule create/delete CQRS domain layer only exists since PrestaShop 9.2 (develop).


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Pins both CI matrices on the `9.1.5` tag instead of `9.1.4`. 9.1.5 is the last release of the 9.1 line: the `9.1.x` branch was deleted from the core once it shipped, so nothing newer will come out of it. Covers the PHPStan matrix in `php.yml`, the integration matrix in `integration.yml`, and the neon's `tmpDir`.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Part of PrestaShop/PrestaShop#41648
| How to test?      | CI only. The `9.1.5` PHPStan and integration jobs must be green.
| Sponsor company   | @PrestaShopCorp

The 9.1.4 pin was merged before 9.1.5 was released (2026-08-18), hence the follow-up.

The neon rename is a `git mv`, since `phpstan-config` interpolates `matrix.presta_version`. Its version-specific suppression is unchanged, the TaxRule CQRS classes are still absent from that line.

Unrelated observation while going through it: the matrix has a `9.2.x` entry but there is no `tests/PHPStan/phpstan-9.2.x.neon`. With `phpstan-config-merge: 'false'`, a missing file makes the action fall back to the php-dev-tools config, so that job silently runs without this module's own PHPStan configuration and custom rules. Left out of this PR to keep it a pure pin, but worth a follow-up.
