### PR TITLE
Add the extra property definition endpoints

### DIFF
--- a/src/ApiPlatform/Resources/ExtraPropertyDefinition/BulkDeleteExtraPropertyDefinitions.php
+++ b/src/ApiPlatform/Resources/ExtraPropertyDefinition/BulkDeleteExtraPropertyDefinitions.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\ExtraPropertyDefinition;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Command\BulkDeleteExtraPropertyDefinitionCommand;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ExtraPropertyDefinitionNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ProtectedModuleExtraPropertyDefinitionException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Deletes several definitions at once. A definition that cannot be deleted (unknown id,
+ * module-owned) does not stop the others: the response is a 207 listing the per-item failures.
+ */
+#[ApiResource(
+    operations: [
+        new CQRSDelete(
+            uriTemplate: '/extra-property-definitions/bulk-delete',
+            CQRSCommand: BulkDeleteExtraPropertyDefinitionCommand::class,
+            scopes: ['extra_property_definition_write'],
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            allowEmptyBody: false,
+            extraProperties: ExtraPropertyDefinition::VERSION_GATE,
+            openapiContext: [
+                'requestBody' => [
+                    'required' => true,
+                    'content' => [
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'required' => ['extraPropertyDefinitionIds'],
+                                'properties' => [
+                                    'extraPropertyDefinitionIds' => [
+                                        'type' => 'array',
+                                        'items' => ['type' => 'integer'],
+                                    ],
+                                    'dropColumn' => [
+                                        'type' => 'boolean',
+                                        'default' => false,
+                                        'description' => 'Also drop the storage columns and every stored value of these properties.',
+                                    ],
+                                ],
+                            ],
+                            'example' => [
+                                'extraPropertyDefinitionIds' => [1, 3],
+                                'dropColumn' => false,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ),
+    ],
+    exceptionToStatus: [
+        ExtraPropertyDefinitionNotFoundException::class => Response::HTTP_NOT_FOUND,
+        ProtectedModuleExtraPropertyDefinitionException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class BulkDeleteExtraPropertyDefinitions
+{
+    /**
+     * @var int[]
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'example' => [1, 3]])]
+    #[Assert\NotBlank]
+    public array $extraPropertyDefinitionIds;
+
+    /**
+     * Also drop the storage columns (data loss); defaults to keeping them.
+     */
+    public ?bool $dropColumn;
+
+    public const COMMAND_MAPPING = [
+        '[extraPropertyDefinitionIds]' => '[ids]',
+    ];
+}

--- a/src/ApiPlatform/Resources/ExtraPropertyDefinition/ExtraPropertyDefinition.php
+++ b/src/ApiPlatform/Resources/ExtraPropertyDefinition/ExtraPropertyDefinition.php
@@ -1,0 +1,289 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\ExtraPropertyDefinition;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\Decimal\DecimalNumber;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Command\AddExtraPropertyDefinitionCommand;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Command\DeleteExtraPropertyDefinitionCommand;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Command\UpdateExtraPropertyDefinitionCommand;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ExtraPropertyConstraintException;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ExtraPropertyDefinitionNotFoundException;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ExtraPropertyRegistrationFailureException;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Exception\ProtectedModuleExtraPropertyDefinitionException;
+use PrestaShop\PrestaShop\Core\Domain\ExtraProperty\Query\GetExtraPropertyDefinitionForEditing;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Exception\InvalidExtraPropertyDefinitionException;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSCreate;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSDelete;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSGet;
+use PrestaShopBundle\ApiPlatform\Metadata\CQRSPartialUpdate;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Registry of the "extra property" definitions: the typed fields a module (or the merchant, through
+ * this API) adds to native entities. Definitions created here are core-owned (no moduleName);
+ * module-owned definitions are readable but only their shop association can be modified.
+ *
+ * The extra property VALUES themselves are exposed on each entity's own endpoints (the
+ * "extraProperties" sub-object on items, inline "extra_<module>_<property>" keys on lists), not here.
+ */
+#[ApiResource(
+    operations: [
+        new CQRSGet(
+            uriTemplate: '/extra-property-definitions/{extraPropertyDefinitionId}',
+            requirements: ['extraPropertyDefinitionId' => '\d+'],
+            CQRSQuery: GetExtraPropertyDefinitionForEditing::class,
+            scopes: ['extra_property_definition_read'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            extraProperties: self::VERSION_GATE,
+        ),
+        new CQRSCreate(
+            uriTemplate: '/extra-property-definitions',
+            validationContext: ['groups' => ['Default', 'Create']],
+            CQRSCommand: AddExtraPropertyDefinitionCommand::class,
+            CQRSQuery: GetExtraPropertyDefinitionForEditing::class,
+            scopes: ['extra_property_definition_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            extraProperties: self::VERSION_GATE,
+        ),
+        new CQRSPartialUpdate(
+            uriTemplate: '/extra-property-definitions/{extraPropertyDefinitionId}',
+            requirements: ['extraPropertyDefinitionId' => '\d+'],
+            read: false,
+            validationContext: ['groups' => ['Default', 'Update']],
+            CQRSCommand: UpdateExtraPropertyDefinitionCommand::class,
+            CQRSQuery: GetExtraPropertyDefinitionForEditing::class,
+            scopes: ['extra_property_definition_write'],
+            CQRSQueryMapping: self::QUERY_MAPPING,
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            extraProperties: self::VERSION_GATE,
+        ),
+        new CQRSDelete(
+            uriTemplate: '/extra-property-definitions/{extraPropertyDefinitionId}',
+            requirements: ['extraPropertyDefinitionId' => '\d+'],
+            output: false,
+            CQRSCommand: DeleteExtraPropertyDefinitionCommand::class,
+            scopes: ['extra_property_definition_write'],
+            CQRSCommandMapping: self::COMMAND_MAPPING,
+            extraProperties: self::VERSION_GATE,
+            // The body is optional: without it the storage column (and its data) is kept, like the
+            // back office "Delete" action; {"dropColumn": true} also drops the column.
+            openapiContext: [
+                'requestBody' => [
+                    'required' => false,
+                    'content' => [
+                        'application/json' => [
+                            'schema' => [
+                                'type' => 'object',
+                                'properties' => [
+                                    'dropColumn' => [
+                                        'type' => 'boolean',
+                                        'default' => false,
+                                        'description' => 'Also drop the storage column and every stored value of this property.',
+                                    ],
+                                ],
+                            ],
+                            'example' => ['dropColumn' => false],
+                        ],
+                    ],
+                ],
+            ],
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+    exceptionToStatus: [
+        ExtraPropertyDefinitionNotFoundException::class => Response::HTTP_NOT_FOUND,
+        // Input format (invalid constraints DSL, invalid id).
+        ExtraPropertyConstraintException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        // Registry refusals: unknown entity, scope conflict, destructive change, invalid default
+        // value, constraints that cannot be stored, unknown shop, form options that build no field.
+        ExtraPropertyRegistrationFailureException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        // Module-owned definitions only accept a shop association change.
+        ProtectedModuleExtraPropertyDefinitionException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+        // Identifier rules of the definition value object (entity/property names, sizes).
+        InvalidExtraPropertyDefinitionException::class => Response::HTTP_UNPROCESSABLE_ENTITY,
+    ],
+)]
+class ExtraPropertyDefinition
+{
+    /**
+     * The definition CQRS layer only exists since PrestaShop 9.2.0: the operations are filtered out
+     * of the API on older cores (declared as an extra property so those cores can still parse this
+     * class — the named argument only exists on 9.2+).
+     */
+    public const VERSION_GATE = ['minVersion' => '9.2.0'];
+
+    public const TYPES = ['int', 'bool', 'string', 'float', 'date', 'html', 'json', 'choice'];
+    public const SCOPES = ['common', 'lang', 'shop'];
+    public const SQL_INDEXES = ['none', 'key', 'unique'];
+
+    #[ApiProperty(identifier: true)]
+    public int $extraPropertyDefinitionId;
+
+    /**
+     * Logical entity name (product, customer, combination, order...).
+     */
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $entityName;
+
+    /**
+     * Owning module technical name; null for core-owned definitions (every definition created
+     * through this API). Read-only: module-owned definitions cannot be created or edited here,
+     * except for their shop association.
+     */
+    public ?string $moduleName;
+
+    #[Assert\NotBlank(groups: ['Create'])]
+    public string $propertyName;
+
+    #[ApiProperty(openapiContext: ['type' => 'string', 'enum' => self::TYPES, 'default' => 'string'])]
+    #[Assert\Choice(choices: self::TYPES)]
+    public string $type;
+
+    /**
+     * common = one value for every shop and language, lang = one value per language, shop = one
+     * value per shop.
+     */
+    #[ApiProperty(openapiContext: ['type' => 'string', 'enum' => self::SCOPES, 'default' => 'common'])]
+    #[Assert\Choice(choices: self::SCOPES)]
+    public string $scope;
+
+    #[ApiProperty(openapiContext: ['type' => 'string', 'enum' => self::SQL_INDEXES, 'default' => 'none'])]
+    #[Assert\Choice(choices: self::SQL_INDEXES)]
+    public string $sqlIndex;
+
+    /**
+     * Whether front-office presenters expose the value.
+     */
+    public bool $displayFront;
+
+    /**
+     * Marks the field as required in the back office form and in the OpenAPI schema of the entity
+     * endpoints; it adds no server-side validation (declare NotBlank in the constraints for that).
+     */
+    public bool $required;
+
+    /**
+     * Whether the storage column accepts NULL.
+     */
+    public bool $nullable;
+
+    /**
+     * VARCHAR size for string properties (null = 255).
+     */
+    public ?int $size;
+
+    /**
+     * Default value served for entities without a stored value, typed like the property (a float
+     * property returns a JSON number, a bool property a JSON boolean). A float default travels as
+     * a DecimalNumber; the scalar members keep their own type (the core CQRS normalizer tries the
+     * scalar members of a union before the class ones).
+     */
+    #[ApiProperty(openapiContext: ['oneOf' => [['type' => 'integer'], ['type' => 'number'], ['type' => 'string'], ['type' => 'boolean']], 'nullable' => true])]
+    public int|string|bool|DecimalNumber|null $defaultValue;
+
+    /**
+     * Allowed values of a choice property.
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'string'], 'nullable' => true])]
+    public ?array $enumValues;
+
+    public ?string $labelWording;
+
+    public ?string $labelDomain;
+
+    public ?string $descriptionWording;
+
+    public ?string $descriptionDomain;
+
+    /**
+     * Validation constraints applied to each written value, in the extra property constraint DSL:
+     * one Symfony constraint per line (or comma-separated), e.g. "NotBlank", "Length(min: 2, max: 64)",
+     * "Choice(['a', 'b'])", "All[ Url ]". Read back in its canonical form (one per line). Null or
+     * empty = no validation.
+     */
+    #[ApiProperty(openapiContext: [
+        'type' => 'string',
+        'nullable' => true,
+        'description' => 'One constraint per line: Name, Name(value), Name(option: value, ...) or Composite[ ... ] — e.g. NotBlank, Length(min: 2, max: 64), Choice([\'a\', \'b\']), All[ Url ].',
+        'example' => "NotBlank\nLength(min: 2, max: 64)",
+    ])]
+    public ?string $constraints;
+
+    /**
+     * Symfony form type FQCN used by the back office entity form (null = text input).
+     */
+    public ?string $formType;
+
+    /**
+     * Options passed to the back office form type.
+     */
+    #[ApiProperty(openapiContext: ['type' => 'object', 'additionalProperties' => true, 'nullable' => true])]
+    public ?array $formOptions;
+
+    /**
+     * Back office form placements: "formId[:path[:before|after]]".
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'string'], 'nullable' => true, 'example' => ['product', 'category:seo:after']])]
+    public ?array $associatedForms;
+
+    /**
+     * Back office grid placements: "gridId[:columnId[:before|after]]".
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'string'], 'nullable' => true, 'example' => ['product:reference:after']])]
+    public ?array $associatedGrids;
+
+    /**
+     * Admin API endpoints exposing the value: URI templates with an optional ":METHOD" filter.
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'string'], 'nullable' => true, 'example' => ['/products', '/products/{productId}:GET,PATCH']])]
+    public ?array $associatedApis;
+
+    /**
+     * Shops the definition is restricted to. Null = no explicit restriction (core-owned: every
+     * shop, module-owned: the module's shops); an empty list on update reverts to that fallback.
+     */
+    #[ApiProperty(openapiContext: ['type' => 'array', 'items' => ['type' => 'integer'], 'nullable' => true])]
+    public ?array $shopIds;
+
+    public const QUERY_MAPPING = [
+        // URI parameter → GetExtraPropertyDefinitionForEditing(int $id)
+        '[extraPropertyDefinitionId]' => '[id]',
+        // Query result → API resource
+        '[id]' => '[extraPropertyDefinitionId]',
+        '[fieldType]' => '[type]',
+        '[fieldScope]' => '[scope]',
+        '[associatedShopIds]' => '[shopIds]',
+    ];
+
+    public const COMMAND_MAPPING = [
+        // URI parameter → Update/DeleteExtraPropertyDefinitionCommand(int $id)
+        '[extraPropertyDefinitionId]' => '[id]',
+        '[type]' => '[fieldType]',
+        '[scope]' => '[fieldScope]',
+        '[shopIds]' => '[associatedShopIds]',
+    ];
+}

--- a/src/ApiPlatform/Resources/ExtraPropertyDefinition/ExtraPropertyDefinition.php
+++ b/src/ApiPlatform/Resources/ExtraPropertyDefinition/ExtraPropertyDefinition.php
@@ -72,7 +72,6 @@ use Symfony\Component\Validator\Constraints as Assert;
         new CQRSPartialUpdate(
             uriTemplate: '/extra-property-definitions/{extraPropertyDefinitionId}',
             requirements: ['extraPropertyDefinitionId' => '\d+'],
-            read: false,
             validationContext: ['groups' => ['Default', 'Update']],
             CQRSCommand: UpdateExtraPropertyDefinitionCommand::class,
             CQRSQuery: GetExtraPropertyDefinitionForEditing::class,
@@ -84,7 +83,6 @@ use Symfony\Component\Validator\Constraints as Assert;
         new CQRSDelete(
             uriTemplate: '/extra-property-definitions/{extraPropertyDefinitionId}',
             requirements: ['extraPropertyDefinitionId' => '\d+'],
-            output: false,
             CQRSCommand: DeleteExtraPropertyDefinitionCommand::class,
             scopes: ['extra_property_definition_write'],
             CQRSCommandMapping: self::COMMAND_MAPPING,
@@ -274,16 +272,12 @@ class ExtraPropertyDefinition
         '[extraPropertyDefinitionId]' => '[id]',
         // Query result → API resource
         '[id]' => '[extraPropertyDefinitionId]',
-        '[fieldType]' => '[type]',
-        '[fieldScope]' => '[scope]',
         '[associatedShopIds]' => '[shopIds]',
     ];
 
     public const COMMAND_MAPPING = [
         // URI parameter → Update/DeleteExtraPropertyDefinitionCommand(int $id)
         '[extraPropertyDefinitionId]' => '[id]',
-        '[type]' => '[fieldType]',
-        '[scope]' => '[fieldScope]',
         '[shopIds]' => '[associatedShopIds]',
     ];
 }

--- a/src/ApiPlatform/Resources/ExtraPropertyDefinition/ExtraPropertyDefinition.php
+++ b/src/ApiPlatform/Resources/ExtraPropertyDefinition/ExtraPropertyDefinition.php
@@ -67,7 +67,10 @@ use Symfony\Component\Validator\Constraints as Assert;
             scopes: ['extra_property_definition_write'],
             CQRSQueryMapping: self::QUERY_MAPPING,
             CQRSCommandMapping: self::COMMAND_MAPPING,
-            extraProperties: self::VERSION_GATE,
+            // The defaults are declared as an extra property, not with the dedicated operation argument,
+            // so that older cores still parse this class (they ignore it and the fields stay required
+            // there). Create only: a partial update must never apply them.
+            extraProperties: self::VERSION_GATE + ['defaultValues' => self::CREATE_DEFAULT_VALUES],
         ),
         new CQRSPartialUpdate(
             uriTemplate: '/extra-property-definitions/{extraPropertyDefinitionId}',
@@ -137,6 +140,20 @@ class ExtraPropertyDefinition
     public const TYPES = ['int', 'bool', 'string', 'float', 'date', 'html', 'json', 'choice'];
     public const SCOPES = ['common', 'lang', 'shop'];
     public const SQL_INDEXES = ['none', 'key', 'unique'];
+
+    /**
+     * Mirrors the constructor defaults of AddExtraPropertyDefinitionCommand, so a payload that omits
+     * these fields behaves exactly like a back office form left untouched. They are documented as
+     * `default` in the schema and no longer listed as required.
+     */
+    public const CREATE_DEFAULT_VALUES = [
+        'type' => 'string',
+        'scope' => 'common',
+        'sqlIndex' => 'none',
+        'displayFront' => false,
+        'required' => false,
+        'nullable' => true,
+    ];
 
     #[ApiProperty(identifier: true)]
     public int $extraPropertyDefinitionId;

--- a/src/ApiPlatform/Resources/ExtraPropertyDefinition/ExtraPropertyDefinitionList.php
+++ b/src/ApiPlatform/Resources/ExtraPropertyDefinition/ExtraPropertyDefinitionList.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PrestaShop\Module\APIResources\ApiPlatform\Resources\ExtraPropertyDefinition;
+
+use ApiPlatform\Metadata\ApiProperty;
+use ApiPlatform\Metadata\ApiResource;
+use PrestaShop\PrestaShop\Core\Search\Filters\ExtraPropertyDefinitionFilters;
+use PrestaShopBundle\ApiPlatform\Metadata\PaginatedList;
+
+/**
+ * Backed by the back office registry grid. The grid follows the request's shop context: with a
+ * single shop or shop group context only the definitions available on those shops are listed.
+ */
+#[ApiResource(
+    operations: [
+        new PaginatedList(
+            uriTemplate: '/extra-property-definitions',
+            scopes: ['extra_property_definition_read'],
+            ApiResourceMapping: self::MAPPING,
+            gridDataFactory: 'prestashop.core.grid.data_factory.extra_property_definition',
+            filtersClass: ExtraPropertyDefinitionFilters::class,
+            filtersMapping: [
+                '[extraPropertyDefinitionId]' => '[id_extra_property_definition]',
+                '[entityName]' => '[entity_name]',
+                '[moduleName]' => '[module_name]',
+                '[propertyName]' => '[property_name]',
+                '[sqlIndex]' => '[sql_index]',
+                '[displayFront]' => '[display_front]',
+            ],
+            extraProperties: ExtraPropertyDefinition::VERSION_GATE,
+        ),
+    ],
+    normalizationContext: ['skip_null_values' => false],
+)]
+class ExtraPropertyDefinitionList
+{
+    #[ApiProperty(identifier: true)]
+    public int $extraPropertyDefinitionId;
+
+    public string $entityName;
+
+    /**
+     * Null for core-owned definitions.
+     */
+    public ?string $moduleName;
+
+    public string $propertyName;
+
+    #[ApiProperty(openapiContext: ['type' => 'string', 'enum' => ExtraPropertyDefinition::TYPES])]
+    public string $type;
+
+    #[ApiProperty(openapiContext: ['type' => 'string', 'enum' => ExtraPropertyDefinition::SCOPES])]
+    public string $scope;
+
+    #[ApiProperty(openapiContext: ['type' => 'string', 'enum' => ExtraPropertyDefinition::SQL_INDEXES])]
+    public string $sqlIndex;
+
+    public bool $displayFront;
+
+    public const MAPPING = [
+        '[id_extra_property_definition]' => '[extraPropertyDefinitionId]',
+        '[entity_name]' => '[entityName]',
+        '[module_name]' => '[moduleName]',
+        '[property_name]' => '[propertyName]',
+        '[sql_index]' => '[sqlIndex]',
+        '[display_front]' => '[displayFront]',
+    ];
+}

--- a/tests/Integration/ApiPlatform/ExtraPropertyDefinitionEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ExtraPropertyDefinitionEndpointTest.php
@@ -1,0 +1,425 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinition;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyRegistryInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * Contract of the extra property DEFINITION endpoints (the registry): payload shape, mappings,
+ * exception statuses, list filters. The effect of a definition on the entity endpoints is covered
+ * by ExtraPropertyValuesEndpointTest; the CQRS error matrix (every refused constraint DSL, every
+ * registry refusal) is covered by the core Behat suite, so only one error per HTTP mapping is
+ * asserted here.
+ */
+class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
+{
+    private const READ = 'extra_property_definition_read';
+    private const WRITE = 'extra_property_definition_write';
+    private const ENDPOINT = '/extra-property-definitions';
+
+    /**
+     * Every property created by this class starts with this prefix so the teardown can drop them
+     * (storage column included) whatever the state a failing test left behind.
+     */
+    private const PROPERTY_PREFIX = 'apidef_';
+
+    private const MODULE_OWNED_PROPERTY = self::PROPERTY_PREFIX . 'module_owned';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        if (!self::isVersionAtLeast('9.2.0')) {
+            return;
+        }
+
+        self::cleanDefinitions();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::isVersionAtLeast('9.2.0')) {
+            self::cleanDefinitions();
+        }
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->markTestSkippedByMinVersion('9.2.0');
+    }
+
+    /**
+     * Unregisters (column dropped) every definition created by these tests and restores the
+     * registry tables from the dump.
+     */
+    private static function cleanDefinitions(): void
+    {
+        $registry = self::getContainer()->get(ExtraPropertyRegistryInterface::class);
+        $repository = self::getContainer()->get(ExtraPropertyDefinitionRepositoryInterface::class);
+        foreach ($repository->getAllDefinitions() as $definition) {
+            if (str_starts_with($definition->getPropertyName(), self::PROPERTY_PREFIX)) {
+                $registry->unregister($definition, true);
+            }
+        }
+
+        DatabaseDump::restoreTables(['extra_property_definition', 'extra_property_definition_shop']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get endpoint' => ['GET', self::ENDPOINT . '/1'];
+        yield 'create endpoint' => ['POST', self::ENDPOINT];
+        yield 'patch endpoint' => ['PATCH', self::ENDPOINT . '/1'];
+        yield 'delete endpoint' => ['DELETE', self::ENDPOINT . '/1'];
+        yield 'list endpoint' => ['GET', self::ENDPOINT];
+        yield 'bulk delete endpoint' => ['DELETE', self::ENDPOINT . '/bulk-delete'];
+    }
+
+    public function testAddExtraPropertyDefinition(): int
+    {
+        $postData = [
+            'entityName' => 'product',
+            'propertyName' => self::PROPERTY_PREFIX . 'string',
+            'type' => 'string',
+            'scope' => 'common',
+            'sqlIndex' => 'key',
+            'displayFront' => true,
+            'required' => false,
+            'nullable' => true,
+            'size' => 64,
+            'defaultValue' => 'n/a',
+            'labelWording' => 'API string',
+            'labelDomain' => 'Modules.Apitest.Admin',
+            'descriptionWording' => 'Created through the Admin API',
+            'descriptionDomain' => 'Modules.Apitest.Admin',
+            // Constraints travel as the DSL string, read back in its canonical form (one per line,
+            // named options sorted).
+            'constraints' => "NotBlank\nLength(min: 2, max: 64)",
+            'formOptions' => ['attr' => ['placeholder' => 'n/a']],
+            'associatedForms' => ['product'],
+            'associatedGrids' => ['product'],
+            'associatedApis' => ['/products', '/products/{productId}'],
+        ];
+
+        $definition = $this->createItem(self::ENDPOINT, $postData, [self::WRITE]);
+        $this->assertArrayHasKey('extraPropertyDefinitionId', $definition);
+        $definitionId = $definition['extraPropertyDefinitionId'];
+        $this->assertIsInt($definitionId);
+
+        $this->assertEquals([
+            'extraPropertyDefinitionId' => $definitionId,
+            'entityName' => 'product',
+            'moduleName' => null,
+            'propertyName' => self::PROPERTY_PREFIX . 'string',
+            'type' => 'string',
+            'scope' => 'common',
+            'sqlIndex' => 'key',
+            'displayFront' => true,
+            'required' => false,
+            'nullable' => true,
+            'size' => 64,
+            'defaultValue' => 'n/a',
+            'enumValues' => null,
+            'labelWording' => 'API string',
+            'labelDomain' => 'Modules.Apitest.Admin',
+            'descriptionWording' => 'Created through the Admin API',
+            'descriptionDomain' => 'Modules.Apitest.Admin',
+            'constraints' => "NotBlank\nLength(max: 64, min: 2)",
+            'formType' => null,
+            'formOptions' => ['attr' => ['placeholder' => 'n/a']],
+            'associatedForms' => ['product'],
+            'associatedGrids' => ['product'],
+            'associatedApis' => ['/products', '/products/{productId}'],
+            'shopIds' => null,
+        ], $definition);
+
+        return $definitionId;
+    }
+
+    /**
+     * The default value keeps the type of the property: a float default is a JSON number, a bool
+     * default a JSON boolean, a choice default one of the enum values.
+     */
+    public function testTypedDefaultValues(): void
+    {
+        $float = $this->createItem(self::ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => self::PROPERTY_PREFIX . 'float',
+            'type' => 'float',
+            'defaultValue' => 1.5,
+        ], [self::WRITE]);
+        $this->assertSame(1.5, $float['defaultValue']);
+        $this->assertNull($float['constraints']);
+
+        $int = $this->createItem(self::ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => self::PROPERTY_PREFIX . 'int',
+            'type' => 'int',
+            'defaultValue' => 5,
+        ], [self::WRITE]);
+        $this->assertSame(5, $int['defaultValue']);
+
+        $bool = $this->createItem(self::ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => self::PROPERTY_PREFIX . 'bool',
+            'type' => 'bool',
+            'nullable' => false,
+            'defaultValue' => false,
+        ], [self::WRITE]);
+        $this->assertFalse($bool['defaultValue']);
+        $this->assertFalse($bool['nullable']);
+
+        $choice = $this->createItem(self::ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => self::PROPERTY_PREFIX . 'choice',
+            'type' => 'choice',
+            'enumValues' => ['small', 'large'],
+            'defaultValue' => 'small',
+        ], [self::WRITE]);
+        $this->assertSame(['small', 'large'], $choice['enumValues']);
+        $this->assertSame('small', $choice['defaultValue']);
+    }
+
+    /**
+     * @depends testAddExtraPropertyDefinition
+     */
+    public function testGetExtraPropertyDefinition(int $definitionId): int
+    {
+        $definition = $this->getItem(self::ENDPOINT . '/' . $definitionId, [self::READ]);
+        $this->assertSame($definitionId, $definition['extraPropertyDefinitionId']);
+        $this->assertSame(self::PROPERTY_PREFIX . 'string', $definition['propertyName']);
+        $this->assertSame("NotBlank\nLength(max: 64, min: 2)", $definition['constraints']);
+
+        return $definitionId;
+    }
+
+    /**
+     * @depends testGetExtraPropertyDefinition
+     */
+    public function testPartialUpdateExtraPropertyDefinition(int $definitionId): int
+    {
+        $patchData = [
+            'labelWording' => 'API string (edited)',
+            'displayFront' => false,
+            'required' => true,
+            // Non-destructive storage change: a larger size.
+            'size' => 128,
+            'constraints' => 'Email',
+            'associatedApis' => ['/products/{productId}'],
+        ];
+        $updated = $this->partialUpdateItem(self::ENDPOINT . '/' . $definitionId, $patchData, [self::WRITE]);
+        $this->assertSame('API string (edited)', $updated['labelWording']);
+        $this->assertFalse($updated['displayFront']);
+        $this->assertTrue($updated['required']);
+        $this->assertSame(128, $updated['size']);
+        $this->assertSame('Email', $updated['constraints']);
+        $this->assertSame(['/products/{productId}'], $updated['associatedApis']);
+        // Untouched fields keep their value.
+        $this->assertSame('Created through the Admin API', $updated['descriptionWording']);
+        $this->assertSame(['product'], $updated['associatedGrids']);
+
+        $fetched = $this->getItem(self::ENDPOINT . '/' . $definitionId, [self::READ]);
+        $this->assertSame($updated, $fetched);
+
+        // An empty constraints string removes every constraint (null would leave them untouched).
+        $cleared = $this->partialUpdateItem(self::ENDPOINT . '/' . $definitionId, ['constraints' => ''], [self::WRITE]);
+        $this->assertNull($cleared['constraints']);
+        $this->assertSame('API string (edited)', $cleared['labelWording']);
+
+        // Structural fields are not editable: they are simply not part of the update command.
+        $unchanged = $this->partialUpdateItem(self::ENDPOINT . '/' . $definitionId, ['type' => 'int', 'scope' => 'lang'], [self::WRITE]);
+        $this->assertSame('string', $unchanged['type']);
+        $this->assertSame('common', $unchanged['scope']);
+
+        return $definitionId;
+    }
+
+    /**
+     * @depends testPartialUpdateExtraPropertyDefinition
+     */
+    public function testListExtraPropertyDefinitions(int $definitionId): int
+    {
+        $list = $this->listItems(self::ENDPOINT . '?orderBy=extraPropertyDefinitionId&sortOrder=desc', [self::READ]);
+        $this->assertGreaterThanOrEqual(1, $list['totalItems']);
+        $this->assertSame('extraPropertyDefinitionId', $list['orderBy']);
+
+        $filtered = $this->listItems(self::ENDPOINT, [self::READ], ['propertyName' => self::PROPERTY_PREFIX . 'string']);
+        $this->assertSame(1, $filtered['totalItems']);
+        $this->assertEquals([
+            'extraPropertyDefinitionId' => $definitionId,
+            'entityName' => 'product',
+            'moduleName' => null,
+            'propertyName' => self::PROPERTY_PREFIX . 'string',
+            'type' => 'string',
+            'scope' => 'common',
+            'sqlIndex' => 'key',
+            'displayFront' => false,
+        ], $filtered['items'][0]);
+
+        // Exact-match filters on the enum columns, LIKE filter on the names.
+        $floats = $this->listItems(self::ENDPOINT, [self::READ], ['type' => 'float', 'propertyName' => self::PROPERTY_PREFIX]);
+        $this->assertSame(1, $floats['totalItems']);
+        $this->assertSame(self::PROPERTY_PREFIX . 'float', $floats['items'][0]['propertyName']);
+
+        $prefixed = $this->listItems(self::ENDPOINT, [self::READ], ['entityName' => 'product', 'propertyName' => self::PROPERTY_PREFIX]);
+        $this->assertSame(5, $prefixed['totalItems']);
+
+        return $definitionId;
+    }
+
+    /**
+     * @depends testListExtraPropertyDefinitions
+     */
+    public function testDeleteExtraPropertyDefinition(int $definitionId): void
+    {
+        $propertyName = self::PROPERTY_PREFIX . 'string';
+
+        // Without a body the storage column is kept (like the back office "Delete" action)...
+        $this->assertNull($this->deleteItem(self::ENDPOINT . '/' . $definitionId, [self::WRITE]));
+        $this->getItem(self::ENDPOINT . '/' . $definitionId, [self::READ], Response::HTTP_NOT_FOUND);
+        $this->assertTrue($this->storageColumnExists('product_extra', $propertyName));
+
+        // ...so the property can be registered again on the existing column...
+        $recreated = $this->createItem(self::ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => $propertyName,
+            'type' => 'string',
+            'size' => 128,
+        ], [self::WRITE]);
+
+        // ...and {"dropColumn": true} removes the column and its data.
+        $this->requestApi(
+            'DELETE',
+            self::ENDPOINT . '/' . $recreated['extraPropertyDefinitionId'],
+            ['dropColumn' => true],
+            [self::WRITE],
+            Response::HTTP_NO_CONTENT
+        );
+        $this->getItem(self::ENDPOINT . '/' . $recreated['extraPropertyDefinitionId'], [self::READ], Response::HTTP_NOT_FOUND);
+        $this->assertFalse($this->storageColumnExists('product_extra', $propertyName));
+    }
+
+    public function testBulkDeleteExtraPropertyDefinitions(): void
+    {
+        $first = $this->createItem(self::ENDPOINT, ['entityName' => 'product', 'propertyName' => self::PROPERTY_PREFIX . 'bulk_1'], [self::WRITE]);
+        $second = $this->createItem(self::ENDPOINT, ['entityName' => 'product', 'propertyName' => self::PROPERTY_PREFIX . 'bulk_2'], [self::WRITE]);
+        $third = $this->createItem(self::ENDPOINT, ['entityName' => 'product', 'propertyName' => self::PROPERTY_PREFIX . 'bulk_3'], [self::WRITE]);
+
+        $this->bulkDeleteItems(self::ENDPOINT . '/bulk-delete', [
+            'extraPropertyDefinitionIds' => [$first['extraPropertyDefinitionId'], $second['extraPropertyDefinitionId']],
+            'dropColumn' => true,
+        ], [self::WRITE]);
+        $this->getItem(self::ENDPOINT . '/' . $first['extraPropertyDefinitionId'], [self::READ], Response::HTTP_NOT_FOUND);
+        $this->getItem(self::ENDPOINT . '/' . $second['extraPropertyDefinitionId'], [self::READ], Response::HTTP_NOT_FOUND);
+        $this->assertFalse($this->storageColumnExists('product_extra', self::PROPERTY_PREFIX . 'bulk_1'));
+
+        // An unknown id does not stop the batch: the valid one is deleted and the failure reported.
+        $this->bulkCommandItemsWithExpectedErrors('DELETE', self::ENDPOINT . '/bulk-delete', [
+            'extraPropertyDefinitionIds' => [$third['extraPropertyDefinitionId'], 999999999],
+            'dropColumn' => true,
+        ], null, [self::WRITE]);
+        $this->getItem(self::ENDPOINT . '/' . $third['extraPropertyDefinitionId'], [self::READ], Response::HTTP_NOT_FOUND);
+    }
+
+    public function testInvalidExtraPropertyDefinition(): void
+    {
+        // Resource validation.
+        $response = $this->createItem(self::ENDPOINT, ['type' => 'string'], [self::WRITE], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertValidationErrors([
+            ['propertyPath' => 'entityName', 'message' => 'This value should not be blank.'],
+            ['propertyPath' => 'propertyName', 'message' => 'This value should not be blank.'],
+        ], $response);
+
+        $response = $this->createItem(self::ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => self::PROPERTY_PREFIX . 'bad_type',
+            'type' => 'bogus',
+        ], [self::WRITE], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertValidationErrors([
+            ['propertyPath' => 'type', 'message' => 'The value you selected is not a valid choice.'],
+        ], $response);
+
+        // The command refuses a constraints DSL it cannot parse.
+        $response = $this->createItem(self::ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => self::PROPERTY_PREFIX . 'bad_dsl',
+            'constraints' => 'Nope',
+        ], [self::WRITE], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertStringContainsString('Unknown extra property constraint "Nope"', $response['detail']);
+
+        // The registry refuses an entity without a table.
+        $response = $this->createItem(self::ENDPOINT, [
+            'entityName' => 'no_such_entity',
+            'propertyName' => self::PROPERTY_PREFIX . 'orphan',
+        ], [self::WRITE], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertArrayHasKey('detail', $response);
+
+        $this->getItem(self::ENDPOINT . '/999999999', [self::READ], Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * A module-owned definition is listed and readable, but the module stays the source of truth:
+     * only its shop association can be changed, and it cannot be deleted from the API.
+     */
+    public function testModuleOwnedDefinitionIsProtected(): void
+    {
+        $registry = self::getContainer()->get(ExtraPropertyRegistryInterface::class);
+        $definitionId = $registry->register(new ExtraPropertyDefinition(
+            entityName: 'product',
+            propertyName: self::MODULE_OWNED_PROPERTY,
+            moduleName: 'ps_apiresources',
+        ));
+
+        $definition = $this->getItem(self::ENDPOINT . '/' . $definitionId, [self::READ]);
+        $this->assertSame('ps_apiresources', $definition['moduleName']);
+
+        $listed = $this->listItems(self::ENDPOINT, [self::READ], ['moduleName' => 'ps_apiresources']);
+        $this->assertSame(1, $listed['totalItems']);
+        $this->assertSame($definitionId, $listed['items'][0]['extraPropertyDefinitionId']);
+
+        $this->partialUpdateItem(self::ENDPOINT . '/' . $definitionId, ['labelWording' => 'Hijacked'], [self::WRITE], Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->deleteItem(self::ENDPOINT . '/' . $definitionId, [self::WRITE], Response::HTTP_UNPROCESSABLE_ENTITY);
+
+        // The shop association is the one field the merchant owns on a module definition.
+        $updated = $this->partialUpdateItem(self::ENDPOINT . '/' . $definitionId, ['shopIds' => [1]], [self::WRITE]);
+        $this->assertSame([1], $updated['shopIds']);
+        $reverted = $this->partialUpdateItem(self::ENDPOINT . '/' . $definitionId, ['shopIds' => []], [self::WRITE]);
+        $this->assertNull($reverted['shopIds']);
+    }
+
+    private function storageColumnExists(string $table, string $column): bool
+    {
+        $count = \Db::getInstance()->getValue(sprintf(
+            'SELECT COUNT(*) FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = "%s" AND COLUMN_NAME = "%s"',
+            pSQL(_DB_PREFIX_ . $table),
+            pSQL($column)
+        ));
+
+        return (int) $count > 0;
+    }
+}

--- a/tests/Integration/ApiPlatform/ExtraPropertyDefinitionEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ExtraPropertyDefinitionEndpointTest.php
@@ -131,32 +131,7 @@ class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
         $definitionId = $definition['extraPropertyDefinitionId'];
         $this->assertIsInt($definitionId);
 
-        $this->assertEquals([
-            'extraPropertyDefinitionId' => $definitionId,
-            'entityName' => 'product',
-            'moduleName' => null,
-            'propertyName' => self::PROPERTY_PREFIX . 'string',
-            'type' => 'string',
-            'scope' => 'common',
-            'sqlIndex' => 'key',
-            'displayFront' => true,
-            'required' => false,
-            'nullable' => true,
-            'size' => 64,
-            'defaultValue' => 'n/a',
-            'enumValues' => null,
-            'labelWording' => 'API string',
-            'labelDomain' => 'Modules.Apitest.Admin',
-            'descriptionWording' => 'Created through the Admin API',
-            'descriptionDomain' => 'Modules.Apitest.Admin',
-            'constraints' => "NotBlank\nLength(max: 64, min: 2)",
-            'formType' => null,
-            'formOptions' => ['attr' => ['placeholder' => 'n/a']],
-            'associatedForms' => ['product'],
-            'associatedGrids' => ['product'],
-            'associatedApis' => ['/products', '/products/{productId}'],
-            'shopIds' => null,
-        ], $definition);
+        $this->assertEquals($this->expectedStringDefinition($definitionId), $definition);
 
         return $definitionId;
     }
@@ -211,9 +186,7 @@ class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
     public function testGetExtraPropertyDefinition(int $definitionId): int
     {
         $definition = $this->getItem(self::ENDPOINT . '/' . $definitionId, [self::READ]);
-        $this->assertSame($definitionId, $definition['extraPropertyDefinitionId']);
-        $this->assertSame(self::PROPERTY_PREFIX . 'string', $definition['propertyName']);
-        $this->assertSame("NotBlank\nLength(max: 64, min: 2)", $definition['constraints']);
+        $this->assertEquals($this->expectedStringDefinition($definitionId), $definition);
 
         return $definitionId;
     }
@@ -233,18 +206,11 @@ class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
             'associatedApis' => ['/products/{productId}'],
         ];
         $updated = $this->partialUpdateItem(self::ENDPOINT . '/' . $definitionId, $patchData, [self::WRITE]);
-        $this->assertSame('API string (edited)', $updated['labelWording']);
-        $this->assertFalse($updated['displayFront']);
-        $this->assertTrue($updated['required']);
-        $this->assertSame(128, $updated['size']);
-        $this->assertSame('Email', $updated['constraints']);
-        $this->assertSame(['/products/{productId}'], $updated['associatedApis']);
-        // Untouched fields keep their value.
-        $this->assertSame('Created through the Admin API', $updated['descriptionWording']);
-        $this->assertSame(['product'], $updated['associatedGrids']);
+        $expected = $this->expectedStringDefinition($definitionId, $patchData);
+        $this->assertEquals($expected, $updated);
 
         $fetched = $this->getItem(self::ENDPOINT . '/' . $definitionId, [self::READ]);
-        $this->assertSame($updated, $fetched);
+        $this->assertEquals($expected, $fetched);
 
         // An empty constraints string removes every constraint (null would leave them untouched).
         $cleared = $this->partialUpdateItem(self::ENDPOINT . '/' . $definitionId, ['constraints' => ''], [self::WRITE]);
@@ -410,6 +376,46 @@ class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
         $this->assertSame([1], $updated['shopIds']);
         $reverted = $this->partialUpdateItem(self::ENDPOINT . '/' . $definitionId, ['shopIds' => []], [self::WRITE]);
         $this->assertNull($reverted['shopIds']);
+    }
+
+    /**
+     * The full expected payload for the PROPERTY_PREFIX.'string' definition created by
+     * testAddExtraPropertyDefinition(), shared by every test that asserts the read/write contract
+     * on that same definition through its lifecycle, so the literal isn't duplicated (and left to
+     * drift) at every step — override only the fields a given step actually changed.
+     *
+     * @param array<string, mixed> $overrides
+     *
+     * @return array<string, mixed>
+     */
+    private function expectedStringDefinition(int $definitionId, array $overrides = []): array
+    {
+        return array_replace([
+            'extraPropertyDefinitionId' => $definitionId,
+            'entityName' => 'product',
+            'moduleName' => null,
+            'propertyName' => self::PROPERTY_PREFIX . 'string',
+            'type' => 'string',
+            'scope' => 'common',
+            'sqlIndex' => 'key',
+            'displayFront' => true,
+            'required' => false,
+            'nullable' => true,
+            'size' => 64,
+            'defaultValue' => 'n/a',
+            'enumValues' => null,
+            'labelWording' => 'API string',
+            'labelDomain' => 'Modules.Apitest.Admin',
+            'descriptionWording' => 'Created through the Admin API',
+            'descriptionDomain' => 'Modules.Apitest.Admin',
+            'constraints' => "NotBlank\nLength(max: 64, min: 2)",
+            'formType' => null,
+            'formOptions' => ['attr' => ['placeholder' => 'n/a']],
+            'associatedForms' => ['product'],
+            'associatedGrids' => ['product'],
+            'associatedApis' => ['/products', '/products/{productId}'],
+            'shopIds' => null,
+        ], $overrides);
     }
 
     private function storageColumnExists(string $table, string $column): bool

--- a/tests/Integration/ApiPlatform/ExtraPropertyDefinitionEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ExtraPropertyDefinitionEndpointTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace PsApiResourcesTest\Integration\ApiPlatform;
 
+use PrestaShop\Module\APIResources\ApiPlatform\Resources\ExtraPropertyDefinition\ExtraPropertyDefinition as ExtraPropertyDefinitionResource;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinition;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface;
 use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyRegistryInterface;
@@ -150,6 +151,13 @@ class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
         ], [self::WRITE]);
         $this->assertSame(1.5, $float['defaultValue']);
         $this->assertNull($float['constraints']);
+        $this->assertReadsBackIdentically($float);
+
+        // Exact-match filter on an enum column, LIKE filter on the name: only the definition created
+        // just above matches.
+        $floats = $this->listItems(self::ENDPOINT, [self::READ], ['type' => 'float', 'propertyName' => self::PROPERTY_PREFIX]);
+        $this->assertSame(1, $floats['totalItems']);
+        $this->assertSame(self::PROPERTY_PREFIX . 'float', $floats['items'][0]['propertyName']);
 
         $int = $this->createItem(self::ENDPOINT, [
             'entityName' => 'product',
@@ -158,6 +166,7 @@ class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
             'defaultValue' => 5,
         ], [self::WRITE]);
         $this->assertSame(5, $int['defaultValue']);
+        $this->assertReadsBackIdentically($int);
 
         $bool = $this->createItem(self::ENDPOINT, [
             'entityName' => 'product',
@@ -168,6 +177,7 @@ class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
         ], [self::WRITE]);
         $this->assertFalse($bool['defaultValue']);
         $this->assertFalse($bool['nullable']);
+        $this->assertReadsBackIdentically($bool);
 
         $choice = $this->createItem(self::ENDPOINT, [
             'entityName' => 'product',
@@ -178,6 +188,42 @@ class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
         ], [self::WRITE]);
         $this->assertSame(['small', 'large'], $choice['enumValues']);
         $this->assertSame('small', $choice['defaultValue']);
+        $this->assertReadsBackIdentically($choice);
+    }
+
+    /**
+     * The fields with a declared default can be omitted, exactly like the BO form fields left
+     * untouched: the create operation injects them before validation, so the minimal payload is the
+     * two identifiers. Every other field falls back to the command's own optional defaults.
+     */
+    public function testCreateWithTheDefaultValues(): void
+    {
+        $created = $this->createItem(self::ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => self::PROPERTY_PREFIX . 'defaults',
+        ], [self::WRITE]);
+
+        $this->assertEquals([
+            'extraPropertyDefinitionId' => $created['extraPropertyDefinitionId'],
+            'entityName' => 'product',
+            'moduleName' => null,
+            'propertyName' => self::PROPERTY_PREFIX . 'defaults',
+            'size' => null,
+            'defaultValue' => null,
+            'enumValues' => null,
+            'labelWording' => null,
+            'labelDomain' => null,
+            'descriptionWording' => null,
+            'descriptionDomain' => null,
+            'constraints' => null,
+            'formType' => null,
+            'formOptions' => null,
+            'associatedForms' => null,
+            'associatedGrids' => null,
+            'associatedApis' => null,
+            'shopIds' => null,
+        ] + ExtraPropertyDefinitionResource::CREATE_DEFAULT_VALUES, $created);
+        $this->assertReadsBackIdentically($created);
     }
 
     /**
@@ -247,13 +293,16 @@ class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
             'displayFront' => false,
         ], $filtered['items'][0]);
 
-        // Exact-match filters on the enum columns, LIKE filter on the names.
-        $floats = $this->listItems(self::ENDPOINT, [self::READ], ['type' => 'float', 'propertyName' => self::PROPERTY_PREFIX]);
-        $this->assertSame(1, $floats['totalItems']);
-        $this->assertSame(self::PROPERTY_PREFIX . 'float', $floats['items'][0]['propertyName']);
-
+        // LIKE filter on the name: whatever else this class created so far shares the prefix, so only
+        // assert on the shape and on the definition this chain owns — never on a count another test
+        // method happens to contribute to.
         $prefixed = $this->listItems(self::ENDPOINT, [self::READ], ['entityName' => 'product', 'propertyName' => self::PROPERTY_PREFIX]);
-        $this->assertSame(5, $prefixed['totalItems']);
+        $this->assertGreaterThanOrEqual(1, $prefixed['totalItems']);
+        $propertyNames = array_column($prefixed['items'], 'propertyName');
+        $this->assertContains(self::PROPERTY_PREFIX . 'string', $propertyNames);
+        foreach ($propertyNames as $propertyName) {
+            $this->assertStringStartsWith(self::PROPERTY_PREFIX, $propertyName);
+        }
 
         return $definitionId;
     }
@@ -416,6 +465,20 @@ class ExtraPropertyDefinitionEndpointTest extends ApiTestCase
             'associatedApis' => ['/products', '/products/{productId}'],
             'shopIds' => null,
         ], $overrides);
+    }
+
+    /**
+     * The read endpoint must return exactly what the create endpoint answered — the only way the
+     * read path of a typed default value (float, int, bool, choice) gets covered.
+     *
+     * @param array<string, mixed> $created
+     */
+    private function assertReadsBackIdentically(array $created): void
+    {
+        $this->assertSame(
+            $created,
+            $this->getItem(self::ENDPOINT . '/' . $created['extraPropertyDefinitionId'], [self::READ])
+        );
     }
 
     private function storageColumnExists(string $table, string $column): bool

--- a/tests/Integration/ApiPlatform/ExtraPropertyMultiShopEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ExtraPropertyMultiShopEndpointTest.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyRegistryInterface;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagManager;
+use PrestaShop\PrestaShop\Core\FeatureFlag\FeatureFlagSettings;
+use PrestaShop\PrestaShop\Core\Multistore\MultistoreConfig;
+use Tests\Resources\DatabaseDump;
+use Tests\Resources\Resetter\ProductResetter;
+use Tests\Resources\Resetter\ShopResetter;
+
+/**
+ * Multishop contract of the definitions created through the API: a SHOP-scoped property follows the
+ * request's shop context (single shop write stays on its shop, allShops fans out, per-shop reads), and
+ * a definition restricted to some shops (shopIds) only exists on those shops — on the entity endpoints
+ * and in the definition list.
+ */
+class ExtraPropertyMultiShopEndpointTest extends ApiTestCase
+{
+    private const DEFINITION_READ = 'extra_property_definition_read';
+    private const DEFINITION_WRITE = 'extra_property_definition_write';
+    private const PRODUCT_READ = 'product_read';
+    private const PRODUCT_WRITE = 'product_write';
+    private const DEFINITIONS_ENDPOINT = '/extra-property-definitions';
+
+    private const PRODUCT_ID = 1;
+    private const DEFAULT_SHOP_ID = 1;
+    private const CORE_KEY = '_core';
+
+    private const PROPERTY_PREFIX = 'apims_';
+    private const SHOP_NOTE = self::PROPERTY_PREFIX . 'shop_note';
+    private const RESTRICTED = self::PROPERTY_PREFIX . 'restricted';
+
+    private static int $secondShopId;
+    private static bool $definitionsCreated = false;
+    private static ?int $restrictedDefinitionId = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        if (!self::isVersionAtLeast('9.2.0')) {
+            return;
+        }
+
+        self::cleanDefinitions();
+
+        // The Admin API refuses to run on a multistore installation unless the dedicated feature
+        // flag is enabled (every route 404s otherwise).
+        self::updateConfiguration(MultistoreConfig::FEATURE_STATUS, 1);
+        self::getContainer()->get(FeatureFlagManager::class)->enable(FeatureFlagSettings::FEATURE_FLAG_ADMIN_API_MULTISTORE);
+
+        $defaultGroupId = (int) \Shop::getGroupFromShop(self::DEFAULT_SHOP_ID, true);
+        self::$secondShopId = self::addShop('Extra Property Definition API Shop 2', $defaultGroupId);
+
+        // Associate the tested product to both shops so per-shop reads/writes are valid on each.
+        $product = new \Product(self::PRODUCT_ID);
+        $product->id_shop_list = [self::DEFAULT_SHOP_ID, self::$secondShopId];
+        $product->save();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::isVersionAtLeast('9.2.0')) {
+            self::cleanDefinitions();
+            self::getContainer()->get(FeatureFlagManager::class)->disable(FeatureFlagSettings::FEATURE_FLAG_ADMIN_API_MULTISTORE);
+            ProductResetter::resetProducts();
+            ShopResetter::resetShops();
+        }
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->markTestSkippedByMinVersion('9.2.0');
+        $this->ensureDefinitions();
+
+        foreach (['product_extra', 'product_extra_shop'] as $table) {
+            if ($this->tableExists($table)) {
+                \Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . $table . '`');
+            }
+        }
+    }
+
+    /**
+     * Under multistore every request must carry a shop context, the definition endpoints included.
+     */
+    private function ensureDefinitions(): void
+    {
+        if (self::$definitionsCreated) {
+            return;
+        }
+
+        // SHOP-scoped: one value per shop, stored in product_extra_shop.
+        $this->createItem(self::DEFINITIONS_ENDPOINT . '?shopId=' . self::DEFAULT_SHOP_ID, [
+            'entityName' => 'product',
+            'propertyName' => self::SHOP_NOTE,
+            'type' => 'string',
+            'scope' => 'shop',
+            'associatedApis' => ['/products/{productId}'],
+        ], [self::DEFINITION_WRITE]);
+
+        // COMMON but restricted to the second shop: a single shared value, only visible there.
+        $restricted = $this->createItem(self::DEFINITIONS_ENDPOINT . '?shopId=' . self::DEFAULT_SHOP_ID, [
+            'entityName' => 'product',
+            'propertyName' => self::RESTRICTED,
+            'type' => 'string',
+            'scope' => 'common',
+            'defaultValue' => 'restricted-default',
+            'associatedApis' => ['/products/{productId}'],
+            'shopIds' => [self::$secondShopId],
+        ], [self::DEFINITION_WRITE]);
+        $this->assertSame([self::$secondShopId], $restricted['shopIds']);
+        self::$restrictedDefinitionId = $restricted['extraPropertyDefinitionId'];
+
+        self::$definitionsCreated = true;
+    }
+
+    private static function cleanDefinitions(): void
+    {
+        $registry = self::getContainer()->get(ExtraPropertyRegistryInterface::class);
+        $repository = self::getContainer()->get(ExtraPropertyDefinitionRepositoryInterface::class);
+        foreach ($repository->getAllDefinitions() as $definition) {
+            if (str_starts_with($definition->getPropertyName(), self::PROPERTY_PREFIX)) {
+                $registry->unregister($definition, true);
+            }
+        }
+        self::$definitionsCreated = false;
+        self::$restrictedDefinitionId = null;
+
+        DatabaseDump::restoreTables(['extra_property_definition', 'extra_property_definition_shop']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get product endpoint' => ['GET', '/products/' . self::PRODUCT_ID . '?shopId=' . self::DEFAULT_SHOP_ID];
+        yield 'list definitions endpoint' => ['GET', self::DEFINITIONS_ENDPOINT . '?shopId=' . self::DEFAULT_SHOP_ID];
+    }
+
+    public function testShopScopedValuesFollowTheShopContext(): void
+    {
+        // A single-shop write stays on its shop.
+        $patched = $this->partialUpdateItem(
+            '/products/' . self::PRODUCT_ID . '?shopId=' . self::$secondShopId,
+            ['extraProperties' => [self::CORE_KEY => [self::SHOP_NOTE => 'only-shop-2']]],
+            [self::PRODUCT_WRITE]
+        );
+        $this->assertSame('only-shop-2', $patched['extraProperties'][self::CORE_KEY][self::SHOP_NOTE]);
+
+        $secondShopProduct = $this->getItem('/products/' . self::PRODUCT_ID . '?shopId=' . self::$secondShopId, [self::PRODUCT_READ]);
+        $this->assertSame('only-shop-2', $secondShopProduct['extraProperties'][self::CORE_KEY][self::SHOP_NOTE]);
+
+        $defaultShopProduct = $this->getItem('/products/' . self::PRODUCT_ID . '?shopId=' . self::DEFAULT_SHOP_ID, [self::PRODUCT_READ]);
+        $this->assertNull($defaultShopProduct['extraProperties'][self::CORE_KEY][self::SHOP_NOTE]);
+
+        // An all-shops write fans out to every shop the product is associated with.
+        $this->partialUpdateItem(
+            '/products/' . self::PRODUCT_ID . '?allShops',
+            ['extraProperties' => [self::CORE_KEY => [self::SHOP_NOTE => 'everywhere']]],
+            [self::PRODUCT_WRITE]
+        );
+        foreach ([self::DEFAULT_SHOP_ID, self::$secondShopId] as $shopId) {
+            $product = $this->getItem('/products/' . self::PRODUCT_ID . '?shopId=' . $shopId, [self::PRODUCT_READ]);
+            $this->assertSame('everywhere', $product['extraProperties'][self::CORE_KEY][self::SHOP_NOTE], 'shop ' . $shopId);
+        }
+    }
+
+    public function testRestrictedDefinitionOnlyExistsOnItsShops(): void
+    {
+        // Entity endpoint: the property is absent on the default shop, present (defaulted) on the second.
+        $defaultShopProduct = $this->getItem('/products/' . self::PRODUCT_ID . '?shopId=' . self::DEFAULT_SHOP_ID, [self::PRODUCT_READ]);
+        $this->assertArrayNotHasKey(self::RESTRICTED, $defaultShopProduct['extraProperties'][self::CORE_KEY]);
+
+        $secondShopProduct = $this->getItem('/products/' . self::PRODUCT_ID . '?shopId=' . self::$secondShopId, [self::PRODUCT_READ]);
+        $this->assertSame('restricted-default', $secondShopProduct['extraProperties'][self::CORE_KEY][self::RESTRICTED]);
+
+        // Definition list: follows the shop context, everything under allShops.
+        $defaultShopList = $this->listItems(self::DEFINITIONS_ENDPOINT . '?shopId=' . self::DEFAULT_SHOP_ID, [self::DEFINITION_READ], ['propertyName' => self::PROPERTY_PREFIX]);
+        $this->assertSame([self::SHOP_NOTE], array_column($defaultShopList['items'], 'propertyName'));
+
+        $secondShopList = $this->listItems(self::DEFINITIONS_ENDPOINT . '?shopId=' . self::$secondShopId, [self::DEFINITION_READ], ['propertyName' => self::PROPERTY_PREFIX]);
+        $this->assertEqualsCanonicalizing([self::SHOP_NOTE, self::RESTRICTED], array_column($secondShopList['items'], 'propertyName'));
+
+        $allShopsList = $this->listItems(self::DEFINITIONS_ENDPOINT . '?allShops', [self::DEFINITION_READ], ['propertyName' => self::PROPERTY_PREFIX]);
+        $this->assertSame(2, $allShopsList['totalItems']);
+
+        // An empty shopIds reverts to the fallback (no restriction): the property shows up everywhere.
+        $reverted = $this->partialUpdateItem(
+            self::DEFINITIONS_ENDPOINT . '/' . self::$restrictedDefinitionId . '?shopId=' . self::DEFAULT_SHOP_ID,
+            ['shopIds' => []],
+            [self::DEFINITION_WRITE]
+        );
+        $this->assertNull($reverted['shopIds']);
+
+        $defaultShopProduct = $this->getItem('/products/' . self::PRODUCT_ID . '?shopId=' . self::DEFAULT_SHOP_ID, [self::PRODUCT_READ]);
+        $this->assertSame('restricted-default', $defaultShopProduct['extraProperties'][self::CORE_KEY][self::RESTRICTED]);
+
+        // Restore the restriction for the other tests / a re-run.
+        $restored = $this->partialUpdateItem(
+            self::DEFINITIONS_ENDPOINT . '/' . self::$restrictedDefinitionId . '?shopId=' . self::DEFAULT_SHOP_ID,
+            ['shopIds' => [self::$secondShopId]],
+            [self::DEFINITION_WRITE]
+        );
+        $this->assertSame([self::$secondShopId], $restored['shopIds']);
+    }
+
+    private function tableExists(string $table): bool
+    {
+        return (int) \Db::getInstance()->getValue(sprintf(
+            'SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = "%s"',
+            pSQL(_DB_PREFIX_ . $table)
+        )) > 0;
+    }
+}

--- a/tests/Integration/ApiPlatform/ExtraPropertyValuesEndpointTest.php
+++ b/tests/Integration/ApiPlatform/ExtraPropertyValuesEndpointTest.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License version 3.0
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License version 3.0
+ */
+
+declare(strict_types=1);
+
+namespace PsApiResourcesTest\Integration\ApiPlatform;
+
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyDefinitionRepositoryInterface;
+use PrestaShop\PrestaShop\Core\ExtraProperty\Definition\ExtraPropertyRegistryInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Resources\DatabaseDump;
+
+/**
+ * Runtime effect of definitions created through the API on the REAL module endpoints: values are
+ * exposed and written on the item endpoints (nested "extraProperties" sub-object grouped by module,
+ * "_core" for definitions created here), inlined at the item root on the grid-backed and
+ * CQRS-paginated lists, validated with the declared constraints, and defaulted for row-less entities.
+ */
+class ExtraPropertyValuesEndpointTest extends ApiTestCase
+{
+    private const DEFINITION_WRITE = 'extra_property_definition_write';
+    private const PRODUCT_READ = 'product_read';
+    private const PRODUCT_WRITE = 'product_write';
+    private const DEFINITIONS_ENDPOINT = '/extra-property-definitions';
+
+    /**
+     * Existing product fixture (has combinations).
+     */
+    private const PRODUCT_ID = 1;
+
+    /**
+     * Definitions created here are core-owned, hence this module key in the payloads.
+     */
+    private const CORE_KEY = '_core';
+
+    private const PROPERTY_PREFIX = 'apival_';
+    private const NOTE = self::PROPERTY_PREFIX . 'note';
+    private const LANG_NOTE = self::PROPERTY_PREFIX . 'lang_note';
+    private const META = self::PROPERTY_PREFIX . 'meta';
+    private const COMBO_NOTE = self::PROPERTY_PREFIX . 'combo_note';
+
+    private const VALUE_TABLES = ['product_extra', 'product_extra_lang', 'product_attribute_extra'];
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        if (!self::isVersionAtLeast('9.2.0')) {
+            return;
+        }
+
+        self::cleanDefinitions();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::isVersionAtLeast('9.2.0')) {
+            self::cleanDefinitions();
+        }
+        parent::tearDownAfterClass();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->markTestSkippedByMinVersion('9.2.0');
+
+        // The definitions are created through the API, so they need a token: done lazily on the first
+        // test rather than in the static setup.
+        $this->ensureDefinitions();
+
+        // Each test starts from row-less entities so the exact-content assertions are deterministic.
+        foreach (self::VALUE_TABLES as $table) {
+            if ($this->tableExists($table)) {
+                \Db::getInstance()->execute('DELETE FROM `' . _DB_PREFIX_ . $table . '`');
+            }
+        }
+    }
+
+    private static bool $definitionsCreated = false;
+
+    private function ensureDefinitions(): void
+    {
+        if (self::$definitionsCreated) {
+            return;
+        }
+
+        // COMMON string on product: exposed on the item endpoints AND the grid-backed list, with a
+        // constraint and a default value.
+        $this->createItem(self::DEFINITIONS_ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => self::NOTE,
+            'type' => 'string',
+            'scope' => 'common',
+            'defaultValue' => 'n/a',
+            'constraints' => 'Length(max: 10)',
+            'labelWording' => 'API note',
+            'associatedGrids' => ['product'],
+            'associatedApis' => ['/products', '/products/{productId}'],
+        ], [self::DEFINITION_WRITE]);
+
+        // LANG string on product: locale-keyed object on the item, single locale value on the list.
+        $this->createItem(self::DEFINITIONS_ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => self::LANG_NOTE,
+            'type' => 'string',
+            'scope' => 'lang',
+            'labelWording' => 'API localized note',
+            'associatedApis' => ['/products', '/products/{productId}'],
+        ], [self::DEFINITION_WRITE]);
+
+        // JSON, API-only (no grid placement): decoded object, served by the batch reader on lists.
+        $this->createItem(self::DEFINITIONS_ENDPOINT, [
+            'entityName' => 'product',
+            'propertyName' => self::META,
+            'type' => 'json',
+            'scope' => 'common',
+            'defaultValue' => '{"a":1}',
+            'associatedApis' => ['/products', '/products/{productId}'],
+        ], [self::DEFINITION_WRITE]);
+
+        // COMMON string on the combination entity (product_attribute table): CQRS-paginated list.
+        $this->createItem(self::DEFINITIONS_ENDPOINT, [
+            'entityName' => 'combination',
+            'propertyName' => self::COMBO_NOTE,
+            'type' => 'string',
+            'scope' => 'common',
+            'defaultValue' => 'combo-default',
+            'associatedApis' => ['/products/{productId}/combinations'],
+        ], [self::DEFINITION_WRITE]);
+
+        self::$definitionsCreated = true;
+    }
+
+    private static function cleanDefinitions(): void
+    {
+        $registry = self::getContainer()->get(ExtraPropertyRegistryInterface::class);
+        $repository = self::getContainer()->get(ExtraPropertyDefinitionRepositoryInterface::class);
+        foreach ($repository->getAllDefinitions() as $definition) {
+            if (str_starts_with($definition->getPropertyName(), self::PROPERTY_PREFIX)) {
+                $registry->unregister($definition, true);
+            }
+        }
+        self::$definitionsCreated = false;
+
+        DatabaseDump::restoreTables(['extra_property_definition', 'extra_property_definition_shop']);
+    }
+
+    public static function getProtectedEndpoints(): iterable
+    {
+        yield 'get product endpoint' => ['GET', '/products/' . self::PRODUCT_ID];
+        yield 'update product endpoint' => ['PATCH', '/products/' . self::PRODUCT_ID];
+        yield 'list products endpoint' => ['GET', '/products'];
+        yield 'list combinations endpoint' => ['GET', '/products/' . self::PRODUCT_ID . '/combinations'];
+    }
+
+    /**
+     * A row-less entity reads back the declared defaults, typed: the string default as a string,
+     * the JSON default decoded as an object. The localized property has no stored value in any
+     * language yet, and the combination-only property never leaks onto the product.
+     */
+    public function testDefaultsAreServedForARowlessProduct(): void
+    {
+        $product = $this->getItem('/products/' . self::PRODUCT_ID, [self::PRODUCT_READ]);
+
+        $this->assertArrayHasKey(self::CORE_KEY, $product['extraProperties']);
+        $core = $product['extraProperties'][self::CORE_KEY];
+        $this->assertSame('n/a', $core[self::NOTE]);
+        $this->assertSame(['a' => 1], $core[self::META]);
+        $this->assertSame([], $core[self::LANG_NOTE]);
+        $this->assertArrayNotHasKey(self::COMBO_NOTE, $core);
+    }
+
+    public function testWriteAndReadBackProductExtraProperties(): void
+    {
+        $written = [
+            self::NOTE => 'hello',
+            self::LANG_NOTE => ['en-US' => 'hello', 'fr-FR' => 'bonjour'],
+            self::META => ['b' => 2, 'list' => [1, 2]],
+        ];
+        $patched = $this->partialUpdateItem(
+            '/products/' . self::PRODUCT_ID,
+            ['extraProperties' => [self::CORE_KEY => $written]],
+            [self::PRODUCT_WRITE]
+        );
+        $this->assertEquals($written, $patched['extraProperties'][self::CORE_KEY]);
+
+        $fetched = $this->getItem('/products/' . self::PRODUCT_ID, [self::PRODUCT_READ]);
+        $this->assertEquals($written, $fetched['extraProperties'][self::CORE_KEY]);
+
+        // A partial write touches only the given property: the localized values are kept.
+        $patched = $this->partialUpdateItem(
+            '/products/' . self::PRODUCT_ID,
+            ['extraProperties' => [self::CORE_KEY => [self::NOTE => 'again']]],
+            [self::PRODUCT_WRITE]
+        );
+        $this->assertSame('again', $patched['extraProperties'][self::CORE_KEY][self::NOTE]);
+        $this->assertEquals(['en-US' => 'hello', 'fr-FR' => 'bonjour'], $patched['extraProperties'][self::CORE_KEY][self::LANG_NOTE]);
+        $this->assertEquals(['b' => 2, 'list' => [1, 2]], $patched['extraProperties'][self::CORE_KEY][self::META]);
+    }
+
+    /**
+     * The constraints declared on the definition (here Length(max: 10)) are run on every write, and
+     * violations are reported under the merged path of the property.
+     */
+    public function testDeclaredConstraintsAreEnforced(): void
+    {
+        $response = $this->partialUpdateItem(
+            '/products/' . self::PRODUCT_ID,
+            ['extraProperties' => [self::CORE_KEY => [self::NOTE => 'way too long value']]],
+            [self::PRODUCT_WRITE],
+            Response::HTTP_UNPROCESSABLE_ENTITY
+        );
+
+        $this->assertValidationErrors([
+            [
+                'propertyPath' => 'extraProperties.' . self::CORE_KEY . '.' . self::NOTE,
+                'message' => 'This value is too long. It should have 10 characters or less.',
+            ],
+        ], $response);
+
+        // Nothing was written.
+        $product = $this->getItem('/products/' . self::PRODUCT_ID, [self::PRODUCT_READ]);
+        $this->assertSame('n/a', $product['extraProperties'][self::CORE_KEY][self::NOTE]);
+    }
+
+    /**
+     * The grid-backed product list inlines the values at the item root under extra_<module>_<property>
+     * (never a nested extraProperties object): the grid-associated property comes from the grid query,
+     * the API-only one from the batch reader.
+     */
+    public function testGridBackedListInlinesValues(): void
+    {
+        $this->partialUpdateItem(
+            '/products/' . self::PRODUCT_ID,
+            ['extraProperties' => [self::CORE_KEY => [
+                self::NOTE => 'listed',
+                self::LANG_NOTE => ['en-US' => 'listed-en', 'fr-FR' => 'listed-fr'],
+                self::META => ['c' => 3],
+            ]]],
+            [self::PRODUCT_WRITE]
+        );
+
+        $list = $this->listItems('/products?orderBy=productId&sortOrder=asc', [self::PRODUCT_READ]);
+        $item = $this->findListItem($list['items'], 'productId', self::PRODUCT_ID);
+        $this->assertNotNull($item, 'The product written to was not present in the list');
+
+        $this->assertArrayNotHasKey('extraProperties', $item);
+        $this->assertSame('listed', $item['extra_' . self::CORE_KEY . '_' . self::NOTE]);
+        $this->assertSame('listed-en', $item['extra_' . self::CORE_KEY . '_' . self::LANG_NOTE]);
+        $this->assertEquals(['c' => 3], $item['extra_' . self::CORE_KEY . '_' . self::META]);
+        $this->assertArrayNotHasKey('extra_' . self::CORE_KEY . '_' . self::COMBO_NOTE, $item);
+    }
+
+    /**
+     * A CQRS-paginated list (no grid behind it) is enriched too, by a batched read; row-less
+     * combinations get the declared default.
+     */
+    public function testCqrsPaginatedCombinationListIsEnriched(): void
+    {
+        $list = $this->listItems('/products/' . self::PRODUCT_ID . '/combinations', [self::PRODUCT_READ]);
+        $this->assertNotEmpty($list['items'], 'The product fixture should have combinations');
+
+        $key = 'extra_' . self::CORE_KEY . '_' . self::COMBO_NOTE;
+        foreach ($list['items'] as $item) {
+            $this->assertArrayNotHasKey('extraProperties', $item);
+            $this->assertSame('combo-default', $item[$key]);
+            $this->assertArrayNotHasKey('extra_' . self::CORE_KEY . '_' . self::NOTE, $item);
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $items
+     *
+     * @return array<string, mixed>|null
+     */
+    private function findListItem(array $items, string $idField, int $id): ?array
+    {
+        foreach ($items as $item) {
+            if (isset($item[$idField]) && (int) $item[$idField] === $id) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+
+    private function tableExists(string $table): bool
+    {
+        return (int) \Db::getInstance()->getValue(sprintf(
+            'SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = "%s"',
+            pSQL(_DB_PREFIX_ . $table)
+        )) > 0;
+    }
+}

--- a/tests/PHPStan/phpstan-9.0.3.neon
+++ b/tests/PHPStan/phpstan-9.0.3.neon
@@ -29,3 +29,10 @@ parameters:
             message: "#Class .*GetCarriersForProduct not found.#"
             identifier: class.notFound
             path: ../../src/ApiPlatform/Resources/Product/ProductCarrier.php
+        # The extra property definition CQRS layer (Core\Domain\ExtraProperty, Core\ExtraProperty,
+        # ExtraPropertyDefinitionFilters) only exists since PrestaShop 9.2; the operations declare
+        # minVersion 9.2.0 so they are filtered out of the API on this core version.
+        -
+            message: "#Class .*ExtraProperty.* not found.#"
+            identifier: class.notFound
+            path: ../../src/ApiPlatform/Resources/ExtraPropertyDefinition/*

--- a/tests/PHPStan/phpstan-9.1.5.neon
+++ b/tests/PHPStan/phpstan-9.1.5.neon
@@ -19,3 +19,10 @@ parameters:
             message: "#Class .*GetCarriersForProduct not found.#"
             identifier: class.notFound
             path: ../../src/ApiPlatform/Resources/Product/ProductCarrier.php
+        # The extra property definition CQRS layer (Core\Domain\ExtraProperty, Core\ExtraProperty,
+        # ExtraPropertyDefinitionFilters) only exists since PrestaShop 9.2; the operations declare
+        # minVersion 9.2.0 so they are filtered out of the API on this core version.
+        -
+            message: "#Class .*ExtraProperty.* not found.#"
+            identifier: class.notFound
+            path: ../../src/ApiPlatform/Resources/ExtraPropertyDefinition/*

--- a/tests/PHPStan/phpstan-9.2.x.neon
+++ b/tests/PHPStan/phpstan-9.2.x.neon
@@ -1,0 +1,7 @@
+includes:
+    - %currentWorkingDirectory%/tests/PHPStan/phpstan.neon
+
+parameters:
+    tmpDir: %currentWorkingDirectory%/var/phpstan-tmp/9.2.x
+    ignoreErrors:
+        # Add version-specific ignores here as needed


### PR DESCRIPTION
CRUD and list endpoints for the extra property definitions registry, on top of the core CQRS layer (PrestaShop/PrestaShop#41542).

Depends on the core PR https://github.com/PrestaShop/PrestaShop/pull/42787: the commands must accept the constraint DSL string, and the union-typed `defaultValue` needs the scalar-first type extractor. Until that core PR is merged the three new test classes fail on the `9.2.x` / `develop` CI jobs and are skipped on older cores (`minVersion 9.2.0`).

## Endpoints

| Operation | URI | Scope |
|---|---|---|
| `CQRSGet` | `GET /extra-property-definitions/{extraPropertyDefinitionId}` | `extra_property_definition_read` |
| `CQRSCreate` | `POST /extra-property-definitions` | `extra_property_definition_write` |
| `CQRSPartialUpdate` | `PATCH /extra-property-definitions/{extraPropertyDefinitionId}` | `extra_property_definition_write` |
| `CQRSDelete` | `DELETE /extra-property-definitions/{extraPropertyDefinitionId}` (optional body `{"dropColumn": true}`) | `extra_property_definition_write` |
| `PaginatedList` | `GET /extra-property-definitions` (grid `extra_property_definition`) | `extra_property_definition_read` |
| `CQRSDelete` | `DELETE /extra-property-definitions/bulk-delete` | `extra_property_definition_write` |

Payload notes:

- `constraints` is the extra property constraint DSL string (`NotBlank\nLength(min: 2, max: 64)`), read back in its canonical form; `""` on PATCH removes every constraint.
- `type`, `scope`, `sqlIndex` are the enum string values, documented as OpenAPI enums.
- `defaultValue` is typed like the property: `int|string|bool|DecimalNumber|null` (a float default travels as a JSON number).
- `shopIds` maps the shop association (`null` = fallback, `[]` on PATCH reverts to it).
- Module-owned definitions are readable and listed; PATCH/DELETE on them answer 422, except a `shopIds` change.

## Tests

- `ExtraPropertyDefinitionEndpointTest`: contract of the endpoints (typed defaults, canonical constraints, partial update, list filters, delete keeping vs dropping the column, bulk 207, one error per HTTP mapping, module-owned protection). The CQRS error matrix itself is covered by the core Behat suite.
- `ExtraPropertyValuesEndpointTest`: runtime effect of API-created definitions on the real product endpoints: defaults for a row-less product, JSON decoded, write and read back, constraint violations at `extraProperties._core.<property>`, inline `extra__core_<property>` keys on the grid-backed list and on the CQRS combination list.
- `ExtraPropertyMultiShopEndpointTest`: shop-scoped values follow the shop context (single shop, `allShops` fan-out) and a definition restricted with `shopIds` only exists on its shops, on the product endpoint and in the definition list.

Run locally against a 9.2.x core: `composer run-module-tests` or `_PS_ROOT_DIR_=<core> php vendor/phpunit/phpunit/phpunit -c tests/Integration/phpunit-local.xml --filter ExtraProperty`.